### PR TITLE
Clarify derived mode and sync assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ mera turns a WebAuthn passkey into stable, authenticator-bound entropy for walle
 
 - One passkey, multiple chains (EVM + Solana today).
 - One biometric per session, not per transaction.
-- Derived mode reproduces the same PRF output for the same PRF-capable credential, `rpId`, and PRF salt. Cross-device use requires that credential to be available on the new device.
+- Derived mode reproduces the same PRF output for the same PRF-capable passkey, `rpId`, and PRF salt. Cross-device use requires that passkey to be available on the new device.
 - Apps can choose standard wallet derivation and offer explicit recovery-phrase export.
 - Sessions are explicitly lockable; private-key bytes are zeroed on `session.lock()`.
 - No silent extraction path: key export is an explicit app workflow.
 
 ## Modes
 
-**Derived.** Stateless. Mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable credential and `rpId`; cross-device use requires that credential to be available on the new device. The app derives wallet keys from that output using its chosen scheme. The demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519. Best for "log in from anywhere."
+**Derived.** Stateless. Mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable passkey and `rpId`; cross-device use requires that passkey to be available on the new device. The app derives wallet keys from that output using its chosen scheme. The demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519. Best for "log in from anywhere."
 
 **Wrapped.** An AES-256-GCM blob holds one secret — a recovery phrase, a private key, any bytes; only the passkey can unlock it. The blob can live in `localStorage`, a backend, or a sync service. Best for hot-wallet UX, returning users who want to sign many transactions per session, and importing an existing wallet.
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 Passkey-backed signing for multichain accounts — one biometric, many chains.
 
-mera turns a WebAuthn passkey into stable, authenticator-bound entropy for wallet apps. The browser's WebAuthn PRF extension gives mera 32 bytes per ceremony; apps can feed those bytes into their chosen wallet derivation scheme (for example BIP-39/BIP-32 or SLIP-0010) or wrap an app-held secret — a recovery phrase, a private key — into a passkey-encrypted vault. Same passkey, same biometric, multiple chains. No smart-account deploys, no custom on-chain verifier programs.
+mera turns a WebAuthn passkey into stable, authenticator-bound entropy for wallet apps. The browser's WebAuthn PRF extension gives mera 32 bytes per ceremony; apps can feed those bytes into their chosen wallet derivation scheme (for example BIP-39/BIP-32 or SLIP-0010) or wrap an app-held secret — a recovery phrase, a private key — into a passkey-encrypted vault. No smart-account deploys, no custom on-chain verifier programs.
 
 ## What you get
 
 - One passkey, multiple chains (EVM + Solana today).
 - One biometric per session, not per transaction.
-- The same passkey can reproduce the same wallet entropy on a new device when synced.
+- Derived mode reproduces the same PRF output for the same PRF-capable credential, `rpId`, and PRF salt. Cross-device use requires that credential to be available on the new device.
 - Apps can choose standard wallet derivation and offer explicit recovery-phrase export.
 - Sessions are explicitly lockable; private-key bytes are zeroed on `session.lock()`.
 - No silent extraction path: key export is an explicit app workflow.
 
 ## Modes
 
-**Derived.** Stateless. Mera reproduces the same PRF output using the passkey and Mera's fixed deterministic salt. The app derives wallet keys from that output using its chosen scheme. The demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519, with account indexing handled by HD paths. Best for "log in from anywhere."
+**Derived.** Stateless. Mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable credential and `rpId`; cross-device use requires that credential to be available on the new device. The app derives wallet keys from that output using its chosen scheme. The demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519. Best for "log in from anywhere."
 
 **Wrapped.** An AES-256-GCM blob holds one secret — a recovery phrase, a private key, any bytes; only the passkey can unlock it. The blob can live in `localStorage`, a backend, or a sync service. Best for hot-wallet UX, returning users who want to sign many transactions per session, and importing an existing wallet.
 

--- a/site/index.html
+++ b/site/index.html
@@ -597,9 +597,8 @@ clientDataJSON
         <ul>
           <li>
             <strong>Deterministic.</strong>
