### PR TITLE
docs(agents): add Core Values preamble

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,12 @@
+### Core Values
+
+Simplicity, elegance, and correctness are the bar for everything here — code, documentation, tests, and examples alike.
+
+- Correctness comes first: prefer the obviously correct implementation over a shorter or cleverer one.
+- Write the simplest code that solves the problem; reach for a plainer construct over a clever one a reader has to decode.
+- Treat elegance as what remains after removing the unnecessary — fewer moving parts and clearer names, not more abstraction.
+- Write documentation in plain language: explain things directly, avoid jargon, and define a domain term only when the reader genuinely needs it.
+
 ### API Design Philosophy
 
 This repository is a library. Its API is part of its documentation.


### PR DESCRIPTION
## What

Adds a `### Core Values` section to the top of `AGENTS.md` as a governing preamble for the sections that follow:

> Simplicity, elegance, and correctness are the bar for everything here — code, documentation, tests, and examples alike.

Four bullets cover: correctness first, simplest-code-that-works (no hard-to-parse cleverness), elegance as subtraction, and plain-language docs (no jargon).

## Why

`AGENTS.md` captured specific principles (API design, docs, TypeScript) but never stated the unifying values that govern *all* work. This makes that value explicit as a north star the more detailed sections refine.

## Notes for reviewers

- **Voice:** kept neutral/declarative to match the rest of the file (no first-person "we"), consistent with the file's own "Keep documentation prose neutral" rule. Easy to switch to "We value…" if preferred.
- **No contradiction:** the clever-code bullet is scoped to code a reader *has to decode*, deliberately not touching comments — this stays consistent with the existing guidance that comments should explain *why* (rationale/invariants).
- Docs-only change; no code or behavior affected.