### PR TITLE
Document recovery phrase string lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Secret-vault flows, demo HD derivation recipes (BIP-39/BIP-32, SLIP-0010), the s
 
 Keys are not protected once unlocked inside a compromised JavaScript runtime. Host apps should serve over HTTPS, use a strict CSP, avoid untrusted scripts, and keep unlocked sessions short-lived — call `session.lock()` as soon as you're done signing.
 
+Recovery phrases become JavaScript strings when displayed or exported. Unlike `Uint8Array` buffers, strings cannot be zeroed in place; apps can only drop references and keep their lifetime short. Mera zeroes owned byte buffers where possible, but host apps should treat revealed recovery phrases as high-risk UI state.
+
 **Dependency scope.** The library’s shipped runtime dependency tree is the root manifest’s `dependencies` (`@noble/*`, `@scure/*`). The root `devDependencies` are build/test/lint tooling (supply-chain only), and the `demo/` app is a non-published example (`private: true`) with its own, larger dependency tree; neither set of packages ships to library consumers.
 
 ## License

--- a/demo/src/WalletBackup.tsx
+++ b/demo/src/WalletBackup.tsx
@@ -4,7 +4,7 @@ import { useCopyButton } from "./useCopyButton";
 type WalletBackupProps = {
   /** The revealed recovery phrase to display (12 or 24 words). */
   phrase: string;
-  /** Return to the account view, dropping the phrase from memory. */
+  /** Return to the account view, dropping the phrase reference. */
   onHide: () => void;
 };
 

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -329,8 +329,8 @@ function connect(
  * wallets decrypt the phrase the user generated or imported out of the secret
  * vault. Either way the mnemonic is fetched on demand rather than held in
  * memory: revealing the whole-wallet backup is a high-privilege action, so it
- * is gated behind a fresh biometric and every secret is zeroed as soon as the
- * words are read.
+ * is gated behind a fresh biometric, byte buffers are zeroed where possible,
+ * and the returned string is dropped when the backup view hides or unmounts.
  */
 async function revealMnemonic(wallet: ConnectedWallet): Promise<string> {
   if (wallet.mode === "wrapped") {


### PR DESCRIPTION
## Summary
- Clarify that revealed recovery phrases become JavaScript strings that cannot be zeroed in place.
- Note that Mera zeroes owned byte buffers where possible and that host apps should treat revealed phrases as high-risk UI state.
- Update demo documentation to describe dropping the phrase reference rather than implying in-memory zeroing.

## Testing
- Not run (not requested)