### PR TITLE
fix(demo): bind resolved chain/cluster to the selected network mode

### DIFF
--- a/demo/src/chains/ethereum.ts
+++ b/demo/src/chains/ethereum.ts
@@ -51,9 +51,14 @@ async function resolveEthereumContext(
   const bootstrap = createPublicClient({ transport: http(rpcUrl) });
   const id = await bootstrap.getChainId();
   const known = KNOWN_CHAINS[id];
-  if (!known || known.mode !== networkMode) {
+  if (!known) {
     throw new Error(
-      `The ${networkMode} RPC reports chain id ${id}, which is not a recognized ${networkMode} chain.`,
+      `The ${networkMode} RPC is on chain id ${id}, which the demo doesn't recognize.`,
+    );
+  }
+  if (known.mode !== networkMode) {
+    throw new Error(
+      `The ${networkMode} RPC is on ${known.chain.name} (chain id ${id}), which belongs to ${known.mode}.`,
     );
   }
   const publicClient = createPublicClient({

--- a/demo/src/chains/ethereum.ts
+++ b/demo/src/chains/ethereum.ts
@@ -3,7 +3,6 @@ import {
   type Chain,
   createPublicClient,
   createWalletClient as createViemTransactionClient,
-  defineChain,
   type HttpTransport,
   http,
   type PublicClient,
@@ -14,12 +13,16 @@ import { cachePerNetwork, type NetworkMode } from "../network";
 
 const MONAD_MAINNET_RPC_URL = "https://rpc.monad.xyz";
 
-const KNOWN_CHAINS: Record<number, Chain> = {
-  [mainnet.id]: mainnet,
-  [sepolia.id]: sepolia,
-  [foundry.id]: foundry,
-  [monad.id]: monad,
-  [monadTestnet.id]: monadTestnet,
+// Each chain the demo recognizes, keyed by chain id and tagged with the network
+// mode it belongs to. Resolution looks the RPC's chain id up here and requires
+// the mode to match, so the "Testnet"/"Mainnet" toggle can never disagree with
+// the chain that is signed for and broadcast to. Add a row to support a new one.
+const KNOWN_CHAINS: Record<number, { chain: Chain; mode: NetworkMode }> = {
+  [mainnet.id]: { chain: mainnet, mode: "mainnet" },
+  [monad.id]: { chain: monad, mode: "mainnet" },
+  [sepolia.id]: { chain: sepolia, mode: "testnet" },
+  [monadTestnet.id]: { chain: monadTestnet, mode: "testnet" },
+  [foundry.id]: { chain: foundry, mode: "testnet" },
 };
 
 /** A resolved chain paired with a public client bound to it. */
@@ -47,16 +50,17 @@ async function resolveEthereumContext(
   const rpcUrl = rpcUrlForMode(networkMode);
   const bootstrap = createPublicClient({ transport: http(rpcUrl) });
   const id = await bootstrap.getChainId();
-  const chain =
-    KNOWN_CHAINS[id] ??
-    defineChain({
-      id,
-      name: `Chain ${id}`,
-      nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-      rpcUrls: { default: { http: [rpcUrl] } },
-    });
-  const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
-  return { chain, publicClient, rpcUrl };
+  const known = KNOWN_CHAINS[id];
+  if (!known || known.mode !== networkMode) {
+    throw new Error(
+      `The ${networkMode} RPC reports chain id ${id}, which is not a recognized ${networkMode} chain.`,
+    );
+  }
+  const publicClient = createPublicClient({
+    chain: known.chain,
+    transport: http(rpcUrl),
+  });
+  return { chain: known.chain, publicClient, rpcUrl };
 }
 
 /**

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -12,15 +12,30 @@ import { cachePerNetwork, type NetworkMode } from "../network";
 
 const SOLANA_MAINNET_RPC_URL = "https://solana-rpc.publicnode.com";
 
-// Genesis hashes uniquely identify each Solana cluster. Mirrors the chain-id
-// probe in `getEthereumContext` so the cluster is resolved from the RPC itself
-// rather than guessed from the URL — many providers (Helius, publicnode, …)
-// host all clusters under hostnames that don't contain the cluster name.
-const GENESIS_HASH_TO_CLUSTER: Record<string, Cluster> = {
-  "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d": "mainnet-beta",
-  EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG: "devnet",
-  "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY": "testnet",
-};
+// Each Solana cluster the demo recognizes, keyed by genesis hash and tagged
+// with the network mode it belongs to. Resolution looks the RPC's genesis hash
+// up here and requires the mode to match, so the "Testnet"/"Mainnet" toggle can
+// never disagree with the cluster that is signed for and broadcast to. Mirrors
+// the chain-id table in `ethereum.ts`.
+//
+// The genesis hash identifies the cluster from the RPC itself rather than
+// guessing from the URL — many providers (Helius, publicnode, …) host every
+// cluster under hostnames that don't contain the cluster name.
+const KNOWN_CLUSTERS: Record<string, { cluster: Cluster; mode: NetworkMode }> =
+  {
+    "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d": {
+      cluster: "mainnet-beta",
+      mode: "mainnet",
+    },
+    EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG: {
+      cluster: "devnet",
+      mode: "testnet",
+    },
+    "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY": {
+      cluster: "testnet",
+      mode: "testnet",
+    },
+  };
 
 type SolanaContext = {
   cluster: Cluster;
@@ -44,10 +59,13 @@ async function resolveSolanaContext(
   const rpcUrl = rpcUrlForMode(networkMode);
   const connection = new Connection(rpcUrl, "confirmed");
   const genesis = await connection.getGenesisHash();
-  const fallbackCluster: Cluster =
-    networkMode === "mainnet" ? "mainnet-beta" : "devnet";
-  const cluster = GENESIS_HASH_TO_CLUSTER[genesis] ?? fallbackCluster;
-  return { cluster, connection, rpcUrl, symbol: "SOL" };
+  const known = KNOWN_CLUSTERS[genesis];
+  if (!known || known.mode !== networkMode) {
+    throw new Error(
+      `The ${networkMode} RPC reports an unrecognized or mismatched Solana cluster.`,
+    );
+  }
+  return { cluster: known.cluster, connection, rpcUrl, symbol: "SOL" };
 }
 
 /**

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -62,7 +62,7 @@ async function resolveSolanaContext(
   const known = KNOWN_CLUSTERS[genesis];
   if (!known || known.mode !== networkMode) {
     throw new Error(
-      `The ${networkMode} RPC reports an unrecognized or mismatched Solana cluster.`,
+      `The ${networkMode} RPC reports genesis hash ${genesis}, which is not a recognized ${networkMode} cluster.`,
     );
   }
   return { cluster: known.cluster, connection, rpcUrl, symbol: "SOL" };

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -60,9 +60,14 @@ async function resolveSolanaContext(
   const connection = new Connection(rpcUrl, "confirmed");
   const genesis = await connection.getGenesisHash();
   const known = KNOWN_CLUSTERS[genesis];
-  if (!known || known.mode !== networkMode) {
+  if (!known) {
     throw new Error(
-      `The ${networkMode} RPC reports genesis hash ${genesis}, which is not a recognized ${networkMode} cluster.`,
+      `The ${networkMode} RPC is on genesis hash ${genesis}, which the demo doesn't recognize.`,
+    );
+  }
+  if (known.mode !== networkMode) {
+    throw new Error(
+      `The ${networkMode} RPC is on the ${known.cluster} cluster, which belongs to ${known.mode}.`,
     );
   }
   return { cluster: known.cluster, connection, rpcUrl, symbol: "SOL" };


### PR DESCRIPTION
## What

Make the demo's network **mode** (the "Testnet"/"Mainnet" toggle) and the chain that is actually signed for provably agree, by design rather than by a bolted-on check.

- `demo/src/chains/ethereum.ts`: `KNOWN_CHAINS` now maps chain id → `{ chain, mode }`. Resolution looks up the RPC's chain id and throws unless the tagged mode matches the selected mode. Removes the `defineChain` fallback that invented a chain for unknown ids.
- `demo/src/chains/solana.ts`: mirror image — `KNOWN_CLUSTERS` maps genesis hash → `{ cluster, mode }`, with the same match-or-throw. Removes the `fallbackCluster` that silently assumed the intended cluster for unknown genesis hashes.

## Why

The toggle set `networkMode`, which drove the UI label and all testnet affordances. But the chain that got **signed and broadcast** came solely from the RPC — the EVM `getChainId()` probe and the Solana genesis-hash lookup. Nothing tied the two together, and each resolver had a fallback that *fabricated a chain to match the request* instead of verifying it.

So a misconfigured or wrong RPC endpoint (e.g. a fork pointing `VITE_*_TESTNET_RPC_URL` at a mainnet endpoint) could resolve to a chain from the *other* mode while the label still read the selected one — e.g. signing a real mainnet transaction with real funds while the UI shows testnet. This addresses a review comment asking that the resolved chain id / genesis hash be validated against the selected mode before signing.

## Approach

Rather than add a separate validation step (which can be forgotten), one lookup table per chain is the single source of truth tying each chain/cluster to its mode. The lookup **is** the check — it's the only way to obtain a chain, so mode and chain cannot drift. Downstream `isTestnet = networkMode === "testnet"` logic is then correct by construction, so no UI changes were needed. Net effect is a simplification: the two guess-a-chain fallbacks are gone and the tables are self-documenting (each chain states its mode; add a row to support a new one).

## Behavior change for reviewers

- An unknown EVM chain id (previously accepted via `defineChain`) now throws.
- An unknown Solana genesis hash (previously assumed to be the intended cluster) now throws.

Both surface through the demo's existing "Ethereum/Solana unavailable — …" error banners. For a demo, this stricter behavior is the intended outcome.

## Verification

- `demo` `tsc` typecheck passes (against the built library).
- `biome check` clean on both files.

Scope is the demo only; the published library (`@category-labs/mera`) is untouched.