### PR TITLE
Document and test shared private-key snapshot handling

### DIFF
--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -36,9 +36,9 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
  * `signMessage` signs the raw message bytes with Ed25519 (Ed25519pure); the curve hashes internally with SHA-512.
  *
  * @param options - Signing session inputs.
- * @param options.consumePrivateKey - Ed25519 seed. Must be 32 bytes. Zeroed before this call returns or throws.
+ * @param options.consumePrivateKey - Ed25519 seed. Must be 32 bytes. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked Ed25519 signing session.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; on success first copies it into session memory, which `lock()` later zeroes.
+ * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not 32 bytes.
  */
 function createEd25519SigningSession({

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -55,9 +55,9 @@ function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
  * `signDigest` signs exactly 32 bytes without prehashing. Calling `lock` zeroes the active private-key copy and makes future signing or export fail.
  *
  * @param options - Signing session inputs.
- * @param options.consumePrivateKey - secp256k1 private key. Zeroed before this call returns or throws.
+ * @param options.consumePrivateKey - secp256k1 private key. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked secp256k1 signing session.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; on success first copies it into session memory, which `lock()` later zeroes.
+ * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.
  */
 function createSecp256k1SigningSession({

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,8 +5,8 @@ import { requireUnlocked } from "./errors.js";
  * Handle to a session-owned private key whose lifetime is gated by `lock`.
  *
  * Centralizes the key-zeroing lifecycle shared by every signing session: the
- * caller's buffer is consumed (copied, then zeroed) on creation, access throws
- * once locked, and `lock` zeroes the session-owned copy.
+ * caller's buffer is consumed (copied into one owned snapshot, then zeroed) on
+ * creation, access throws once locked, and `lock` zeroes the session-owned copy.
  */
 type LockableKey = {
   /**
@@ -28,22 +28,27 @@ type LockableKey = {
 /**
  * Consumes a private key into a lockable signing key and derives its public key.
  *
- * The caller's buffer is zeroed before this function returns or throws.
+ * The caller's buffer is copied into one owned snapshot, which is used for
+ * public-key derivation and signing. The caller's buffer is zeroed before this
+ * function returns or throws.
  *
  * @param consumePrivateKey - Private key to consume. Zeroed before this function returns or throws.
- * @param derivePublicKey - Derives the public key from the private key; a throw doubles as private-key validation.
+ * @param derivePublicKey - Derives the public key from the owned private-key snapshot; a throw doubles as private-key validation.
  * @returns The {@link LockableKey} handle gating access on lock state, paired with the derived public key.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; on success first copies it into session memory, which `lock()` later zeroes.
- * @throws Rethrows whatever `derivePublicKey` throws, after zeroing `consumePrivateKey`.
+ * @remarks Side effects: zeroes `consumePrivateKey` on every path; the owned snapshot is zeroed by `lock()` on success or before rethrowing a validation failure.
+ * @throws Rethrows whatever `derivePublicKey` throws, after zeroing the owned snapshot and `consumePrivateKey`.
  */
 function createSigningKey(
   consumePrivateKey: Uint8Array,
   derivePublicKey: (privateKey: Uint8Array) => Uint8Array,
 ): { key: LockableKey; publicKey: Uint8Array } {
+  let activePrivateKey: Uint8Array | undefined;
+
   try {
-    // Derive (which validates) before copying, so an invalid key is never copied into session memory.
-    const publicKey = derivePublicKey(consumePrivateKey);
-    let activePrivateKey: Uint8Array | undefined = copyBytes(consumePrivateKey);
+    // Derive and store from the same owned snapshot, so the public key cannot
+    // diverge from the private key later used for signing or export.
+    activePrivateKey = copyBytes(consumePrivateKey);
+    const publicKey = derivePublicKey(activePrivateKey);
 
     const key: LockableKey = {
       use(): Uint8Array {
@@ -61,6 +66,9 @@ function createSigningKey(
     };
 
     return { key, publicKey };
+  } catch (error) {
+    activePrivateKey?.fill(0);
+    throw error;
   } finally {
     consumePrivateKey.fill(0);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ type CreateSigningSessionOptions = {
   /**
    * Curve private key. Must be exactly 32 bytes; secp256k1 must also be a valid scalar.
    *
-   * Zeroed before the call returns or throws. Pass a fresh copy if the bytes are needed elsewhere.
+   * Copied into one session-owned snapshot, then zeroed before the call returns or throws. Pass a fresh copy if the bytes are needed elsewhere.
    */
   consumePrivateKey: Uint8Array;
 };

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,23 +1,35 @@
 import { expect, test } from "@playwright/test";
 import { createSigningKey } from "../dist/session.js";
 
-test("derives the public key from the stored private-key snapshot", () => {
-  const privateKey = new Uint8Array([1, 2, 3, 4]);
-  const original = new Uint8Array(privateKey);
+function sharedBytes(values: number[]): Uint8Array {
+  const bytes = new Uint8Array(new SharedArrayBuffer(values.length));
+  bytes.set(values);
+  return bytes;
+}
 
-  const { key, publicKey } = createSigningKey(privateKey, (snapshot) => {
-    const derived = new Uint8Array(snapshot);
+test("derives the public key from the stored private-key snapshot", () => {
+  const privateKey = sharedBytes([1, 2, 3, 4]);
+  const original = new Uint8Array(privateKey);
+  let snapshot: Uint8Array | undefined;
+
+  const { key, publicKey } = createSigningKey(privateKey, (value) => {
+    snapshot = value;
+    const derived = new Uint8Array(value);
     privateKey.fill(9);
     return derived;
   });
 
   expect(privateKey).toEqual(new Uint8Array(4));
+  expect(snapshot).not.toBe(privateKey);
+  expect(snapshot?.buffer).not.toBe(privateKey.buffer);
+  expect(snapshot?.buffer).toBeInstanceOf(ArrayBuffer);
   expect(publicKey).toEqual(original);
   expect(key.exportCopy()).toEqual(original);
+  key.lock();
 });
 
 test("zeroes the stored private-key snapshot when validation fails", () => {
-  const privateKey = new Uint8Array([1, 2, 3, 4]);
+  const privateKey = sharedBytes([1, 2, 3, 4]);
   let snapshot: Uint8Array | undefined;
 
   expect(() => {
@@ -28,5 +40,8 @@ test("zeroes the stored private-key snapshot when validation fails", () => {
   }).toThrow("invalid test key");
 
   expect(privateKey).toEqual(new Uint8Array(4));
+  expect(snapshot).not.toBe(privateKey);
+  expect(snapshot?.buffer).not.toBe(privateKey.buffer);
+  expect(snapshot?.buffer).toBeInstanceOf(ArrayBuffer);
   expect(snapshot).toEqual(new Uint8Array(4));
 });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { createSigningKey } from "../dist/session.js";
+
+test("derives the public key from the stored private-key snapshot", () => {
+  const privateKey = new Uint8Array([1, 2, 3, 4]);
+  const original = new Uint8Array(privateKey);
+
+  const { key, publicKey } = createSigningKey(privateKey, (snapshot) => {
+    const derived = new Uint8Array(snapshot);
+    privateKey.fill(9);
+    return derived;
+  });
+
+  expect(privateKey).toEqual(new Uint8Array(4));
+  expect(publicKey).toEqual(original);
+  expect(key.exportCopy()).toEqual(original);
+});
+
+test("zeroes the stored private-key snapshot when validation fails", () => {
+  const privateKey = new Uint8Array([1, 2, 3, 4]);
+  let snapshot: Uint8Array | undefined;
+
+  expect(() => {
+    createSigningKey(privateKey, (value) => {
+      snapshot = value;
+      throw new Error("invalid test key");
+    });
+  }).toThrow("invalid test key");
+
+  expect(privateKey).toEqual(new Uint8Array(4));
+  expect(snapshot).toEqual(new Uint8Array(4));
+});


### PR DESCRIPTION
## Summary
- Clarify signing-session docs to state that private keys are copied into one session-owned snapshot before use.
- Update `createSigningKey` to derive the public key from the stored snapshot and zero that snapshot on validation failure.
- Add tests covering snapshot-based derivation and cleanup when key validation throws.

## Testing
- Added unit tests for public-key derivation from the owned snapshot.
- Added unit tests for zeroing the stored snapshot when validation fails.
- Not run (not requested).