### PR TITLE
[codex] Remove session private-key export

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ mera turns a WebAuthn passkey into stable, authenticator-bound entropy for walle
 - Derived mode reproduces the same PRF output for the same PRF-capable passkey, `rpId`, and PRF salt. Cross-device use requires that passkey to be available on the new device.
 - Apps can choose standard wallet derivation and offer explicit recovery-phrase export.
 - Sessions are explicitly lockable; private-key bytes are zeroed on `session.lock()`.
-- No silent extraction path: key export is an explicit app workflow.
+- Recovery export is an app-owned flow behind a fresh passkey or vault ceremony.
 
 ## Modes
 
@@ -99,7 +99,7 @@ Secret-vault flows, demo HD derivation recipes (BIP-39/BIP-32, SLIP-0010), the s
 
 ## Security
 
-Keys are not protected once unlocked inside a compromised JavaScript runtime. Host apps should serve over HTTPS, use a strict CSP, avoid untrusted scripts, and keep unlocked sessions short-lived — call `session.lock()` as soon as you're done signing.
+Keys are not protected once derived, imported, or unlocked inside a compromised JavaScript runtime: compromised code can observe key material during app-owned derivation/import and can sign with an unlocked session until `session.lock()`. Recovery export should be handled as a separate app-owned flow that reruns WebAuthn PRF or unwraps a vault with fresh user verification.
 
 **Dependency scope.** The library’s shipped runtime dependency tree is the root manifest’s `dependencies` (`@noble/*`, `@scure/*`). The root `devDependencies` are build/test/lint tooling (supply-chain only), and the `demo/` app is a non-published example (`private: true`) with its own, larger dependency tree; neither set of packages ships to library consumers.
 

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -56,9 +56,6 @@ function createEd25519SigningSession({
       const messageCopy = copyBytes(message);
       return new Uint8Array(await ed25519.signAsync(messageCopy, key.use()));
     },
-    exportPrivateKey(): Uint8Array {
-      return key.exportCopy();
-    },
     lock(): void {
       key.lock();
     },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,7 +3,7 @@
  *
  * - `PASSKEY_OPERATION_FAILED`: WebAuthn or the browser credential API failed, was cancelled, or returned an unexpected credential.
  * - `PRF_UNAVAILABLE`: the authenticator did not enable or return a usable 32-byte WebAuthn PRF output.
- * - `SESSION_LOCKED`: a signing or export call was made after `lock()`.
+ * - `SESSION_LOCKED`: a signing call was made after `lock()`.
  * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key, or tampered ciphertext or AAD).
  * - `INPUT_INVALID`: a caller-supplied value at a public boundary did not satisfy a length, range, encoding, or scalar constraint.
  * - `VAULT_FORMAT_INVALID`: untrusted vault data (JSON or object) was malformed, missing required fields, or used a non-canonical encoding.
@@ -53,7 +53,7 @@ function isPasskeyAccountError(error: unknown): error is PasskeyAccountError {
 /**
  * Returns the active private key for a signing session, or throws if the
  * session has been locked. Used by curve-specific session helpers to gate
- * `signDigest`/`signMessage`/`exportPrivateKey` after `lock()`.
+ * `signDigest`/`signMessage` after `lock()`.
  *
  * @throws PasskeyAccountError with code `SESSION_LOCKED` when `privateKey` is undefined.
  */

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -52,7 +52,7 @@ function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
 /**
  * Wraps a secp256k1 private key in an explicitly lockable signing session.
  *
- * `signDigest` signs exactly 32 bytes without prehashing. Calling `lock` zeroes the active private-key copy and makes future signing or export fail.
+ * `signDigest` signs exactly 32 bytes without prehashing. Calling `lock` zeroes the active private-key copy and makes future signing fail.
  *
  * @param options - Signing session inputs.
  * @param options.consumePrivateKey - secp256k1 private key. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
@@ -91,9 +91,6 @@ function createSecp256k1SigningSession({
         compact: signature.slice(1),
         recovery: signature[0],
       };
-    },
-    exportPrivateKey(): Uint8Array {
-      return key.exportCopy();
     },
     lock(): void {
       key.lock();

--- a/src/session.ts
+++ b/src/session.ts
@@ -15,12 +15,6 @@ type LockableKey = {
    * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
    */
   use(): Uint8Array;
-  /**
-   * Returns a fresh copy of the session-owned key.
-   *
-   * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
-   */
-  exportCopy(): Uint8Array;
   /** Zeroes the session-owned key and permanently locks this handle. */
   lock(): void;
 };
