### PR TITLE
Document dependency scope and add scoped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,9 @@ updates:
           - "minor"
           - "patch"
 
-  # GitHub Actions used by CI workflows — keeps action pins on the latest release.
+  # GitHub Actions in CI. The workflows track floating major tags
+  # (e.g. actions/checkout@v7), which already pick up minor and patch
+  # releases; Dependabot opens a PR when a new major tag is available.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -45,10 +47,3 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Dependabot version updates.
+# Scope mirrors the "Dependency scope" note in README.md: the published
+# package's dependency tree (root) is kept current here, alongside the CI
+# GitHub Actions. The private demo/ app is out of scope and is intentionally
+# not listed. Minor/patch bumps are grouped into a single PR per ecosystem;
+# major bumps arrive as individual PRs so they can be reviewed on their own.
+version: 2
+
+updates:
+  # Published library — the security-relevant dependency tree.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      library:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by CI workflows — keeps action pins on the latest release.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,16 @@
 # Dependabot version updates.
-# Scope mirrors the "Dependency scope" note in README.md: the published
-# package's dependency tree (root) is kept current here, alongside the CI
-# GitHub Actions. The private demo/ app is out of scope and is intentionally
-# not listed. Minor/patch bumps are grouped into a single PR per ecosystem;
-# major bumps arrive as individual PRs so they can be reviewed on their own.
+# Keeps the root library package current — its runtime dependencies (the
+# shipped surface named in README.md's "Dependency scope" note) and its
+# build/test/lint toolchain — plus the GitHub Actions used by CI. The private
+# demo/ app is intentionally not listed, matching that note's scope.
+# Runtime and tooling bumps are grouped separately so runtime-dependency PRs
+# (the consumer-facing surface) stand on their own; major bumps arrive as
+# individual PRs.
 version: 2
 
 updates:
-  # Published library — the security-relevant dependency tree.
+  # Root library package: runtime dependencies (the shipped surface) and the
+  # build/test/lint toolchain, grouped separately.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -19,9 +22,13 @@ updates:
       prefix: "build"
       include: "scope"
     groups:
-      library:
-        patterns:
-          - "*"
+      library-runtime:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      library-tooling:
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,5 @@
-# Dependabot version updates.
-# Keeps the root library package current — its runtime dependencies (the
-# shipped surface named in README.md's "Dependency scope" note) and its
-# build/test/lint toolchain — plus the GitHub Actions used by CI. The private
-# demo/ app is intentionally not listed, matching that note's scope.
-# Runtime and tooling bumps are grouped separately so runtime-dependency PRs
-# (the consumer-facing surface) stand on their own; major bumps arrive as
-# individual PRs.
+# Dependabot version updates. The private demo/ app is intentionally not
+# covered.
 version: 2
 
 updates:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Secret-vault flows, demo HD derivation recipes (BIP-39/BIP-32, SLIP-0010), the s
 
 Keys are not protected once unlocked inside a compromised JavaScript runtime. Host apps should serve over HTTPS, use a strict CSP, avoid untrusted scripts, and keep unlocked sessions short-lived — call `session.lock()` as soon as you're done signing.
 
+**Dependency scope.** The published package ships a deliberately minimal dependency tree — the `@noble/*` and `@scure/*` primitives declared in the root manifest. Dependency audits and security alerts apply to that tree. The `demo/` app is a non-published example (`private: true`) with its own, larger dependency tree; those packages never reach consumers and are out of scope for the package's security guarantees.
+
 ## License
 
 Licensed under either of [Apache License](./LICENSE-APACHE), Version

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Secret-vault flows, demo HD derivation recipes (BIP-39/BIP-32, SLIP-0010), the s
 
 Keys are not protected once unlocked inside a compromised JavaScript runtime. Host apps should serve over HTTPS, use a strict CSP, avoid untrusted scripts, and keep unlocked sessions short-lived — call `session.lock()` as soon as you're done signing.
 
-**Dependency scope.** The published package ships a deliberately minimal dependency tree — the `@noble/*` and `@scure/*` primitives declared in the root manifest. Dependency audits and security alerts apply to that tree. The `demo/` app is a non-published example (`private: true`) with its own, larger dependency tree; those packages never reach consumers and are out of scope for the package's security guarantees.
+**Dependency scope.** The library’s shipped runtime dependency tree is the root manifest’s `dependencies` (`@noble/*`, `@scure/*`). The root `devDependencies` are build/test/lint tooling (supply-chain only), and the `demo/` app is a non-published example (`private: true`) with its own, larger dependency tree; neither set of packages ships to library consumers.
 
 ## License
 


### PR DESCRIPTION
## What

1. Adds a **Dependency scope** paragraph to the README's Security section: the published package's audit/security-alert surface is the root dependency tree (`@noble/*`, `@scure/*`); the private `demo/` app's larger tree is out of scope.
2. Adds `.github/dependabot.yml` with weekly version updates for:
   - the **root npm tree** (runtime deps = the shipped surface, plus the build/test/lint toolchain), and
   - the **GitHub Actions** used in CI. The workflows track floating major tags (`actions/checkout@v7`, `actions/setup-node@v6`), which already pick up minor/patch releases, so Dependabot's role here is to flag a new **major** (e.g. v7 → v8).

## Why

Resolves a review comment asking whether the demo dependency tree needs its own audit gate or a documented exception list.

The two trees have very different profiles:

| | Runtime deps | Total tree (incl. dev) | Published? |
|---|---|---|---|
| Library (`@category-labs/mera`) | 4 (`@noble/*`, `@scure/base`) | 27 | yes |
| Demo (`mera-demo`) | React, viem, `@solana/web3.js`, vite… | 276 | no (`private: true`) |

The demo never ships, so its transitive advisories cannot reach library consumers, and gating CI on a 276-package React/Vite/Solana tree would be recurring, unfixable-in-practice noise. So the demo is documented as an explicit exception rather than gated, and Dependabot is scoped to the shipped surface + CI actions.

## Dependabot config notes

- **npm** is grouped so runtime deps and the build/test/lint toolchain land in **separate PRs** (`library-runtime` / `library-tooling`), keeping the consumer-facing runtime surface reviewable on its own. Major bumps arrive individually.
- Dev tooling is kept current (not restricted to production): the toolchain that builds/validates `dist/` is part of the artifact's supply chain.
- **GitHub Actions** use floating major tags, so there are no minor/patch PRs to group; each new major is a separate PR to review on its own. Kept floating tags rather than SHA/full-version pins — the simpler, lower-noise choice.
- Commit prefixes follow the repo's convention (`build(deps):`/`build(deps-dev):` for npm, `ci(deps):` for actions).
- `demo/` is intentionally **not** listed, consistent with the README note. Trivial to add later as a grouped, low-cadence entry if we want the example kept current.
- Version updates run against the default branch, so they take effect once this merges to `main`.

## Notes for reviewers

- No code or runtime dependency changes; docs + CI config only.