### PR TITLE
Snapshot async passkey and vault inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 - Internal helpers with non-obvious invariants should have short comments or docstrings.
 - Document observable behavior, not caller instructions: state what a function does to its inputs and outputs (for example, "the input is copied before use; the original buffer is not modified") rather than what the caller may or should do with them. Callers derive correct usage from the stated facts.
 - When a comment or doc gives a rationale, explain the mechanism, not just the claim: a reader should see *why* from the text (for example, "signing reads the buffer after an await, so copy it first") rather than having to reconstruct the cause.
+- For section-style JSDoc/TSDoc block tags, use one tag per semantic section and continue with paragraphs until the next block tag. Put the tag on its own line when the content is multi-sentence. Repeat only naturally repeatable tags such as `@param`, `@throws`, `@example`, and `@see`; do not repeat section-style tags such as `@remarks` just to split paragraphs.
 
 ### TypeScript Conventions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,17 @@ export {
 } from "./passkey.js";
 export { createSecp256k1SigningSession } from "./secp256k1.js";
 export type {
+  CreateSecretVaultOptions,
+  GetSecretVaultPrfOutputOptions,
+  UnwrapSecretVaultOptions,
+} from "./secret.js";
+export {
+  createSecretVault,
+  getSecretVaultPrfOutput,
+  parseSecretVault,
+  unwrapSecretVault,
+} from "./secret.js";
+export type {
   CreatePasskeyResult,
   CreatePasskeyWithPrfOutputResult,
   CreateSigningSessionOptions,
@@ -29,14 +40,3 @@ export type {
   Secp256k1SigningSession,
   SigningCurve,
 } from "./types.js";
-export type {
-  CreateSecretVaultOptions,
-  GetSecretVaultPrfOutputOptions,
-  UnwrapSecretVaultOptions,
-} from "./secret.js";
-export {
-  createSecretVault,
-  getSecretVaultPrfOutput,
-  parseSecretVault,
-  unwrapSecretVault,
-} from "./secret.js";

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -1,4 +1,9 @@
-import { asArrayBuffer, base64UrlDecode, base64UrlEncode } from "./encoding.js";
+import {
+  asArrayBuffer,
+  base64UrlDecode,
+  base64UrlEncode,
+  copyBytes,
+} from "./encoding.js";
 import { isPasskeyAccountError, PasskeyAccountError } from "./errors.js";
 import type {
   CreatePasskeyResult,
@@ -308,8 +313,12 @@ async function getPasskeyPrfOutput({
  *
  * @param options - Passkey creation inputs. `rp.id` is required so the fallback ceremony can target the same relying party. `prfSalt` must be exactly 32 bytes.
  * @returns Credential metadata and the first PRF output.
- * @remarks Side effects: invokes `navigator.credentials.create()`. On authenticators that do not evaluate PRF during creation, also invokes `navigator.credentials.get()` — which means a second browser prompt for the user.
- * @remarks Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
+ * @remarks
+ * Side effects: invokes `navigator.credentials.create()`. On authenticators that do not evaluate PRF during creation, also invokes `navigator.credentials.get()` — which means a second browser prompt for the user.
+ *
+ * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of the input does not change the fallback ceremony or returned salt.
+ *
+ * Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
  * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or does not return PRF output on the fallback ceremony.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
@@ -322,13 +331,15 @@ async function createPasskeyWithPrfOutput({
   attestation,
   prfSalt,
 }: CreatePasskeyWithPrfOutputInput): Promise<CreatePasskeyWithPrfOutputResult> {
+  const prfSaltCopy = copyBytes(prfSalt);
+
   const credential = await createPasskey({
     rp,
     user,
     challenge,
     timeout,
     attestation,
-    prfSalt,
+    prfSalt: prfSaltCopy,
   });
 
   const prfOutput =
@@ -338,15 +349,14 @@ async function createPasskeyWithPrfOutput({
         rpId: rp.id,
         credentialId: credential.credentialId,
         transports: credential.transports,
-        prfSalt,
+        prfSalt: prfSaltCopy,
         timeout,
       })
     ).prfOutput;
 
   const result: CreatePasskeyWithPrfOutputResult = {
     credentialId: credential.credentialId,
-    // Copy so the returned salt is stable even if the caller mutates theirs.
-    prfSalt: new Uint8Array(prfSalt),
+    prfSalt: prfSaltCopy,
     prfOutput,
   };
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -3,6 +3,7 @@ import {
   base64UrlDecode,
   base64UrlEncode,
   canonicalEncode,
+  copyBytes,
   uint32Be,
   utf8ToBytes,
 } from "./encoding.js";
@@ -196,9 +197,12 @@ type CreateSecretVaultInput = {
 /**
  * Encrypts an arbitrary secret into a passkey-protected vault.
  *
- * The secret is opaque: no curve, no public key, no length or scalar checks. An AES-256-GCM wrapping key is derived from the PRF output with secret-specific HKDF info, and the secret is encrypted under canonical AAD. The input `secret` buffer is not mutated; callers that hold sensitive bytes should zero them when done.
+ * The secret is opaque: no curve, no public key, no length or scalar checks. An AES-256-GCM wrapping key is derived from the PRF output with secret-specific HKDF info, and the secret is encrypted under canonical AAD.
  *
- * @remarks Security: a vault is bound to its `prfOutput` only — not to the credential ID, salt, or nonce (the AAD is a fixed constant). Use a fresh `prfSalt` per secret. Secrets wrapped under one reused PRF output share a wrapping key, so their ciphertexts are interchangeable by anyone who can rewrite stored vault JSON.
+ * @remarks
+ * The input byte buffers are copied before async cryptographic work starts; post-call mutation does not change the vault being produced. Caller-owned input buffers are not modified or zeroed.
+ *
+ * Security: a vault is bound to its `prfOutput` only — not to the credential ID, salt, or nonce (the AAD is a fixed constant). Use a fresh `prfSalt` per secret. Secrets wrapped under one reused PRF output share a wrapping key, so their ciphertexts are interchangeable by anyone who can rewrite stored vault JSON.
  * @param options - Credential material and the secret to wrap.
  * @returns A JSON-safe secret vault.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when the credential ID is empty, the PRF salt or output is not 32 bytes, or `secret` is empty.
@@ -224,26 +228,35 @@ async function createSecretVault({
     throw new PasskeyAccountError("INPUT_INVALID", "secret must not be empty");
   }
 
-  const wrappingKey = await deriveWrappingKey({
-    info: SECRET_WRAP_INFO,
-    prfOutput,
-  });
-  const encrypted = await aesGcmEncrypt({
-    plaintext: secret,
-    wrappingKey,
-    aad: SECRET_AAD,
-  });
+  const prfSaltCopy = copyBytes(prfSalt);
+  const prfOutputCopy = copyBytes(prfOutput);
+  const secretCopy = copyBytes(secret);
 
-  return {
-    version: 1,
-    credential: {
-      credentialId,
-      ...(transports !== undefined ? { transports: [...transports] } : {}),
-    },
-    prfSalt: base64UrlEncode(prfSalt),
-    nonce: base64UrlEncode(encrypted.nonce),
-    ciphertext: base64UrlEncode(encrypted.ciphertext),
-  };
+  try {
+    const wrappingKey = await deriveWrappingKey({
+      info: SECRET_WRAP_INFO,
+      prfOutput: prfOutputCopy,
+    });
+    const encrypted = await aesGcmEncrypt({
+      plaintext: secretCopy,
+      wrappingKey,
+      aad: SECRET_AAD,
+    });
+
+    return {
+      version: 1,
+      credential: {
+        credentialId,
+        ...(transports !== undefined ? { transports: [...transports] } : {}),
+      },
+      prfSalt: base64UrlEncode(prfSaltCopy),
+      nonce: base64UrlEncode(encrypted.nonce),
+      ciphertext: base64UrlEncode(encrypted.ciphertext),
+    };
+  } finally {
+    prfOutputCopy.fill(0);
+    secretCopy.fill(0);
+  }
 }
 
 /** Inputs for decrypting a secret vault. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ type CreatePasskeyWithPrfOutputResult = {
   credentialId: string;
   /** Authenticator transports reported by the browser, when available. */
   transports?: PasskeyCredentialTransport[];
-  /** PRF salt that was evaluated. Always 32 bytes. */
+  /** PRF salt that was evaluated. Always 32 bytes and never aliases the caller input. */
   prfSalt: Uint8Array;
   /** First WebAuthn PRF output for `prfSalt`. Always 32 bytes. */
   prfOutput: Uint8Array;

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { copyPrfOutput } from "../dist/passkey.js";
+import { copyPrfOutput, createPasskeyWithPrfOutput } from "../dist/passkey.js";
 import { expectError } from "./helpers.js";
+
+const ORIGINAL_NAVIGATOR = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "navigator",
+);
 
 test("copyPrfOutput copies a plain ArrayBuffer without aliasing", () => {
   const source = new Uint8Array([1, 2, 3, 4]);
@@ -48,4 +53,70 @@ test("copyPrfOutput rejects non-byte array values instead of coercing them", () 
   expectError(() => copyPrfOutput([-1]), "PRF_UNAVAILABLE");
   expectError(() => copyPrfOutput([1.5]), "PRF_UNAVAILABLE");
   expectError(() => copyPrfOutput([Number.NaN]), "PRF_UNAVAILABLE");
+});
+
+test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", async () => {
+  const originalSalt = Uint8Array.from({ length: 32 }, (_, index) => index);
+  const prfSalt = new Uint8Array(originalSalt);
+  let fallbackSalt: Uint8Array | undefined;
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      credentials: {
+        async create() {
+          await Promise.resolve();
+          return {
+            type: "public-key",
+            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+            response: {
+              getTransports: () => ["internal"],
+            },
+            getClientExtensionResults: () => ({ prf: { enabled: true } }),
+          };
+        },
+        async get({ publicKey }: CredentialRequestOptions) {
+          const first = publicKey?.extensions?.prf?.eval?.first;
+          if (!(first instanceof ArrayBuffer)) {
+            throw new Error("expected fallback PRF salt");
+          }
+
+          fallbackSalt = new Uint8Array(first);
+          return {
+            type: "public-key",
+            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+            getClientExtensionResults: () => ({
+              prf: { results: { first } },
+            }),
+          };
+        },
+      },
+    },
+  });
+
+  try {
+    const pending = createPasskeyWithPrfOutput({
+      rp: { id: "example.com", name: "Mera Test" },
+      user: {
+        id: new Uint8Array([1]),
+        name: "nad",
+        displayName: "nad",
+      },
+      prfSalt,
+    });
+
+    prfSalt.fill(255);
+
+    const result = await pending;
+
+    expect(result.prfSalt).toEqual(originalSalt);
+    expect(result.prfOutput).toEqual(originalSalt);
+    expect(fallbackSalt).toEqual(originalSalt);
+  } finally {
+    if (ORIGINAL_NAVIGATOR) {
+      Object.defineProperty(globalThis, "navigator", ORIGINAL_NAVIGATOR);
+    } else {
+      Reflect.deleteProperty(globalThis, "navigator");
+    }
+  }
 });

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -45,6 +45,32 @@ test("creates a secret vault and unwraps the exact bytes", async () => {
   ).resolves.toEqual(SECRET);
 });
 