@@ -46,16 +40,13 @@ function createSigningKey(
 
   try {
     // Derive and store from the same owned snapshot, so the public key cannot
-    // diverge from the private key later used for signing or export.
+    // diverge from the private key later used for signing.
     activePrivateKey = copyBytes(consumePrivateKey);
     const publicKey = derivePublicKey(activePrivateKey);
 
     const key: LockableKey = {
       use(): Uint8Array {
         return requireUnlocked(activePrivateKey);
-      },
-      exportCopy(): Uint8Array {
-        return new Uint8Array(requireUnlocked(activePrivateKey));
       },
       lock(): void {
         if (activePrivateKey !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,16 +108,9 @@ type Secp256k1SigningSession = {
    */
   signDigest(digest32: Uint8Array): Promise<Secp256k1Signature>;
   /**
-   * Returns a copy of the active private key.
-   *
-   * @returns A copy of the active private key.
-   * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
-   */
-  exportPrivateKey(): Uint8Array;
-  /**
    * Clears the active private key and permanently locks this session.
    *
-   * @remarks Side effects: overwrites the session-owned private-key copy with zeros and makes future signing or export fail.
+   * @remarks Side effects: overwrites the session-owned private-key copy with zeros and makes future signing fail.
    * @remarks If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
    */
   lock(): void;
@@ -137,16 +130,9 @@ type Ed25519SigningSession = {
    */
   signMessage(message: Uint8Array): Promise<Uint8Array>;
   /**
-   * Returns a copy of the active private key (Ed25519 seed).
-   *
-   * @returns A copy of the active 32-byte seed.
-   * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
-   */
-  exportPrivateKey(): Uint8Array;
-  /**
    * Clears the active private key and permanently locks this session.
    *
-   * @remarks Side effects: overwrites the session-owned seed copy with zeros and makes future signing or export fail.
+   * @remarks Side effects: overwrites the session-owned seed copy with zeros and makes future signing fail.
    * @remarks If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
    */
   lock(): void;

--- a/test/ed25519-session.test.ts
+++ b/test/ed25519-session.test.ts
@@ -25,11 +25,9 @@ test("signs messages and locks the session", async () => {
   expect(await ed25519.verifyAsync(signature, message, session.publicKey)).toBe(
     true,
   );
-  expect(session.exportPrivateKey()).toEqual(RFC_SECRET);
 
   session.lock();
 
-  expectError(() => session.exportPrivateKey(), "SESSION_LOCKED");
   await expect(session.signMessage(message)).rejects.toMatchObject({
     code: "SESSION_LOCKED",
   });

--- a/test/secp256k1-session.test.ts
+++ b/test/secp256k1-session.test.ts
@@ -9,7 +9,6 @@ const PRIVATE_KEY_ONE = hexToBytes(
 );
 
 test("signs 32-byte digests and locks the session", async () => {
-  const original = new Uint8Array(PRIVATE_KEY_ONE);
   const buffer = new Uint8Array(PRIVATE_KEY_ONE);
   const session = createSecp256k1SigningSession({ consumePrivateKey: buffer });
   const digest = new Uint8Array(32).fill(1);
@@ -27,11 +26,9 @@ test("signs 32-byte digests and locks the session", async () => {
       prehash: false,
     }),
   ).toBe(true);
-  expect(session.exportPrivateKey()).toEqual(original);
 
   session.lock();
 
-  expectError(() => session.exportPrivateKey(), "SESSION_LOCKED");
   await expect(session.signDigest(digest)).rejects.toMatchObject({
     code: "SESSION_LOCKED",
   });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { createSigningKey } from "../dist/session.js";
+import { expectError } from "./helpers.js";
 
 function sharedBytes(values: number[]): Uint8Array {
   const bytes = new Uint8Array(new SharedArrayBuffer(values.length));
@@ -24,8 +25,10 @@ test("derives the public key from the stored private-key snapshot", () => {
   expect(snapshot?.buffer).not.toBe(privateKey.buffer);
   expect(snapshot?.buffer).toBeInstanceOf(ArrayBuffer);
   expect(publicKey).toEqual(original);
-  expect(key.exportCopy()).toEqual(original);
+  expect(key.use()).toEqual(original);
   key.lock();
+  expect(snapshot).toEqual(new Uint8Array(4));
+  expectError(() => key.use(), "SESSION_LOCKED");
 });
 
 test("zeroes the stored private-key snapshot when validation fails", () => {


### PR DESCRIPTION
## Summary

Remove private-key export from lockable signing sessions. Sessions now expose only `publicKey`, signing, and `lock()`.

## Why

A signing session only owns in-memory key bytes. Letting `session.exportPrivateKey()` read those bytes made export available to any code holding an unlocked session. Prompt-backed recovery export belongs at the app workflow layer, where the app can run a fresh WebAuthn PRF assertion or unwrap a vault with user verification.

## Impact

- Breaking API change: `Secp256k1SigningSession` and `Ed25519SigningSession` no longer have `exportPrivateKey()`.
- Internal `LockableKey` no longer exposes `exportCopy()`.
- README security language now frames recovery export as app-owned and separate from live signing.
- Existing signing, locking, and buffer-zeroing behavior is unchanged.

## Validation

- `npm test`
- `npm run check:pack`
- `npm run check`