### PR TITLE
fix(secret): validate decoded ciphertext length, not encoded string

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -18,6 +18,10 @@ import { getCrypto, hkdfSha256AesGcmKey, randomBytes } from "./webcrypto.js";
 const PRF_SALT_LENGTH = 32;
 const PRF_OUTPUT_LENGTH = 32;
 const NONCE_LENGTH = 12;
+// AES-256-GCM authentication tag length in bytes (WebCrypto's 128-bit default,
+// since aesGcmEncrypt does not set tagLength). Ciphertext carries its tag, so
+// any authentic ciphertext is at least this long.
+const GCM_TAG_LENGTH = 16;
 
 // HKDF info and AAD for the secret vault. The HKDF info keeps the wrapping key
 // distinct from any other key derived from the same PRF output. The AAD is a
@@ -133,7 +137,7 @@ function readBase64Url(
   value: unknown,
   name: string,
   errorCode: PasskeyAccountErrorCode,
-  expectedLength?: number,
+  byteLength?: number | { min: number },
 ): string {
   if (typeof value !== "string") {
     throw new PasskeyAccountError(errorCode, `${name} must be base64url`);
@@ -148,10 +152,17 @@ function readBase64Url(
     });
   }
 
-  if (expectedLength !== undefined && bytes.length !== expectedLength) {
+  if (typeof byteLength === "number" && bytes.length !== byteLength) {
     throw new PasskeyAccountError(
       errorCode,
-      `${name} must be ${expectedLength} bytes`,
+      `${name} must be ${byteLength} bytes`,
+    );
+  }
+
+  if (typeof byteLength === "object" && bytes.length < byteLength.min) {
+    throw new PasskeyAccountError(
+      errorCode,
+      `${name} must be at least ${byteLength.min} bytes`,
     );
   }
 
@@ -202,13 +213,8 @@ async function createSecretVault({
     credential.credentialId,
     "credential.credentialId",
     "INPUT_INVALID",
+    { min: 1 },
   );
-  if (credentialId.length === 0) {
-    throw new PasskeyAccountError(
-      "INPUT_INVALID",
-      "credential.credentialId must not be empty",
-    );
-  }
 
   if (prfSalt.length !== PRF_SALT_LENGTH) {
     throw new PasskeyAccountError("INPUT_INVALID", "PRF salt must be 32 bytes");
@@ -322,14 +328,8 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     vault.credential.credentialId,
     "credential.credentialId",
     "VAULT_FORMAT_INVALID",
+    { min: 1 },
   );
-
-  if (credentialId.length === 0) {
-    throw new PasskeyAccountError(
-      "VAULT_FORMAT_INVALID",
-      "credential.credentialId must not be empty",
-    );
-  }
 
   const credential: PasskeySecretVault["credential"] = { credentialId };
 
@@ -364,14 +364,8 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     vault.ciphertext,
     "ciphertext",
     "VAULT_FORMAT_INVALID",
+    { min: GCM_TAG_LENGTH },
   );
-
-  if (ciphertext.length === 0) {
-    throw new PasskeyAccountError(
-      "VAULT_FORMAT_INVALID",
-      "ciphertext must not be empty",
-    );
-  }
 
   // Allowlist: only v1 schema fields are copied, so unknown input keys are dropped.
   return { version: 1, credential, prfSalt, nonce, ciphertext };

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -165,6 +165,27 @@ test("parseSecretVault rejects empty ciphertext", async () => {
   );
 });
 
+test("parseSecretVault rejects a non-empty ciphertext shorter than the GCM tag", async () => {
+  const vault = await createTestVault();
+
+  // 20 base64url chars decode to 15 bytes: one byte short of the 16-byte
+  // AES-GCM tag, so it cannot be an authentic ciphertext even though the
+  // encoded string is non-empty.
+  expectError(
+    () => parseSecretVault({ ...vault, ciphertext: "A".repeat(20) }),
+    "VAULT_FORMAT_INVALID",
+  );
+});
+
+test("parseSecretVault accepts a ciphertext of exactly the GCM tag length", async () => {
+  const vault = await createTestVault();
+
+  // 22 base64url chars decode to 16 bytes: the shortest structurally valid
+  // AES-GCM output (a bare tag), so parsing passes it through unchanged.
+  const parsed = parseSecretVault({ ...vault, ciphertext: "A".repeat(22) });
+  expect(parsed.ciphertext).toBe("A".repeat(22));
+});
+
 test("createSecretVault rejects an empty secret", async () => {
   await expect(
     createSecretVault({


### PR DESCRIPTION
## What

Validate the **decoded** byte length of a secret vault's ciphertext at the parse boundary, instead of only checking that the base64url-encoded string is non-empty.

Addresses security team review feedback on `parseSecretVault` (`src/secret.ts`).

## Why

`parseSecretVault` guarded the ciphertext with `ciphertext.length === 0`, where `ciphertext` is the base64url **string** returned by `readBase64Url` — so only the empty string `""` was rejected. A short but non-empty value (e.g. `"AA"`, which decodes to a single byte) passed structural validation and only failed later, at unwrap time, as `DECRYPT_FAILED`.

AES-256-GCM output always carries its 128-bit authentication tag (WebCrypto default; `aesGcmEncrypt` does not set `tagLength`), so any authentic ciphertext is **at least 16 bytes**. A shorter value is structurally impossible and should be rejected up front.

Note: confidentiality and integrity were never actually at risk — AES-GCM already rejects any malformed/too-short ciphertext at decrypt. This change makes the parser match its documented "length-checked" contract, fail early at the untrusted-JSON boundary, and return the precise `VAULT_FORMAT_INVALID` code instead of a later `DECRYPT_FAILED`.

## How

- Generalized `readBase64Url`'s length parameter from `expectedLength?: number` to `byteLength?: number | { min: number }`:
  - a bare number keeps the exact-length check (`prfSalt` = 32, `nonce` = 12), unchanged;
  - `{ min }` enforces a floor, checked against the decoded bytes the helper already computes (no double-decode).
- Ciphertext now uses `{ min: GCM_TAG_LENGTH }` (new `GCM_TAG_LENGTH = 16` constant, documented against the WebCrypto tag default).
- **Consistency cleanup:** folded both `credential.credentialId` non-empty checks (in `createSecretVault` and `parseSecretVault`) into `{ min: 1 }` via the same mechanism, removing three ad-hoc string-length checks in total.

## Testing

- `npm run build` and `biome check` clean.
- Full suite passes (43 passed). The only failures are 3 pre-existing `@e2e` tests that require a real WebAuthn passkey ceremony — they fail identically on the clean base and are unrelated to this change.
- Added boundary tests in `test/secret.test.ts`: a non-empty 15-byte ciphertext (`"A".repeat(20)`) is rejected, and a 16-byte ciphertext (`"A".repeat(22)`) is accepted — pinning the floor from both sides.

## Reviewer notes

- `readBase64Url` is file-private, so the signature change has no external blast radius.
- The floor is the GCM tag length (16). The library itself never produces a ciphertext below 17 bytes (it rejects empty secrets), but 16 is the correct wire-format minimum and keeps the parser decoupled from create-time plaintext policy.
- Error message wording changed for the folded checks (now "must be at least N bytes"); tests assert on the stable error `code`, not the message.
