### PR TITLE
Clarify passkey PRF and derived wallet copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ mera turns a WebAuthn passkey into stable, authenticator-bound entropy for walle
 
 ## Modes
 
-**Derived.** Stateless. Mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable passkey and `rpId`; cross-device use requires that passkey to be available on the new device. The app derives wallet keys from that output using its chosen scheme. The demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519. Best for "log in from anywhere."
+**Derived.** Stateless. Mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable passkey and `rpId`; cross-device use requires that passkey to be available on the new device. The app derives wallet keys from that output using its chosen scheme. The demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519. Best for stateless wallet access across devices.
 
 **Wrapped.** An AES-256-GCM blob holds one secret — a recovery phrase, a private key, any bytes; only the passkey can unlock it. The blob can live in `localStorage`, a backend, or a sync service. Best for hot-wallet UX, returning users who want to sign many transactions per session, and importing an existing wallet.
 

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -213,20 +213,22 @@ async function createPasskey({
 }
 
 /**
- * Performs a passkey assertion and returns the first WebAuthn PRF output.
+ * Requests a passkey PRF evaluation and returns the first output.
  *
  * When `credentialId` is omitted, WebAuthn may choose any discoverable credential for the relying party.
  *
- * @param options - Passkey assertion inputs.
- * @param options.rpId - Relying party ID for the WebAuthn assertion.
+ * @param options - Passkey PRF request inputs.
+ * @param options.rpId - Relying party ID for the WebAuthn request.
  * @param options.credentialId - Optional credential ID to restrict the assertion to one passkey.
  * @param options.transports - Optional transports associated with `credentialId`.
  * @param options.prfSalt - PRF salt. Must be exactly 32 bytes.
  * @param options.challenge - WebAuthn challenge. Defaults to 32 cryptographically random bytes.
  * @param options.timeout - WebAuthn timeout in milliseconds. Browser defaults apply when omitted.
- * @returns The selected credential ID and first WebAuthn PRF output.
- * @remarks Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
- * @remarks Caller assumptions: `prfSalt` must be stable for flows that need stable PRF output.
+ * @returns The selected credential ID and first WebAuthn PRF output for wallet derivation or unlock flows.
+ * @remarks
+ * Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
+ *
+ * Caller assumptions: `prfSalt` must be stable for flows that need stable PRF output.
  * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes or `credentialId` is not canonical base64url.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.


### PR DESCRIPTION
## Summary
- Reword the README to describe derived mode as stateless wallet access across devices.
- Tighten the passkey PRF JSDoc to emphasize PRF evaluation and wallet derivation or unlock flows.
- Keep the observable behavior and failure modes unchanged.

## Testing
- Not run (not requested)