### PR TITLE
fix(passkey): reject non-byte values in plain array-like PRF output

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -409,9 +409,9 @@ function assertPublicKeyCredential(
  * into a fresh `Uint8Array` that never aliases the input.
  *
  * The typed forms are already constrained to bytes. A plain array-like is not,
- * so each element is validated as an integer in [0, 255] before use; otherwise
- * `Uint8Array.from` would silently coerce malformed values (mod 256, `NaN` -> 0)
- * into HKDF key material instead of failing.
+ * so each element is validated as an integer in [0, 255] while it is copied; a
+ * bare `Uint8Array.from(value)` would instead silently coerce malformed values
+ * (mod 256, `NaN` -> 0) into HKDF key material.
  *
  * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when a plain array-like
  * contains a value that is not an integer in [0, 255].
@@ -429,20 +429,17 @@ function copyPrfOutput(value: BufferSource | ArrayLike<number>): Uint8Array {
   }
 
   // Plain array-like (for example, 1Password's extension returns a number[]).
-  // Element values are unconstrained here, so reject anything that is not a byte
-  // rather than letting Uint8Array.from coerce it into key material.
-  const bytes = new Uint8Array(value.length);
-  for (let i = 0; i < bytes.length; i++) {
-    const byte = value[i];
+  // Validate each element as it is copied so a non-byte value fails closed
+  // instead of being silently coerced (mod 256, NaN -> 0) into key material.
+  return Uint8Array.from(value, (byte) => {
     if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
       throw new PasskeyAccountError(
         "PRF_UNAVAILABLE",
         "PRF output must contain only byte values (integers 0-255)",
       );
     }
-    bytes[i] = byte;
-  }
-  return bytes;
+    return byte;
+  });
 }
 
 /** Options accepted by `createPasskey`. */

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -408,6 +408,13 @@ function assertPublicKeyCredential(
  * extension) return a plain array of byte values. This normalizes all of them
  * into a fresh `Uint8Array` that never aliases the input.
  *