+test("createSecretVault snapshots caller-owned byte inputs before async work", async () => {
+  const prfSalt = new Uint8Array(PRF_SALT);
+  const prfOutput = new Uint8Array(PRF_OUTPUT);
+  const secret = new Uint8Array(SECRET);
+
+  const pending = createSecretVault({
+    credential: {
+      credentialId: "AQIDBA",
+      prfSalt,
+      prfOutput,
+    },
+    secret,
+  });
+
+  prfSalt.fill(1);
+  prfOutput.fill(2);
+  secret.fill(0);
+
+  const vault = await pending;
+
+  expect(vault.prfSalt).toBe("CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk");
+  await expect(
+    unwrapSecretVault({ vault, prfOutput: PRF_OUTPUT }),
+  ).resolves.toEqual(SECRET);
+});
+
 test("unwrapSecretVault fails with the wrong PRF output", async () => {
   const vault = await createTestVault();
 


### PR DESCRIPTION
## Summary
- Copy `prfSalt` before async passkey fallback work so later mutation does not affect the ceremony or returned salt.
- Copy secret vault inputs before encryption and zero temporary PRF output and secret buffers after use.
- Update docs and type comments to describe the new non-aliasing behavior.
- Add tests that mutate caller-owned buffers after calls start and verify results remain stable.

## Testing
- Added unit tests for `createPasskeyWithPrfOutput` and `createSecretVault` covering input snapshotting and round-trip behavior.