### PR TITLE
Clarify PRF output domain separation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ const session = createSecp256k1SigningSession({ consumePrivateKey: privateKey })
 const address = getEvmAddress(session.publicKey)
 ```
 
+Treat the PRF output as a starting secret. Do not reuse the same output
+unchanged for unrelated purposes, such as wallet derivation and app-data
+encryption. Use a different PRF salt for that purpose, or split one PRF output
+with a purpose-labeled KDF.
+
 Derived/reproducible-wallet flows pass a stable PRF salt such as `createDeterministicPrfSalt()`. Wrapped flows pass fresh random salt bytes.
 
 ## Supported authenticators


### PR DESCRIPTION
## Summary
- Explain that PRF output should be treated as a starting secret, not reused unchanged across unrelated purposes.
- Add guidance to use a different PRF salt or a purpose-labeled KDF when deriving separate uses from the same source.

## Testing
- Not run (not requested)