### PR TITLE
Clarify derived account recovery assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ mera turns a WebAuthn passkey into stable, authenticator-bound entropy for walle
 
 **Wrapped.** An AES-256-GCM blob holds one secret — a recovery phrase, a private key, any bytes; only the passkey can unlock it. The blob can live in `localStorage`, a backend, or a sync service. Best for hot-wallet UX, returning users who want to sign many transactions per session, and importing an existing wallet.
 
+Derived mode stores no app-owned secret to recover. If the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's `rpId` after a domain migration, the account may be unrecoverable unless the app offers export, import, or another backup path.
+
 ## Install
 
 ```sh

--- a/demo/src/ConnectCard.tsx
+++ b/demo/src/ConnectCard.tsx
@@ -12,7 +12,7 @@ const MODES: { id: AccountMode; label: string; hint: string }[] = [
   {
     id: "derived",
     label: "Derived",
-    hint: "Accounts derived from your passkey — nothing is stored, and the same passkey restores them on any device.",
+    hint: "Accounts derived from your passkey — nothing is stored, and a synced passkey can restore them on another device.",
   },
   {
     id: "wrapped",

--- a/site/index.html
+++ b/site/index.html
@@ -808,10 +808,10 @@ const address = getEvmAddress(session.publicKey)</code></pre>
           Nothing is stored: no database row, no localStorage entry, no blob to
           sync. Sign in on a new device with the synced passkey, and the same
           account appears. Cross-device use follows the password manager's
-          normal sync and security assumptions. No recovery flow. And because
-          the derivation is standard, the application can offer an explicit
-          export: the entropy maps to an ordinary recovery phrase that imports
-          into any standard wallet app, like MetaMask or Phantom.
+          normal sync and security assumptions. Because the derivation is
+          standard, the application can offer an explicit export: the entropy
+          maps to an ordinary recovery phrase that imports into any standard
+          wallet app, like MetaMask or Phantom.
         </p>
 
         <h3 id="wrapped-mode">Wrapped mode</h3>
@@ -963,7 +963,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
               </tr>
               <tr>
                 <th scope="row">New device</th>
-                <td>synced passkey is enough</td>
+                <td>synced passkey</td>
                 <td>passkey plus the blob</td>
               </tr>
               <tr>


### PR DESCRIPTION
## Summary
- Clarify that derived accounts depend on synced passkeys and may be unrecoverable if the passkey is lost, deleted, or unavailable under a changed `rpId`.
- Update the demo copy to match the same recovery model.
- Tighten the site copy and comparison table to remove overstatement about recovery and cross-device use.

## Testing
- Not run (not requested)