### PR TITLE
fix: zero consumePrivateKey on signing-session validation failure

### DIFF
--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -1,7 +1,7 @@
 import * as ed25519 from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha2.js";
 import { PasskeyAccountError } from "./errors.js";
-import { createLockableKey } from "./session.js";
+import { createSigningKey } from "./session.js";
 import type {
   CreateSigningSessionOptions,
   Ed25519SigningSession,
@@ -37,16 +37,18 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
  * `signMessage` signs the raw message bytes with Ed25519 (Ed25519pure); the curve hashes internally with SHA-512.
  *
  * @param options - Signing session inputs.
- * @param options.consumePrivateKey - Ed25519 seed. Must be 32 bytes. The session takes ownership: the caller's buffer is zeroed once the session has copied the bytes.
+ * @param options.consumePrivateKey - Ed25519 seed. Must be 32 bytes. Zeroed before this call returns or throws.
  * @returns An unlocked Ed25519 signing session.
- * @remarks Side effects: copies `consumePrivateKey` into session memory and then zeroes the caller's buffer; `lock()` later zeroes the session-owned copy.
+ * @remarks Side effects: zeroes `consumePrivateKey` on every path; on success first copies it into session memory, which `lock()` later zeroes.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not 32 bytes.
  */
 function createEd25519SigningSession({
   consumePrivateKey,
 }: CreateSigningSessionOptions): Ed25519SigningSession {
-  const publicKey = getEd25519PublicKey(consumePrivateKey);
-  const key = createLockableKey(consumePrivateKey);
+  const { key, publicKey } = createSigningKey(
+    consumePrivateKey,
+    getEd25519PublicKey,
+  );
 
   return {
     publicKey,

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -1,6 +1,6 @@
 import * as secp from "@noble/secp256k1";
 import { PasskeyAccountError } from "./errors.js";
-import { createLockableKey } from "./session.js";
+import { createSigningKey } from "./session.js";
 import type {
   CreateSigningSessionOptions,
   Secp256k1Signature,
@@ -56,16 +56,18 @@ function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
  * `signDigest` signs exactly 32 bytes without prehashing. Calling `lock` zeroes the active private-key copy and makes future signing or export fail.
  *
  * @param options - Signing session inputs.
- * @param options.consumePrivateKey - secp256k1 private key. The session takes ownership: the caller's buffer is zeroed once the session has copied the bytes.
+ * @param options.consumePrivateKey - secp256k1 private key. Zeroed before this call returns or throws.
  * @returns An unlocked secp256k1 signing session.
- * @remarks Side effects: copies `consumePrivateKey` into session memory and then zeroes the caller's buffer; `lock()` later zeroes the session-owned copy.
+ * @remarks Side effects: zeroes `consumePrivateKey` on every path; on success first copies it into session memory, which `lock()` later zeroes.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.
  */
 function createSecp256k1SigningSession({
   consumePrivateKey,
 }: CreateSigningSessionOptions): Secp256k1SigningSession {
-  const publicKey = getSecp256k1PublicKey(consumePrivateKey);
-  const key = createLockableKey(consumePrivateKey);
+  const { key, publicKey } = createSigningKey(
+    consumePrivateKey,
+    getSecp256k1PublicKey,
+  );
 
   return {
     publicKey,

--- a/src/session.ts
+++ b/src/session.ts
@@ -26,31 +26,45 @@ type LockableKey = {
 };
 
 /**
- * Copies a private key into session-owned memory and zeroes the caller's buffer.
+ * Consumes a private key into a lockable signing key and derives its public key.
  *
- * @param consumePrivateKey - Private key the session takes ownership of. Zeroed once copied.
- * @returns A {@link LockableKey} gating access on lock state.
- * @remarks Side effects: copies `consumePrivateKey` into session memory and then zeroes the caller's buffer.
+ * The caller's buffer is zeroed before this function returns or throws.
+ *
+ * @param consumePrivateKey - Private key to consume. Zeroed before this function returns or throws.
+ * @param derivePublicKey - Derives the public key from the private key; a throw doubles as private-key validation.
+ * @returns The {@link LockableKey} handle gating access on lock state, paired with the derived public key.
+ * @remarks Side effects: zeroes `consumePrivateKey` on every path; on success first copies it into session memory, which `lock()` later zeroes.
+ * @throws Rethrows whatever `derivePublicKey` throws, after zeroing `consumePrivateKey`.
  */
-function createLockableKey(consumePrivateKey: Uint8Array): LockableKey {
-  let activePrivateKey: Uint8Array | undefined = copyBytes(consumePrivateKey);
-  consumePrivateKey.fill(0);
+function createSigningKey(
+  consumePrivateKey: Uint8Array,
+  derivePublicKey: (privateKey: Uint8Array) => Uint8Array,
+): { key: LockableKey; publicKey: Uint8Array } {
+  try {
+    // Derive (which validates) before copying, so an invalid key is never copied into session memory.
+    const publicKey = derivePublicKey(consumePrivateKey);
+    let activePrivateKey: Uint8Array | undefined = copyBytes(consumePrivateKey);
 
-  return {
-    use(): Uint8Array {
-      return requireUnlocked(activePrivateKey);
-    },
-    exportCopy(): Uint8Array {
-      return new Uint8Array(requireUnlocked(activePrivateKey));
-    },
-    lock(): void {
-      if (activePrivateKey !== undefined) {
-        activePrivateKey.fill(0);
-        activePrivateKey = undefined;
-      }
-    },
-  };
+    const key: LockableKey = {
+      use(): Uint8Array {
+        return requireUnlocked(activePrivateKey);
+      },
+      exportCopy(): Uint8Array {
+        return new Uint8Array(requireUnlocked(activePrivateKey));
+      },
+      lock(): void {
+        if (activePrivateKey !== undefined) {
+          activePrivateKey.fill(0);
+          activePrivateKey = undefined;
+        }
+      },
+    };
+
+    return { key, publicKey };
+  } finally {
+    consumePrivateKey.fill(0);
+  }
 }
 
 export type { LockableKey };
-export { createLockableKey };
+export { createSigningKey };

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ type CreateSigningSessionOptions = {
   /**
    * Curve private key. Must be exactly 32 bytes; secp256k1 must also be a valid scalar.
    *
-   * The session takes ownership of this buffer: once it has copied the bytes into session-owned memory, it zeros the caller's `Uint8Array`. Hand a fresh copy if you need to keep the bytes available elsewhere.
+   * Zeroed before the call returns or throws. Pass a fresh copy if the bytes are needed elsewhere.
    */
   consumePrivateKey: Uint8Array;
 };

--- a/test/ed25519-session.test.ts
+++ b/test/ed25519-session.test.ts
@@ -44,3 +44,14 @@ test("rejects non-32-byte private keys", () => {
     "INPUT_INVALID",
   );
 });
+
+test("zeroes the caller's buffer when the private key is the wrong length", () => {
+  const buffer = new Uint8Array(31).fill(7);
+
+  expectError(
+    () => createEd25519SigningSession({ consumePrivateKey: buffer }),
+    "INPUT_INVALID",
+  );
+
+  expect(buffer).toEqual(new Uint8Array(31));
+});

--- a/test/secp256k1-session.test.ts
+++ b/test/secp256k1-session.test.ts
@@ -46,3 +46,15 @@ test("rejects non-32-byte digests", async () => {
     code: "INPUT_INVALID",
   });
 });
+
+test("zeroes the caller's buffer when the private key is an invalid scalar", () => {
+  // All-0xff exceeds the curve order, so it is a valid length but invalid scalar.
+  const buffer = new Uint8Array(32).fill(0xff);
+
+  expectError(
+    () => createSecp256k1SigningSession({ consumePrivateKey: buffer }),
+    "INPUT_INVALID",
+  );
+
+  expect(buffer).toEqual(new Uint8Array(32));
+});


### PR DESCRIPTION
## What

The signing-session constructors (`createSecp256k1SigningSession`, `createEd25519SigningSession`) now zero the caller's `consumePrivateKey` buffer on **every** path, including when construction throws on an invalid key.

## Why

A security reviewer flagged that both constructors derived the public key — which validates the key material — *before* taking ownership of the buffer. The zeroing lived in `createLockableKey`, which ran afterward, so on the validation-failure path the caller's buffer was left intact.

That contradicts the documented "consume" contract: a caller who hands in a malformed key (wrong length, or a non-scalar for secp256k1) and catches the error would still be holding the secret bytes — having been told ownership transferred. The leaked bytes are invalid *as a curve scalar*, but a wrong-length/mis-encoded buffer can still be real secret material, so "invalid anyway" isn't a safe assumption.

## How

Folded validate → derive → consume into one guarded helper. `createLockableKey` becomes `createSigningKey(consumePrivateKey, derivePublicKey)`:

- Zeroes the caller's buffer in a `finally`, so it clears on success **and** on throw.
- Derives the public key *before* `copyBytes`, so an invalid key is never duplicated into session memory.
- Both constructors lose their `try/catch` and collapse to a single destructuring call: `const { key, publicKey } = createSigningKey(consumePrivateKey, getSecp256k1PublicKey)`.

Docs updated to state the guarantee plainly ("zeroed before the call returns or throws") instead of the "ownership" abstraction. The derive-before-copy ordering is load-bearing — a reorder would silently leak an un-zeroed copy that the tests can't observe — so its rationale is captured in a one-line code comment at the site.

## Reviewer notes

- `createLockableKey`/`LockableKey` are internal (not re-exported), so renaming the helper is safe.
- Added failure-path tests for both curves asserting the caller's buffer is zeroed when construction throws, using **non-zero** buffers so the assertion is meaningful (the prior ed25519 failure test used an all-zero 31-byte buffer that couldn't distinguish zeroed from original).
- Verification: `tsc` clean, `biome check` clean on changed files, all signing-session tests pass (37 passed overall). The 3 `@e2e` passkey failures in the full run are a missing Playwright Chromium binary in this environment, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)