### PR TITLE
build(pack): prepare package for first npm publish

### DIFF
--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -128,3 +128,24 @@ jobs:
       - name: Build demo
         run: npm run build
         working-directory: demo
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          check-latest: true
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify package contents, exports, and types
+        run: npm run check:pack

--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -130,11 +130,11 @@ jobs:
         working-directory: demo
 
   package:
-    name: Package
+    name: Publish check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ mera turns a WebAuthn passkey into stable, authenticator-bound entropy for walle
 
 **Wrapped.** An AES-256-GCM blob holds one secret — a recovery phrase, a private key, any bytes; only the passkey can unlock it. The blob can live in `localStorage`, a backend, or a sync service. Best for hot-wallet UX, returning users who want to sign many transactions per session, and importing an existing wallet.
 
+## Install
+
+```sh
+npm install @category-labs/mera
+```
+
 ## Quick example
 
 A derived-mode skeleton: one passkey ceremony, then app-owned wallet derivation.
@@ -29,7 +35,7 @@ import {
   createSecp256k1SigningSession,
   getEvmAddress,
   getPasskeyPrfOutput,
-} from "mera"
+} from "@category-labs/mera"
 import { derivePrivateKeyWithYourWalletScheme } from "./wallet-derivation"
 
 const rpId = "account.example.com"

