### PR TITLE
docs(readme): distinguish Google Password Manager from Chrome profile authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ mera requires the WebAuthn PRF extension, discoverable credentials, and user ver
 | iCloud Keychain          | Chrome                            | iOS 18+                     | ✓                          | Safari 18 / iOS 18 (2024-09)                 |
 | iCloud Keychain          | Firefox                           | macOS 15+                   | ✓                          | Firefox 139+ (2025-05)                       |
 | Google Password Manager  | Chrome                            | Android                     | ✓                          | Known by 2026-06                             |
-| Google Password Manager  | Chrome                            | Desktop (signed-in profile) | ✓                          | Chrome 132+ (2025-01)                        |
+| Google Password Manager  | Chrome                            | Desktop (signed-in)         | ✓                          | Chrome 132+ (2025-01)                        |
+| Chrome profile           | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
 | Google Password Manager  | Edge                              | Android                     | ✓                          | Known by 2026-06                             |
 | Windows Password Manager | Edge                              | Windows 11 25H2+            | ✓                          | Windows 11 25H2 + 2026-02 update             |
 | Windows Password Manager | Chrome                            | Windows 11 25H2+            | ✓                          | Chrome 147+ (2026-04)                        |
@@ -72,6 +73,8 @@ mera requires the WebAuthn PRF extension, discoverable credentials, and user ver
 | Bitwarden                | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
 | Dashlane                 | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
 | Proton Pass              | Chrome                            | Desktop                     | ✓                          | Latest public version (2026-06)              |
+
+On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local Chrome profile authenticator does not implement the CTAP2 `hmac-secret` extension, so a passkey created there returns `prf.enabled: false`. Creation lands on the local profile authenticator instead of Google Password Manager when Chrome's "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser-fallback ceremony. For the broader PRF compatibility matrix, see Corbado's [Passkeys & WebAuthn PRF for End-to-End Encryption](https://www.corbado.com/blog/passkeys-prf-webauthn).
 
 ## API reference
 


### PR DESCRIPTION
## What

Clarifies the **Supported authenticators** table in `README.md` to distinguish the two desktop-Chrome passkey backends, which behave differently for the WebAuthn PRF extension:

- **Google Password Manager** — carries PRF ✓
- **Chrome profile** (local, on-device authenticator) — does not implement CTAP2 `hmac-secret`, so it returns `prf.enabled: false` ✗

Changes:
- Split the two backends into adjacent table rows (GPM *supported* directly above Chrome profile *not supported*) for a direct contrast.
- Dropped the ambiguous word "profile" from the GPM desktop row (was `Desktop (signed-in profile)` → now `Desktop (signed-in)`), since that wording is exactly what conflated the two backends.
- Added a note below the table explaining *when* creation lands on the no-PRF profile authenticator, and linking [Corbado's PRF compatibility writeup](https://www.corbado.com/blog/passkeys-prf-webauthn).

## Why

A user hit `PRF_UNAVAILABLE` when creating an account in the demo under a Chrome profile where a third-party password-manager extension (1Password) was the controlling passkey provider. Investigation showed this is **not a mera bug and not a Chrome bug**: PRF on desktop Chrome is delivered by Google Password Manager, but when GPM's "Offer to save passwords and passkeys" setting is off (or an extension intercepts WebAuthn and relays the browser-fallback ceremony), creation lands on the local Chrome profile authenticator, which has no PRF. The old table label made this look like a browser-wide lack of PRF support. The README is the library's documentation, so it's the right place to make the distinction durable.

## Reviewer notes

- Docs-only change; no code touched.
- The note deliberately describes **observable browser behavior only** — it does not restate mera's `PRF_UNAVAILABLE` throw, which the section intro already covers, to avoid the README narrating implementation details.
- The `Chrome profile` row is dated `2026-06-01` to match the other "Not supported" rows as a batch, but its basis is documented Chrome behavior (the cited Corbado article) rather than a first-party live test. If you'd prefer the table reflect only first-party live tests, the row could instead carry a footnote pointing at the note. Happy to adjust.