+ * The typed forms are already constrained to bytes. A plain array-like is not,
+ * so each element is validated as an integer in [0, 255] before use; otherwise
+ * `Uint8Array.from` would silently coerce malformed values (mod 256, `NaN` -> 0)
+ * into HKDF key material instead of failing.
+ *
+ * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when a plain array-like
+ * contains a value that is not an integer in [0, 255].
  * @internal
  */
 function copyPrfOutput(value: BufferSource | ArrayLike<number>): Uint8Array {
@@ -421,7 +428,21 @@ function copyPrfOutput(value: BufferSource | ArrayLike<number>): Uint8Array {
     return new Uint8Array(value.slice(0));
   }
 
-  return Uint8Array.from(value);
+  // Plain array-like (for example, 1Password's extension returns a number[]).
+  // Element values are unconstrained here, so reject anything that is not a byte
+  // rather than letting Uint8Array.from coerce it into key material.
+  const bytes = new Uint8Array(value.length);
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = value[i];
+    if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
+      throw new PasskeyAccountError(
+        "PRF_UNAVAILABLE",
+        "PRF output must contain only byte values (integers 0-255)",
+      );
+    }
+    bytes[i] = byte;
+  }
+  return bytes;
 }
 
 /** Options accepted by `createPasskey`. */

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { copyPrfOutput } from "../dist/passkey.js";
+import { expectError } from "./helpers.js";
 
 test("copyPrfOutput copies a plain ArrayBuffer without aliasing", () => {
   const source = new Uint8Array([1, 2, 3, 4]);
@@ -42,9 +43,9 @@ test("copyPrfOutput accepts the boundary byte values 0 and 255", () => {
 test("copyPrfOutput rejects non-byte array values instead of coercing them", () => {
   // Uint8Array.from would silently coerce each of these (256 -> 0, -1 -> 255,
   // 1.5 -> 1, NaN -> 0). The result becomes HKDF key material, so a malformed
-  // plain array must fail loudly instead.
-  expect(() => copyPrfOutput([256])).toThrow(/byte values/);
-  expect(() => copyPrfOutput([-1])).toThrow(/byte values/);
-  expect(() => copyPrfOutput([1.5])).toThrow(/byte values/);
-  expect(() => copyPrfOutput([Number.NaN])).toThrow(/byte values/);
+  // plain array must fail with PRF_UNAVAILABLE instead.
+  expectError(() => copyPrfOutput([256]), "PRF_UNAVAILABLE");
+  expectError(() => copyPrfOutput([-1]), "PRF_UNAVAILABLE");
+  expectError(() => copyPrfOutput([1.5]), "PRF_UNAVAILABLE");
+  expectError(() => copyPrfOutput([Number.NaN]), "PRF_UNAVAILABLE");
 });

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -34,3 +34,17 @@ test("copyPrfOutput copies a plain array of byte values", () => {
   expect(out).toBeInstanceOf(Uint8Array);
   expect([...out]).toEqual([10, 20, 30]);
 });
+
+test("copyPrfOutput accepts the boundary byte values 0 and 255", () => {
+  expect([...copyPrfOutput([0, 255])]).toEqual([0, 255]);
+});
+
+test("copyPrfOutput rejects non-byte array values instead of coercing them", () => {
+  // Uint8Array.from would silently coerce each of these (256 -> 0, -1 -> 255,
+  // 1.5 -> 1, NaN -> 0). The result becomes HKDF key material, so a malformed
+  // plain array must fail loudly instead.
+  expect(() => copyPrfOutput([256])).toThrow(/byte values/);
+  expect(() => copyPrfOutput([-1])).toThrow(/byte values/);
+  expect(() => copyPrfOutput([1.5])).toThrow(/byte values/);
+  expect(() => copyPrfOutput([Number.NaN])).toThrow(/byte values/);
+});


### PR DESCRIPTION
## What

`copyPrfOutput` normalizes WebAuthn PRF output into a `Uint8Array`. Its plain
array-like branch — used for authenticators that return PRF output as a
`number[]` (notably the 1Password browser extension) — passed the value straight
to `Uint8Array.from`, which **silently coerces** each element to a byte
(`mod 256`, `NaN -> 0`, floats truncated). Only the output *length* was validated
downstream, so a malformed plain array would become different HKDF key material
rather than failing.

This PR validates each element of the plain array-like as an integer in
`[0, 255]` before use, throwing `PasskeyAccountError("PRF_UNAVAILABLE")` on a
non-byte value.

## Why

The PRF output is input keying material for HKDF (it derives the AES-256-GCM
wrapping key for the secret vault). Silent coercion of key material is the
opposite of fail-closed: a buggy or non-conformant source could yield
predictable, reduced-entropy, or non-interoperable keys with no error. This
aligns with the repo guideline to preserve runtime validation at cryptographic,
wire, and untrusted-JSON boundaries and to make failure behavior obvious.

Originated from a security-team note: *"Validate plain array-like PRF outputs as
exact integer bytes before `Uint8Array.from`."*

## Notes for reviewers

- **Only the plain array-like branch is validated.** The `ArrayBuffer` and
  `ArrayBufferView` branches are unchanged — their element types already
  guarantee bytes, so checks there would be redundant.
- **Error code:** `PRF_UNAVAILABLE` (not `INPUT_INVALID`) — this is malformed
  authenticator/extension output, not caller-supplied input, and matches the
  existing `errors.ts` definition ("did not enable or return a *usable* 32-byte
  WebAuthn PRF output").
- **Severity:** not attacker-exploitable on its own (a malicious
  authenticator/extension already controls the key material); this is
  robustness and diagnosability hardening.
- **Related, handled separately:** the 1Password extension returning a plain
  `Array` instead of an `ArrayBuffer`/`BufferSource` is non-conformant with the
  WebAuthn IDL and is being reported upstream to 1Password. This validation is
  correct regardless of whether/when that is fixed.

## Testing

- `npm run build` (tsc): clean
- `biome check`: clean
- Unit suite: **41/41 pass** (excludes `@e2e`, which needs a real authenticator
  ceremony)
- New tests: byte boundaries `0`/`255` accepted; `256`, `-1`, `1.5`, `NaN`
  rejected instead of silently coerced