--- a/demo/src/EthereumAccountCard.tsx
+++ b/demo/src/EthereumAccountCard.tsx
@@ -1,4 +1,4 @@
-import type { EvmAddress, Secp256k1SigningSession } from "mera";
+import type { EvmAddress, Secp256k1SigningSession } from "@category-labs/mera";
 import {
   type ReactElement,
   useCallback,

--- a/demo/src/SolanaAccountCard.tsx
+++ b/demo/src/SolanaAccountCard.tsx
@@ -1,4 +1,7 @@
-import { type Ed25519SigningSession, isSolanaAddress } from "mera";
+import {
+  type Ed25519SigningSession,
+  isSolanaAddress,
+} from "@category-labs/mera";
 import { type ReactElement, useCallback, useEffect, useState } from "react";
 import {
   clusterDisplayName,

--- a/demo/src/account.ts
+++ b/demo/src/account.ts
@@ -1,4 +1,7 @@
-import { getEvmAddress, type Secp256k1SigningSession } from "mera";
+import {
+  getEvmAddress,
+  type Secp256k1SigningSession,
+} from "@category-labs/mera";
 import {
   type Account,
   type Hex,

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -1,3 +1,4 @@
+import type { Ed25519SigningSession } from "@category-labs/mera";
 import {
   type Cluster,
   Connection,
@@ -7,7 +8,6 @@ import {
   Transaction,
 } from "@solana/web3.js";
 import { Buffer } from "buffer";
-import type { Ed25519SigningSession } from "mera";
 import { cachePerNetwork, type NetworkMode } from "../network";
 
 const SOLANA_MAINNET_RPC_URL = "https://solana-rpc.publicnode.com";

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -14,7 +14,7 @@ import {
   parseSecretVault,
   type Secp256k1SigningSession,
   unwrapSecretVault,
-} from "mera";
+} from "@category-labs/mera";
 import {
   deriveEthereumPrivateKey,
   deriveSolanaSeed,

--- a/demo/src/registry.ts
+++ b/demo/src/registry.ts
@@ -1,4 +1,4 @@
-import type { PasskeyCredentialTransport } from "mera";
+import type { PasskeyCredentialTransport } from "@category-labs/mera";
 
 /**
  * Non-secret metadata for a derived wallet created on this device.

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "paths": {
-      "mera": ["../dist/index.d.ts"]
+      "@category-labs/mera": ["../dist/index.d.ts"]
     }
   },
   "include": ["src"]

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      mera: libEntry,
+      "@category-labs/mera": libEntry,
     },
   },
   server: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mera",
+  "name": "@category-labs/mera",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mera",
+      "name": "@category-labs/mera",
       "version": "0.1.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
@@ -18,6 +18,7 @@
         "@biomejs/biome": "2.5.0",
         "@playwright/test": "^1.61.0",
         "@types/node": "^25.9.3",
+        "publint": "^0.3.21",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -245,6 +246,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@publint/pack": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.5.tgz",
+      "integrity": "sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyexec": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
@@ -279,6 +296,30 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/playwright": {
       "version": "1.61.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
@@ -307,6 +348,51 @@
       "bin": {
         "playwright-core": "cli.js"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/publint": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.21.tgz",
+      "integrity": "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.4",
+        "package-manager-detector": "^1.6.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,29 @@
 {
-  "name": "mera",
+  "name": "@category-labs/mera",
   "version": "0.1.0",
   "description": "Primitive-first passkey-backed signing utilities for secp256k1 (EVM) and Ed25519 (Solana).",
+  "keywords": [
+    "passkey",
+    "webauthn",
+    "prf",
+    "secp256k1",
+    "ed25519",
+    "ethereum",
+    "evm",
+    "solana",
+    "signing",
+    "crypto"
+  ],
+  "homepage": "https://github.com/category-labs/mera#readme",
+  "bugs": {
+    "url": "https://github.com/category-labs/mera/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/category-labs/mera.git"
+  },
+  "license": "(MIT OR Apache-2.0)",
+  "author": "Category Labs",
   "type": "module",
   "exports": {
     ".": {
@@ -12,11 +34,20 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "README.md"
+    "src",
+    "README.md",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
+  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
+    "prepack": "npm run build",
     "check": "biome check .",
+    "check:pack": "npm run build && node scripts/verify-tarball.mjs && publint --strict",
     "format": "biome format --write .",
     "lint": "biome lint .",
     "test": "npm run build && playwright test",
@@ -32,10 +63,10 @@
     "@biomejs/biome": "2.5.0",
     "@playwright/test": "^1.61.0",
     "@types/node": "^25.9.3",
+    "publint": "^0.3.21",
     "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=24"
-  },
-  "license": "(MIT OR Apache-2.0)"
+  }
 }

--- a/scripts/verify-tarball.mjs
+++ b/scripts/verify-tarball.mjs
@@ -14,11 +14,15 @@ const REQUIRED_FILES = [
   "LICENSE-APACHE",
 ];
 
-// `npm pack --dry-run --json` reports the exact tarball file list (running the
-// prepack build first) without writing a .tgz to disk.
-const packOutput = execFileSync("npm", ["pack", "--dry-run", "--json"], {
-  encoding: "utf8",
-});
+// `npm pack --dry-run --json` reports the exact tarball file list without
+// writing a .tgz to disk. `--ignore-scripts` skips the `prepack` rebuild so
+// this inspects the dist `check:pack` already built (and lints with `publint`)
+// rather than building a second time.
+const packOutput = execFileSync(
+  "npm",
+  ["pack", "--dry-run", "--json", "--ignore-scripts"],
+  { encoding: "utf8" },
+);
 const shipped = new Set(
   JSON.parse(packOutput)[0].files.map((entry) => entry.path),
 );

--- a/scripts/verify-tarball.mjs
+++ b/scripts/verify-tarball.mjs
@@ -1,0 +1,34 @@
+import { execFileSync } from "node:child_process";
+
+// Files a consumer must find in the published tarball: the entry points that
+// `exports` resolves to, the sources the shipped maps reference, and both
+// license files. `dist/` is gitignored and built at pack time (the `prepack`
+// script), so this guards against a broken `files`/`exports`/build shipping a
+// stale, incomplete, or empty package. Run via `npm run check:pack` and CI.
+const REQUIRED_FILES = [
+  "dist/index.js",
+  "dist/index.d.ts",
+  "src/index.ts",
+  "README.md",
+  "LICENSE-MIT",
+  "LICENSE-APACHE",
+];
+
+// `npm pack --dry-run --json` reports the exact tarball file list (running the
+// prepack build first) without writing a .tgz to disk.
+const packOutput = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+  encoding: "utf8",
+});
+const shipped = new Set(
+  JSON.parse(packOutput)[0].files.map((entry) => entry.path),
+);
+
+const missing = REQUIRED_FILES.filter((path) => !shipped.has(path));
+if (missing.length > 0) {
+  console.error(`Tarball is missing required files: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+console.log(
+  `Tarball OK (${shipped.size} files); verified ${REQUIRED_FILES.join(", ")}`,
+);


### PR DESCRIPTION
## Summary

Prepares the library for its first npm publish and hardens the publish path so a broken or stale build can't ship. Publishing itself stays **devops-owned** — no release workflow is added here.

## Why

The package was never published and had two blocking problems:

- **Broken tarball.** `dist/` is gitignored and there was no `prepack`, so `npm pack`/`npm publish` from a clean checkout produced a tarball with **no `dist/` at all** (verified: 2 files — just `README.md` + `package.json`). Since `exports` resolves into `dist/`, installs would fail to import.
- **Name taken.** The unscoped name `mera` already exists on npm (v0.9.1).

## What changed

- **Scoped rename → `@category-labs/mera`** — matches the GitHub org and sidesteps the collision. Updated the demo import specifier, the vite `resolve.alias`, the demo `tsconfig` path, and the README install/import examples.
- **`prepack: npm run build`** — the gitignored `dist/` is always built at pack time, however publishing is triggered.
- **`files` now ships `src/` + both `LICENSE-*`** — so shipped source/declaration maps resolve and both licenses are always included.
- **Publish metadata** — `repository`, `homepage`, `bugs`, `author`, `keywords`.
- **Premature-publish guard** — `private: true` (blocks `npm publish` for now), with `publishConfig.access: "public"` staged for when publishing is enabled.
- **CI `package` job** — runs `npm run check:pack`: builds, then `scripts/verify-tarball.mjs` asserts the tarball contains `dist/index.js`, `dist/index.d.ts`, `src/index.ts`, `README.md`, and both `LICENSE-*` (fails CI otherwise), then `publint --strict`.

## Verification

- `npm run check:pack` → build → `Tarball OK (69 files)` → publint **All good!** (exit 0).
- `npm pack --dry-run` now ships **69 files** (dist + src + README + both licenses) vs. **2 files** before.
- Demo builds (`tsc && vite build`) with the scoped import.
- `biome format .` and `biome lint .` → exit 0.

## Reviewer notes

- **Publishing is intentionally not automated here.** When ready, drop `private: true` and the staged `publishConfig.access: "public"` takes over.
- If npm **provenance** is wanted later, note it requires the source repo to be public.
- `@arethetypeswrong/cli` was considered and dropped as low-value for this ESM-only, single-entry package; `publint` + the tarball content check cover the packaging risks.