-            The secret is created once and reused: the same passkey and salt
-            return the same 32 bytes, forever, on every device the passkey syncs
-            to.
+            The secret is created once per credential. The same PRF-capable
+            credential, relying party, and salt return the same 32 bytes.
           </li>
           <li>
             <strong>Site-scoped.</strong>
@@ -658,11 +657,11 @@ clientDataJSON
         <h3 id="derived-mode">Derived mode</h3>
 
         <p>
-          In derived mode the account is computed entirely from the passkey.
-          mera pins a fixed salt (<code>createDeterministicPrfSalt()</code>), so
-          every ceremony with the same passkey returns the same 32 bytes. The
-          application runs those bytes through its derivation scheme of choice;
-          mera's demo wallet app feeds them into BIP-39 and derives keys with
+          In derived mode the account is computed from the passkey. mera pins a
+          fixed salt (<code>createDeterministicPrfSalt()</code>), so the same
+          passkey yields the same account. The application runs the
+          passkey-derived bytes through its derivation scheme of choice; mera's
+          demo wallet app feeds them into BIP-39 and derives keys with
           <a
             href="https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki"
             >BIP-32</a
@@ -808,10 +807,11 @@ const address = getEvmAddress(session.publicKey)</code></pre>
         <p>
           Nothing is stored: no database row, no localStorage entry, no blob to
           sync. Sign in on a new device with the synced passkey, and the same
-          addresses appear. No recovery flow. And because the derivation is
-          standard, the application can offer an explicit export: the entropy
-          maps to an ordinary recovery phrase that imports into any standard
-          wallet app, like MetaMask or Phantom.
+          account appears. Cross-device use follows the password manager's
+          normal sync and security assumptions. No recovery flow. And because
+          the derivation is standard, the application can offer an explicit
+          export: the entropy maps to an ordinary recovery phrase that imports
+          into any standard wallet app, like MetaMask or Phantom.
         </p>
 
         <h3 id="wrapped-mode">Wrapped mode</h3>
@@ -1030,13 +1030,13 @@ const address = getEvmAddress(session.publicKey)</code></pre>
             The same entropy derives accounts for every chain the app supports.
           </li>
           <li>
-            <strong>Backup comes for free.</strong>
-            A synced passkey is backed up the way logins already are — by a
-            credential manager like iCloud Keychain or Google Password Manager.
+            <strong>Backup is passkey sync.</strong>
+            A credential manager like iCloud Keychain or Google Password Manager
+            makes the passkey available across devices.
           </li>
           <li>
             <strong>A new device is a sign-in.</strong>
-            Same passkey, same addresses.
+            Sign in with the synced passkey, and the same account appears.
           </li>
           <li>
             <strong>There is a way out.</strong>

--- a/site/index.html
+++ b/site/index.html
@@ -597,8 +597,8 @@ clientDataJSON
         <ul>
           <li>
             <strong>Deterministic.</strong>
-            The secret is created once per credential. The same PRF-capable
-            credential, relying party, and salt return the same 32 bytes.
+            The secret is created once per passkey. The same passkey, relying
+            party, and salt return the same 32 bytes.
           </li>
           <li>
             <strong>Site-scoped.</strong>
@@ -1031,8 +1031,8 @@ const address = getEvmAddress(session.publicKey)</code></pre>
           </li>
           <li>
             <strong>Backup is passkey sync.</strong>
-            A credential manager like iCloud Keychain or Google Password Manager
-            makes the passkey available across devices.
+            A password manager with sync, which most now provide, makes the
+            passkey available across devices.
           </li>
           <li>
             <strong>A new device is a sign-in.</strong>


### PR DESCRIPTION
## Summary
- Tighten README and site copy to state derived mode as PRF output tied to a credential, `rpId`, and salt
- Replace overbroad cross-device claims with passkey sync language and normal password-manager assumptions
- Reword backup and new-device copy to match the actual behavior more precisely

## Testing
- Not run (not requested)