### PR TITLE
docs(secret): document and test that parseSecretVault drops unknown fields

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -281,6 +281,8 @@ async function unwrapSecretVault({
  *
  * Only version 1 vaults are accepted. The credential, PRF salt, nonce, and ciphertext are canonicalized to base64url and length-checked.
  *
+ * Fields outside the version-1 schema — unknown top-level keys and unknown `credential` keys — are ignored and absent from the returned vault.
+ *
  * @param value - Secret vault as JSON text or an untrusted object.
  * @returns A canonicalized secret vault.
  * @throws PasskeyAccountError with code `VAULT_FORMAT_INVALID` when required structure, version, or encoded data is invalid.
@@ -371,6 +373,7 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     );
   }
 
+  // Allowlist: only v1 schema fields are copied, so unknown input keys are dropped.
   return { version: 1, credential, prfSalt, nonce, ciphertext };
 }
 

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -72,6 +72,18 @@ test("parseSecretVault round-trips canonical vault JSON", async () => {
   expect(parseSecretVault(JSON.stringify(vault))).toEqual(vault);
 });
 
+test("parseSecretVault drops fields outside the v1 schema", async () => {
+  const vault = await createTestVault();
+
+  expect(
+    parseSecretVault({
+      ...vault,
+      unknown: "drop me",
+      credential: { ...vault.credential, unknown: "drop me" },
+    }),
+  ).toEqual(vault);
+});
+
 test("parseSecretVault reports VAULT_FORMAT_INVALID for malformed base64url", async () => {
   const vault = await createTestVault();
 


### PR DESCRIPTION
## What

Pins the behavior of `parseSecretVault` for fields outside the v1 schema: unknown top-level keys and unknown `credential` keys are dropped. This adds a JSDoc contract, a guard comment at the reconstruction site, and a test — **no production behavior changes.**

- **JSDoc** on `parseSecretVault` now states that unknown top-level and `credential` keys are ignored and absent from the returned vault.
- **Guard comment** at the `return { version: 1, ... }` reconstruction site marks the allowlist as intentional, so a future refactor doesn't "simplify" it into a spread and leak unknown fields.
- **Test** `parseSecretVault drops fields outside the v1 schema` asserts (single `toEqual`) that an extra top-level key and an extra `credential` key are both dropped.

## Why

Security review flagged that `parseSecretVault` silently discarded unknown fields without documenting or testing it — an implicit contract at an untrusted-JSON boundary that could regress unnoticed in a refactor.

The drop is already the safe pattern: the parser rebuilds a clean object from named fields only (allowlist by reconstruction), so unknown keys can never leak into the result. We chose to **pin** this rather than switch to rejecting unknown fields because:

- The crypto already fails closed on tampering — the AAD is a constant, independent of vault metadata, so a tampered/extra field yields `DECRYPT_FAILED` rather than a security gap. Rejecting unknown fields adds essentially no security.
- Tolerant-read / canonical-write is the more interoperable primitive: apps may wrap vaults in their own storage envelopes, and rejection would make otherwise-decryptable vaults unparseable.

## Reviewer notes

- Behavior is unchanged; this is documentation + test + a comment.
- If instead you want strict rejection (`VAULT_FORMAT_INVALID` on unknown keys), that's a deliberate behavior change I'd only recommend if we own every producer and consumer of the format.

## Verification

- `npm run build` (tsc): clean
- `biome check` on changed files: clean
- `playwright test --grep parseSecretVault`: 10 passed, including the new case