### PR TITLE
[codex] Simplify release API and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,37 +29,45 @@ npm install @category-labs/mera
 
 ## Quick example
 
-A derived-mode skeleton: one passkey ceremony, then app-owned wallet derivation.
+Wrap one Ed25519 seed behind a passkey, then unlock it into a signing session.
 
 ```ts
 import {
-  createDeterministicPrfSalt,
-  createSecp256k1SigningSession,
-  getEvmAddress,
-  getPasskeyPrfOutput,
+  createEd25519SigningSession,
+  createPasskeyWithPrfOutput,
+  createSecretVault,
+  getSecretVaultPrfOutput,
+  getSolanaAddress,
+  unwrapSecretVault,
 } from "@category-labs/mera"
-import { derivePrivateKeyWithYourWalletScheme } from "./wallet-derivation"
 
-const rpId = "account.example.com"
+const rp = { id: "account.example.com", name: "Example" }
+const user = { name: "demo", displayName: "Demo" }
+const seed = crypto.getRandomValues(new Uint8Array(32))
 
-const prfSalt = createDeterministicPrfSalt()
-const { prfOutput } = await getPasskeyPrfOutput({ rpId, prfSalt })
-
-const privateKey = derivePrivateKeyWithYourWalletScheme({
-  entropy: prfOutput,
-  path: "m/44'/60'/0'/0/0",
+const credential = await createPasskeyWithPrfOutput({
+  rp,
+  user,
+  prfSalt: crypto.getRandomValues(new Uint8Array(32)),
 })
 
-const session = createSecp256k1SigningSession({ consumePrivateKey: privateKey })
-const address = getEvmAddress(session.publicKey)
+const vault = await createSecretVault({ credential, secret: seed })
+seed.fill(0)
+
+const { prfOutput } = await getSecretVaultPrfOutput({
+  rpId: rp.id,
+  vault,
+})
+const unlockedSeed = await unwrapSecretVault({ vault, prfOutput })
+prfOutput.fill(0)
+
+const session = createEd25519SigningSession({
+  consumePrivateKey: unlockedSeed,
+})
+const address = getSolanaAddress(session.publicKey)
 ```
 
-Treat the PRF output as a starting secret. Do not reuse the same output
-unchanged for unrelated purposes, such as wallet derivation and app-data
-encryption. Use a different PRF salt for that purpose, or split one PRF output
-with a purpose-labeled KDF.
-
-Derived/reproducible-wallet flows pass a stable PRF salt such as `createDeterministicPrfSalt()`. Wrapped flows pass fresh random salt bytes.
+Treat each PRF output as a starting secret. Reusing the same output unchanged for unrelated purposes, such as wallet derivation and app-data encryption, couples those purposes. Derived/reproducible-wallet flows pass a stable PRF salt such as `createDeterministicPrfSalt()`. Wrapped flows pass fresh random salt bytes.
 
 ## Supported authenticators
 
@@ -91,7 +99,7 @@ On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The
 
 ## API reference
 
-Names only — your editor's hover surfaces the full JSDoc.
+Names only. Editor hovers surface the full JSDoc shipped with the package.
 
 - **Passkey ceremonies** — `createPasskey`, `createPasskeyWithPrfOutput`, `getPasskeyPrfOutput`
 - **Deterministic PRF salt** — `createDeterministicPrfSalt`
@@ -100,19 +108,19 @@ Names only — your editor's hover surfaces the full JSDoc.
 - **Chain addresses** — `getEvmAddress`, `isEvmAddress`, `getSolanaAddress`, `isSolanaAddress`
 - **Errors** — `PasskeyAccountError`, `isPasskeyAccountError`, `PasskeyAccountErrorCode`
 
-## Detailed docs
+## More examples
 
-Secret-vault flows, demo HD derivation recipes (BIP-39/BIP-32, SLIP-0010), the secret vault format, and the viem adapter live in the developer documentation.
+The `demo/` app contains app-owned integration examples for BIP-39/BIP-32, SLIP-0010, secret-vault flows, and viem account adaptation.
 
 ## Security
 
-Keys are not protected once derived, imported, or unlocked inside a compromised JavaScript runtime: compromised code can observe key material during app-owned derivation/import and can sign with an unlocked session until `session.lock()`. Recovery export should be handled as a separate app-owned flow that reruns WebAuthn PRF or unwraps a vault with fresh user verification.
+Keys are not protected once derived, imported, or unlocked inside a compromised JavaScript runtime: compromised code can observe key material during app-owned derivation/import and can sign with an unlocked session until `session.lock()`. Recovery export is a separate app-owned flow that reruns WebAuthn PRF or unwraps a vault with fresh user verification.
 
-Recovery phrases become JavaScript strings when displayed or exported. Unlike `Uint8Array` buffers, strings cannot be zeroed in place; apps can only drop references and keep their lifetime short. Mera zeroes owned byte buffers where possible, but host apps should treat revealed recovery phrases as high-risk UI state.
+Recovery phrases become JavaScript strings when displayed or exported. Unlike `Uint8Array` buffers, strings cannot be zeroed in place; apps can only drop references and keep their lifetime short. Mera zeroes owned byte buffers where possible; revealed recovery phrases remain high-risk UI state.
 
 **Dependency scope.** The library’s shipped runtime dependency tree is the root manifest’s `dependencies` (`@noble/*`, `@scure/*`). The root `devDependencies` are build/test/lint tooling (supply-chain only), and the `demo/` app is a non-published example (`private: true`) with its own, larger dependency tree; neither set of packages ships to library consumers.
 
 ## License
 
 Licensed under either of [Apache License](./LICENSE-APACHE), Version
-2.0 or [MIT License](./LICENSE-MIT) at your option.
+2.0 or [MIT License](./LICENSE-MIT), at the licensee's option.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "files": {
     "includes": [
       "**",
@@ -23,7 +23,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "overrides": [

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -7,6 +7,7 @@ import {
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
+// biome-ignore lint/style/useNodejsImportProtocol: Vite maps this package to the browser Buffer polyfill for the demo.
 import { Buffer } from "buffer";
 import { cachePerNetwork, type NetworkMode } from "../network";
 

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -91,6 +91,27 @@ h1 {
   color: var(--muted);
 }
 
+input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--field);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+}
+
+input::placeholder {
+  color: color-mix(in srgb, var(--muted) 75%, transparent);
+}
+
+input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
 .network-toggle {
   position: relative;
   display: flex;
@@ -327,36 +348,10 @@ h1 {
   gap: 8px;
 }
 
-.field-head .link {
-  text-transform: none;
-  letter-spacing: normal;
-}
-
 /* Wrapped-mode recovery-phrase section on the connect screen. */
 .secret {
   display: grid;
   gap: 10px;
-}
-
-input {
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--field);
-  color: var(--text);
-  font: inherit;
-  font-size: 14px;
-}
-
-input::placeholder {
-  color: color-mix(in srgb, var(--muted) 75%, transparent);
-}
-
-input:focus-visible {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
 /* Buttons */
@@ -424,6 +419,11 @@ input:focus-visible {
 .link:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+.field-head .link {
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 .hint {

--- a/src/derived.ts
+++ b/src/derived.ts
@@ -1,5 +1,5 @@
 import { sha256 } from "@noble/hashes/sha2.js";
-import { utf8ToBytes } from "./encoding.js";
+import { utf8ToBytes } from "@noble/hashes/utils.js";
 
 const DETERMINISTIC_PRF_DOMAIN = utf8ToBytes("mera.v1.deterministic.prf");
 // The domain is a compile-time constant, so the salt is constant too: compute
@@ -15,7 +15,7 @@ const DETERMINISTIC_PRF_SALT = sha256(DETERMINISTIC_PRF_DOMAIN);
  * SLIP-0010.
  *
  * @returns Mera's fixed v1 deterministic 32-byte PRF salt.
- * @remarks Caller assumptions: wallet account selection belongs in the caller's wallet derivation scheme, not in this salt.
+ * @remarks Wallet account selection is not encoded in this salt; app-owned derivation schemes own that step.
  */
 function createDeterministicPrfSalt(): Uint8Array {
   return new Uint8Array(DETERMINISTIC_PRF_SALT);

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -38,7 +38,7 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
  * @param options - Signing session inputs.
  * @param options.consumePrivateKey - Ed25519 seed. Must be 32 bytes. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked Ed25519 signing session.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
+ * @remarks `consumePrivateKey` is zeroed on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not 32 bytes.
  */
 function createEd25519SigningSession({

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,4 +1,4 @@
-import { concatBytes, utf8ToBytes } from "@noble/hashes/utils.js";
+import { concatBytes } from "@noble/hashes/utils.js";
 import { base64urlnopad } from "@scure/base";
 import { PasskeyAccountError } from "./errors.js";
 
@@ -58,7 +58,7 @@ function base64UrlDecode(value: string): Uint8Array {
  *
  * @param value - Integer to encode.
  * @returns Four big-endian bytes.
- * @remarks Caller assumptions: `value` is already a uint32 integer.
+ * @remarks `DataView#setUint32` applies the uint32 conversion.
  */
 function uint32Be(value: number): Uint8Array {
   const output = new Uint8Array(4);
@@ -82,8 +82,6 @@ export {
   base64UrlDecode,
   base64UrlEncode,
   canonicalEncode,
-  concatBytes,
   copyBytes,
   uint32Be,
-  utf8ToBytes,
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -50,23 +50,5 @@ function isPasskeyAccountError(error: unknown): error is PasskeyAccountError {
   return error instanceof PasskeyAccountError;
 }
 
-/**
- * Returns the active private key for a signing session, or throws if the
- * session has been locked. Used by curve-specific session helpers to gate
- * `signDigest`/`signMessage` after `lock()`.
- *
- * @throws PasskeyAccountError with code `SESSION_LOCKED` when `privateKey` is undefined.
- */
-function requireUnlocked(privateKey: Uint8Array | undefined): Uint8Array {
-  if (privateKey === undefined) {
-    throw new PasskeyAccountError(
-      "SESSION_LOCKED",
-      "Signing session is locked",
-    );
-  }
-
-  return privateKey;
-}
-
 export type { PasskeyAccountErrorCode };
-export { isPasskeyAccountError, PasskeyAccountError, requireUnlocked };
+export { isPasskeyAccountError, PasskeyAccountError };

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,8 @@ export type {
   Ed25519SigningSession,
   EvmAddress,
   PasskeyCredentialMetadata,
-  PasskeyCredentialTransport,
   PasskeyPrfResult,
   PasskeySecretVault,
   Secp256k1Signature,
   Secp256k1SigningSession,
-  SigningCurve,
 } from "./types.js";

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -5,10 +5,13 @@ import {
   copyBytes,
 } from "./encoding.js";
 import { isPasskeyAccountError, PasskeyAccountError } from "./errors.js";
+import {
+  filterKnownAuthenticatorTransports,
+  readAuthenticatorTransports,
+} from "./transports.js";
 import type {
   CreatePasskeyResult,
   CreatePasskeyWithPrfOutputResult,
-  PasskeyCredentialTransport,
   PasskeyPrfResult,
 } from "./types.js";
 import { randomBytes } from "./webcrypto.js";
@@ -35,7 +38,7 @@ type CreatePasskeyInput = {
   /**
    * Optional 32-byte PRF salt to evaluate during creation. When provided and the authenticator supports PRF eval at create time, the returned `prfOutput` lets a derived-mode flow open the account in a single ceremony.
    *
-   * Authenticators that do not support PRF eval during creation silently ignore this field; callers should fall back to `getPasskeyPrfOutput` if `prfOutput` is undefined.
+   * Authenticators that do not support PRF eval during creation silently ignore this field; `prfOutput` is undefined in that case.
    */
   prfSalt?: Uint8Array;
 };
@@ -64,7 +67,7 @@ type GetPasskeyPrfOutputInput = {
   /** Optional credential ID (canonical unpadded base64url) to restrict the assertion to one passkey. */
   credentialId?: string;
   /** Optional transports associated with `credentialId`. */
-  transports?: PasskeyCredentialTransport[];
+  transports?: AuthenticatorTransport[];
   /** PRF salt as 32 raw bytes. */
   prfSalt: Uint8Array;
   /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
@@ -102,8 +105,9 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * @param options.attestation - WebAuthn attestation preference. Defaults to `"none"`.
  * @param options.prfSalt - Optional 32-byte PRF salt to evaluate at create time.
  * @returns Credential metadata and, when `prfSalt` was provided and the authenticator supports it, the first PRF output.
- * @remarks Side effects: invokes `navigator.credentials.create()`, which may show browser or authenticator UI and create a discoverable passkey.
- * @remarks Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
+ * @remarks
+ * Invokes `navigator.credentials.create()`, which may show browser or authenticator UI and create a discoverable passkey. WebAuthn requires a secure browser context with PRF support.
+ *
  * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
@@ -176,7 +180,7 @@ async function createPasskey({
       publicKeyCredential.response as AuthenticatorAttestationResponse;
     const transports =
       typeof response.getTransports === "function"
-        ? response.getTransports()
+        ? filterKnownAuthenticatorTransports(response.getTransports())
         : undefined;
 
     const result: CreatePasskeyResult = {
@@ -226,11 +230,12 @@ async function createPasskey({
  * @param options.timeout - WebAuthn timeout in milliseconds. Browser defaults apply when omitted.
  * @returns The selected credential ID and first WebAuthn PRF output for wallet derivation or unlock flows.
  * @remarks
- * Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
+ * Invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
  *
- * Caller assumptions: `prfSalt` must be stable for flows that need stable PRF output.
+ * Stable `prfSalt` bytes produce stable PRF output for the same credential and relying party.
+ *
  * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes or `credentialId` is not canonical base64url.
+ * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, `credentialId` is empty or not canonical base64url, or `transports` contains an unknown WebAuthn transport.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function getPasskeyPrfOutput({
@@ -261,14 +266,17 @@ async function getPasskeyPrfOutput({
       extensions: { prf },
     };
 
-    if (credentialId) {
-      publicKey.allowCredentials = [
-        {
-          id: asArrayBuffer(base64UrlDecode(credentialId)),
-          type: "public-key",
-          transports: transports as AuthenticatorTransport[] | undefined,
-        },
-      ];
+    const transportHints = readAuthenticatorTransports(
+      transports,
+      "transports",
+      "INPUT_INVALID",
+    );
+    const credentialDescriptor = createCredentialDescriptor(
+      credentialId,
+      transportHints,
+    );
+    if (credentialDescriptor !== undefined) {
+      publicKey.allowCredentials = [credentialDescriptor];
     }
 
     const credential = await navigator.credentials.get({ publicKey });
@@ -311,16 +319,17 @@ async function getPasskeyPrfOutput({
 /**
  * Creates a passkey and returns the first WebAuthn PRF output, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time.
  *
- * This is the canonical "open this account right after creating it" entry point. It is equivalent to calling `createPasskey` and, when `prfOutput` is undefined, `getPasskeyPrfOutput` with the same salt. The lower-level entry points remain available for callers that want to drive the two ceremonies independently (for example, to show UI between them).
+ * This is the canonical "open this account right after creating it" entry point. It is equivalent to calling `createPasskey` and, when `prfOutput` is undefined, `getPasskeyPrfOutput` with the same salt. The lower-level entry points remain available for flows that drive the two ceremonies independently (for example, to show UI between them).
  *
  * @param options - Passkey creation inputs. `rp.id` is required so the fallback ceremony can target the same relying party. `prfSalt` must be exactly 32 bytes.
  * @returns Credential metadata and the first PRF output.
  * @remarks
- * Side effects: invokes `navigator.credentials.create()`. On authenticators that do not evaluate PRF during creation, also invokes `navigator.credentials.get()` — which means a second browser prompt for the user.
+ * Invokes `navigator.credentials.create()`. On authenticators that do not evaluate PRF during creation, also invokes `navigator.credentials.get()`; this means a second browser prompt.
  *
  * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of the input does not change the fallback ceremony or returned salt.
  *
- * Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
+ * WebAuthn requires a secure browser context with PRF support.
+ *
  * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or does not return PRF output on the fallback ceremony.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
@@ -410,6 +419,37 @@ function assertPublicKeyCredential(
   }
 
   return publicKeyCredential;
+}
+
+/**
+ * Builds the optional WebAuthn descriptor for the stored credential.
+ *
+ * Empty credential IDs are rejected instead of omitted, so a malformed stored
+ * ID cannot widen the assertion to any discoverable credential.
+ *
+ * @internal
+ */
+function createCredentialDescriptor(
+  credentialId: string | undefined,
+  transports: AuthenticatorTransport[] | undefined,
+): PublicKeyCredentialDescriptor | undefined {
+  if (credentialId === undefined) {
+    return undefined;
+  }
+
+  const id = base64UrlDecode(credentialId);
+  if (id.length === 0) {
+    throw new PasskeyAccountError(
+      "INPUT_INVALID",
+      "credentialId must not be empty",
+    );
+  }
+
+  return {
+    id: asArrayBuffer(id),
+    type: "public-key",
+    ...(transports !== undefined ? { transports } : {}),
+  };
 }
 
 /**

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -14,7 +14,7 @@ import type {
  * @internal
  * @param privateKey - A 32-byte secp256k1 private key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
- * @remarks Caller assumptions: the private key must be secret key material; the function does not clear or mutate the input.
+ * @remarks The input is not cleared or mutated.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
  */
 function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
@@ -57,7 +57,7 @@ function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
  * @param options - Signing session inputs.
  * @param options.consumePrivateKey - secp256k1 private key. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked secp256k1 signing session.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
+ * @remarks `consumePrivateKey` is zeroed on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
  * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.
  */
 function createSecp256k1SigningSession({

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -1,3 +1,4 @@
+import { utf8ToBytes } from "@noble/hashes/utils.js";
 import {
   asArrayBuffer,
   base64UrlDecode,
@@ -5,15 +6,11 @@ import {
   canonicalEncode,
   copyBytes,
   uint32Be,
-  utf8ToBytes,
 } from "./encoding.js";
 import { PasskeyAccountError, type PasskeyAccountErrorCode } from "./errors.js";
 import { getPasskeyPrfOutput } from "./passkey.js";
-import type {
-  PasskeyCredentialTransport,
-  PasskeyPrfResult,
-  PasskeySecretVault,
-} from "./types.js";
+import { readAuthenticatorTransports } from "./transports.js";
+import type { PasskeyPrfResult, PasskeySecretVault } from "./types.js";
 import { getCrypto, hkdfSha256AesGcmKey, randomBytes } from "./webcrypto.js";
 
 const PRF_SALT_LENGTH = 32;
@@ -61,9 +58,8 @@ async function deriveWrappingKey({
   return hkdfSha256AesGcmKey(prfOutput, info);
 }
 
-// AES-256-GCM encrypt. subtle.encrypt copies its inputs synchronously and the
-// caller owns the plaintext, so this helper has nothing of its own to zero.
-// GCM nonces are generated internally so callers cannot accidentally reuse one.
+// AES-256-GCM encrypt. subtle.encrypt copies its inputs synchronously, and this
+// helper owns no plaintext buffer to zero. GCM nonces are generated internally.
 async function aesGcmEncrypt({
   plaintext,
   wrappingKey,
@@ -138,7 +134,7 @@ function readBase64Url(
   value: unknown,
   name: string,
   errorCode: PasskeyAccountErrorCode,
-  byteLength?: number | { min: number },
+  length: { exactByteLength?: number; minByteLength?: number } = {},
 ): string {
   if (typeof value !== "string") {
     throw new PasskeyAccountError(errorCode, `${name} must be base64url`);
@@ -153,17 +149,23 @@ function readBase64Url(
     });
   }
 
-  if (typeof byteLength === "number" && bytes.length !== byteLength) {
+  if (
+    length.exactByteLength !== undefined &&
+    bytes.length !== length.exactByteLength
+  ) {
     throw new PasskeyAccountError(
       errorCode,
-      `${name} must be ${byteLength} bytes`,
+      `${name} must be ${length.exactByteLength} bytes`,
     );
   }
 
-  if (typeof byteLength === "object" && bytes.length < byteLength.min) {
+  if (
+    length.minByteLength !== undefined &&
+    bytes.length < length.minByteLength
+  ) {
     throw new PasskeyAccountError(
       errorCode,
-      `${name} must be at least ${byteLength.min} bytes`,
+      `${name} must be at least ${length.minByteLength} bytes`,
     );
   }
 
@@ -184,7 +186,7 @@ type CreateSecretVaultInput = {
     /** Passkey credential ID as canonical unpadded base64url. */
     credentialId: string;
     /** Authenticator transports reported by the browser, when available. */
-    transports?: PasskeyCredentialTransport[];
+    transports?: AuthenticatorTransport[];
     /** PRF salt for this secret. Must be exactly 32 bytes. */
     prfSalt: Uint8Array;
     /** First WebAuthn PRF output for `prfSalt`. Must be exactly 32 bytes. */
@@ -200,24 +202,29 @@ type CreateSecretVaultInput = {
  * The secret is opaque: no curve, no public key, no length or scalar checks. An AES-256-GCM wrapping key is derived from the PRF output with secret-specific HKDF info, and the secret is encrypted under canonical AAD.
  *
  * @remarks
- * The input byte buffers are copied before async cryptographic work starts; post-call mutation does not change the vault being produced. Caller-owned input buffers are not modified or zeroed.
+ * The input byte buffers are copied before async cryptographic work starts; post-call mutation does not change the vault being produced. The original input buffers are not modified or zeroed.
  *
- * Security: a vault is bound to its `prfOutput` only — not to the credential ID, salt, or nonce (the AAD is a fixed constant). Use a fresh `prfSalt` per secret. Secrets wrapped under one reused PRF output share a wrapping key, so their ciphertexts are interchangeable by anyone who can rewrite stored vault JSON.
+ * A vault is bound to its `prfOutput` only — not to the credential ID, salt, or nonce (the AAD is a fixed constant). Secrets wrapped under one reused PRF output share a wrapping key, so their ciphertexts are interchangeable by anyone who can rewrite stored vault JSON.
  * @param options - Credential material and the secret to wrap.
  * @returns A JSON-safe secret vault.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when the credential ID is empty, the PRF salt or output is not 32 bytes, or `secret` is empty.
+ * @throws PasskeyAccountError with code `INPUT_INVALID` when the credential ID is empty or non-canonical base64url, `credential.transports` contains an unknown WebAuthn transport, the PRF salt or output is not 32 bytes, or `secret` is empty.
  */
 async function createSecretVault({
   credential,
   secret,
 }: CreateSecretVaultInput): Promise<PasskeySecretVault> {
-  const { transports, prfSalt, prfOutput } = credential;
+  const { prfSalt, prfOutput } = credential;
 
   const credentialId = readBase64Url(
     credential.credentialId,
     "credential.credentialId",
     "INPUT_INVALID",
-    { min: 1 },
+    { minByteLength: 1 },
+  );
+  const transports = readAuthenticatorTransports(
+    credential.transports,
+    "credential.transports",
+    "INPUT_INVALID",
   );
 
   if (prfSalt.length !== PRF_SALT_LENGTH) {
@@ -261,7 +268,7 @@ async function createSecretVault({
 
 /** Inputs for decrypting a secret vault. */
 type UnwrapSecretVaultInput = {
-  /** Parsed secret vault. */
+  /** Secret vault. Validated before the PRF salt is used. */
   vault: PasskeySecretVault;
   /** WebAuthn PRF output for the vault's PRF salt. Must be exactly 32 bytes. */
   prfOutput: Uint8Array;
@@ -272,14 +279,23 @@ type UnwrapSecretVaultInput = {
  *
  * @param options - Vault and PRF output.
  * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`.
- * @remarks Side effects: callers should zero the returned buffer when finished.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
+ * @remarks The returned buffer is not zeroed by Mera.
+ * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes.
+ * @throws PasskeyAccountError with code `VAULT_FORMAT_INVALID` when the vault structure or encoded data is invalid.
  * @throws PasskeyAccountError with code `DECRYPT_FAILED` when authentication fails.
  */
 async function unwrapSecretVault({
   vault,
   prfOutput,
 }: UnwrapSecretVaultInput): Promise<Uint8Array> {
+  if (prfOutput.length !== PRF_OUTPUT_LENGTH) {
+    throw new PasskeyAccountError(
+      "INPUT_INVALID",
+      "prfOutput must be 32 bytes",
+    );
+  }
+
+  const parsedVault = parseSecretVault(vault);
   const wrappingKey = await deriveWrappingKey({
     info: SECRET_WRAP_INFO,
     prfOutput,
@@ -287,8 +303,8 @@ async function unwrapSecretVault({
 
   return aesGcmDecrypt({
     encrypted: {
-      nonce: base64UrlDecode(vault.nonce),
-      ciphertext: base64UrlDecode(vault.ciphertext),
+      nonce: base64UrlDecode(parsedVault.nonce),
+      ciphertext: base64UrlDecode(parsedVault.ciphertext),
     },
     wrappingKey,
     aad: SECRET_AAD,
@@ -304,7 +320,7 @@ async function unwrapSecretVault({
  *
  * @param value - Secret vault as JSON text or an untrusted object.
  * @returns A canonicalized secret vault.
- * @throws PasskeyAccountError with code `VAULT_FORMAT_INVALID` when required structure, version, or encoded data is invalid.
+ * @throws PasskeyAccountError with code `VAULT_FORMAT_INVALID` when required structure, version, transport metadata, or encoded data is invalid.
  */
 function parseSecretVault(value: unknown): PasskeySecretVault {
   const vault = typeof value === "string" ? parseJsonVault(value) : value;
@@ -341,43 +357,34 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     vault.credential.credentialId,
     "credential.credentialId",
     "VAULT_FORMAT_INVALID",
-    { min: 1 },
+    { minByteLength: 1 },
   );
 
   const credential: PasskeySecretVault["credential"] = { credentialId };
 
-  if (vault.credential.transports !== undefined) {
-    if (
-      !Array.isArray(vault.credential.transports) ||
-      vault.credential.transports.some(
-        (transport) => typeof transport !== "string",
-      )
-    ) {
-      throw new PasskeyAccountError(
-        "VAULT_FORMAT_INVALID",
-        "credential.transports must be an array of strings or omitted",
-      );
-    }
-    credential.transports = [...vault.credential.transports];
+  const transports = readAuthenticatorTransports(
+    vault.credential.transports,
+    "credential.transports",
+    "VAULT_FORMAT_INVALID",
+  );
+  if (transports !== undefined) {
+    credential.transports = transports;
   }
 
   const prfSalt = readBase64Url(
     vault.prfSalt,
     "prfSalt",
     "VAULT_FORMAT_INVALID",
-    PRF_SALT_LENGTH,
+    { exactByteLength: PRF_SALT_LENGTH },
   );
-  const nonce = readBase64Url(
-    vault.nonce,
-    "nonce",
-    "VAULT_FORMAT_INVALID",
-    NONCE_LENGTH,
-  );
+  const nonce = readBase64Url(vault.nonce, "nonce", "VAULT_FORMAT_INVALID", {
+    exactByteLength: NONCE_LENGTH,
+  });
   const ciphertext = readBase64Url(
     vault.ciphertext,
     "ciphertext",
     "VAULT_FORMAT_INVALID",
-    { min: GCM_TAG_LENGTH },
+    { minByteLength: GCM_TAG_LENGTH },
   );
 
   // Allowlist: only v1 schema fields are copied, so unknown input keys are dropped.
@@ -387,11 +394,12 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
 /**
  * Performs the WebAuthn assertion needed to unlock a secret vault.
  *
- * Reads the credential metadata and PRF salt from a parsed vault; pass JSON through `parseSecretVault` first.
+ * The vault is validated before the WebAuthn assertion starts.
  *
  * @param options - Secret-vault PRF inputs.
  * @returns The selected credential ID and first WebAuthn PRF output.
- * @remarks Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
+ * @remarks Invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
+ * @throws PasskeyAccountError with code `VAULT_FORMAT_INVALID` when the vault structure or encoded data is invalid.
  * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
@@ -403,18 +411,19 @@ async function getSecretVaultPrfOutput({
 }: {
   /** Relying party ID for the WebAuthn assertion. */
   rpId: string;
-  /** Parsed secret vault. */
+  /** Secret vault. Validated before the PRF salt is used. */
   vault: PasskeySecretVault;
   /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
   challenge?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
   timeout?: number;
 }): Promise<PasskeyPrfResult> {
+  const parsedVault = parseSecretVault(vault);
   return getPasskeyPrfOutput({
     rpId,
-    credentialId: vault.credential.credentialId,
-    transports: vault.credential.transports,
-    prfSalt: base64UrlDecode(vault.prfSalt),
+    credentialId: parsedVault.credential.credentialId,
+    transports: parsedVault.credential.transports,
+    prfSalt: base64UrlDecode(parsedVault.prfSalt),
     challenge,
     timeout,
   });

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,11 +1,11 @@
 import { copyBytes } from "./encoding.js";
-import { requireUnlocked } from "./errors.js";
+import { PasskeyAccountError } from "./errors.js";
 
 /**
  * Handle to a session-owned private key whose lifetime is gated by `lock`.
  *
  * Centralizes the key-zeroing lifecycle shared by every signing session: the
- * caller's buffer is consumed (copied into one owned snapshot, then zeroed) on
+ * input buffer is consumed (copied into one owned snapshot, then zeroed) on
  * creation, access throws once locked, and `lock` zeroes the session-owned copy.
  */
 type LockableKey = {
@@ -22,14 +22,14 @@ type LockableKey = {
 /**
  * Consumes a private key into a lockable signing key and derives its public key.
  *
- * The caller's buffer is copied into one owned snapshot, which is used for
- * public-key derivation and signing. The caller's buffer is zeroed before this
+ * The input buffer is copied into one owned snapshot, which is used for
+ * public-key derivation and signing. The input buffer is zeroed before this
  * function returns or throws.
  *
  * @param consumePrivateKey - Private key to consume. Zeroed before this function returns or throws.
  * @param derivePublicKey - Derives the public key from the owned private-key snapshot; a throw doubles as private-key validation.
  * @returns The {@link LockableKey} handle gating access on lock state, paired with the derived public key.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; the owned snapshot is zeroed by `lock()` on success or before rethrowing a validation failure.
+ * @remarks `consumePrivateKey` is zeroed on every path; the owned snapshot is zeroed by `lock()` on success or before rethrowing a validation failure.
  * @throws Rethrows whatever `derivePublicKey` throws, after zeroing the owned snapshot and `consumePrivateKey`.
  */
 function createSigningKey(
@@ -63,6 +63,17 @@ function createSigningKey(
   } finally {
     consumePrivateKey.fill(0);
   }
+}
+
+function requireUnlocked(privateKey: Uint8Array | undefined): Uint8Array {
+  if (privateKey === undefined) {
+    throw new PasskeyAccountError(
+      "SESSION_LOCKED",
+      "Signing session is locked",
+    );
+  }
+
+  return privateKey;
 }
 
 export type { LockableKey };

--- a/src/transports.ts
+++ b/src/transports.ts
@@ -1,0 +1,72 @@
+import { PasskeyAccountError, type PasskeyAccountErrorCode } from "./errors.js";
+
+const AUTHENTICATOR_TRANSPORTS = new Set<string>([
+  "ble",
+  "hybrid",
+  "internal",
+  "nfc",
+  "usb",
+]);
+
+function isAuthenticatorTransport(
+  value: string,
+): value is AuthenticatorTransport {
+  return AUTHENTICATOR_TRANSPORTS.has(value);
+}
+
+/**
+ * Keeps browser-reported transports that match the current WebAuthn type.
+ *
+ * `getTransports()` returns `string[]` so browsers can add names before
+ * TypeScript does. Unknown strings are omitted because transports are only
+ * hints for future assertions.
+ *
+ * @internal
+ */
+function filterKnownAuthenticatorTransports(
+  transports: string[] | undefined,
+): AuthenticatorTransport[] | undefined {
+  if (transports === undefined) {
+    return undefined;
+  }
+
+  const knownTransports = transports.filter(isAuthenticatorTransport);
+  return knownTransports.length > 0 ? knownTransports : undefined;
+}
+
+/**
+ * Reads transport metadata from a public string or JSON boundary.
+ *
+ * @internal
+ */
+function readAuthenticatorTransports(
+  value: unknown,
+  path: string,
+  code: PasskeyAccountErrorCode,
+): AuthenticatorTransport[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new PasskeyAccountError(
+      code,
+      `${path} must be an array of known WebAuthn transport strings or omitted`,
+    );
+  }
+
+  const transports: AuthenticatorTransport[] = [];
+  for (const transport of value) {
+    if (typeof transport !== "string" || !isAuthenticatorTransport(transport)) {
+      throw new PasskeyAccountError(
+        code,
+        `${path} must be an array of known WebAuthn transport strings or omitted`,
+      );
+    }
+    transports.push(transport);
+  }
+
+  return transports;
+}
+
+export { filterKnownAuthenticatorTransports, readAuthenticatorTransports };

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,18 +6,12 @@
  */
 type EvmAddress = `0x${string}`;
 
-/** Supported signing curves. */
-type SigningCurve = "secp256k1" | "ed25519";
-
-/** WebAuthn authenticator transport metadata, including future browser transport values. */
-type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});
-
 /** Metadata needed to ask WebAuthn for a previously created passkey. */
 type PasskeyCredentialMetadata = {
   /** Credential ID encoded as canonical unpadded base64url. */
   credentialId: string;
   /** Authenticator transports reported by the browser, when available. */
-  transports?: PasskeyCredentialTransport[];
+  transports?: AuthenticatorTransport[];
 };
 
 /** Result of a successful passkey assertion with the WebAuthn PRF extension. */
@@ -33,7 +27,7 @@ type CreatePasskeyResult = {
   /** Credential ID encoded as canonical unpadded base64url. */
   credentialId: string;
   /** Authenticator transports reported by the browser, when available. */
-  transports?: PasskeyCredentialTransport[];
+  transports?: AuthenticatorTransport[];
   /** First WebAuthn PRF output when `prfSalt` was provided and evaluated during creation. */
   prfOutput?: Uint8Array;
 };
@@ -41,16 +35,15 @@ type CreatePasskeyResult = {
 /**
  * Result of creating a passkey together with its first PRF output.
  *
- * `prfSalt` is the caller-provided salt WebAuthn evaluated, so downstream
- * helpers (in particular `createSecretVault`) can be invoked with this result
- * alone.
+ * `prfSalt` is the salt WebAuthn evaluated, so downstream helpers (in
+ * particular `createSecretVault`) can be invoked with this result alone.
  */
 type CreatePasskeyWithPrfOutputResult = {
   /** Credential ID encoded as canonical unpadded base64url. */
   credentialId: string;
   /** Authenticator transports reported by the browser, when available. */
-  transports?: PasskeyCredentialTransport[];
-  /** PRF salt that was evaluated. Always 32 bytes and never aliases the caller input. */
+  transports?: AuthenticatorTransport[];
+  /** PRF salt that was evaluated. Always 32 bytes and never aliases the provided input. */
   prfSalt: Uint8Array;
   /** First WebAuthn PRF output for `prfSalt`. Always 32 bytes. */
   prfOutput: Uint8Array;
@@ -59,7 +52,7 @@ type CreatePasskeyWithPrfOutputResult = {
 /**
  * Versioned JSON-safe vault holding one arbitrary secret encrypted behind a passkey.
  *
- * The secret is opaque — no curve and no public key. Callers decide what the bytes mean (a seed phrase's entropy, a backup blob, …).
+ * The secret is opaque: no curve, no public key, and no package-defined meaning.
  */
 type PasskeySecretVault = {
   /** Secret-vault format version. */
@@ -87,7 +80,7 @@ type CreateSigningSessionOptions = {
   /**
    * Curve private key. Must be exactly 32 bytes; secp256k1 must also be a valid scalar.
    *
-   * Copied into one session-owned snapshot, then zeroed before the call returns or throws. Pass a fresh copy if the bytes are needed elsewhere.
+   * Copied into one session-owned snapshot, then zeroed before the call returns or throws.
    */
   consumePrivateKey: Uint8Array;
 };
@@ -101,8 +94,9 @@ type Secp256k1SigningSession = {
    *
    * @param digest32 - Exactly 32 bytes to sign.
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
-   * @remarks Caller assumptions: `digest32` must already be the digest to sign; this method does not hash it.
-   * @remarks `digest32` is copied before use; the original buffer is not modified.
+   * @remarks
+   * `digest32` is copied before use; the original buffer is not modified. This method does not hash `digest32`.
+   *
    * @throws PasskeyAccountError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
    * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
    */
@@ -110,8 +104,8 @@ type Secp256k1SigningSession = {
   /**
    * Clears the active private key and permanently locks this session.
    *
-   * @remarks Side effects: overwrites the session-owned private-key copy with zeros and makes future signing fail.
-   * @remarks If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
+   * @remarks
+   * Overwrites the session-owned private-key copy with zeros and makes future signing fail. If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
    */
   lock(): void;
 };
@@ -125,15 +119,17 @@ type Ed25519SigningSession = {
    *
    * @param message - Message bytes to sign. Hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
-   * @remarks `message` is copied before use; the original buffer is not modified.
+   * @remarks
+   * `message` is copied before use; the original buffer is not modified.
+   *
    * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
    */
   signMessage(message: Uint8Array): Promise<Uint8Array>;
   /**
    * Clears the active private key and permanently locks this session.
    *
-   * @remarks Side effects: overwrites the session-owned seed copy with zeros and makes future signing fail.
-   * @remarks If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
+   * @remarks
+   * Overwrites the session-owned seed copy with zeros and makes future signing fail. If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
    */
   lock(): void;
 };
@@ -145,10 +141,8 @@ export type {
   Ed25519SigningSession,
   EvmAddress,
   PasskeyCredentialMetadata,
-  PasskeyCredentialTransport,
   PasskeyPrfResult,
   PasskeySecretVault,
   Secp256k1Signature,
   Secp256k1SigningSession,
-  SigningCurve,
 };

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -6,7 +6,7 @@ import { PasskeyAccountError } from "./errors.js";
  *
  * @param length - Number of random bytes to return.
  * @returns Cryptographically random bytes.
- * @remarks Side effects: reads from the host Web Crypto CSPRNG.
+ * @remarks Reads from the host Web Crypto CSPRNG.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 function randomBytes(length: number): Uint8Array {
@@ -38,7 +38,7 @@ function getCrypto(): Crypto {
  * @param ikm - Input keying material.
  * @param info - HKDF info/context bytes.
  * @returns A non-extractable AES-GCM `CryptoKey` usable for encryption and decryption.
- * @remarks Caller assumptions: callers choose domain-separated `info` values appropriate for the wrapping key.
+ * @remarks The `info` bytes domain-separate the derived wrapping key.
  * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 async function hkdfSha256AesGcmKey(

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { copyPrfOutput, createPasskeyWithPrfOutput } from "../dist/passkey.js";
+import {
+  copyPrfOutput,
+  createPasskeyWithPrfOutput,
+  getPasskeyPrfOutput,
+} from "../dist/passkey.js";
 import { expectError } from "./helpers.js";
 
 const ORIGINAL_NAVIGATOR = Object.getOwnPropertyDescriptor(
@@ -55,6 +59,65 @@ test("copyPrfOutput rejects non-byte array values instead of coercing them", () 
   expectError(() => copyPrfOutput([Number.NaN]), "PRF_UNAVAILABLE");
 });
 
+test("getPasskeyPrfOutput rejects an empty credential id", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      credentials: {
+        async get() {
+          throw new Error("credential assertion should not start");
+        },
+      },
+    },
+  });
+
+  try {
+    await expect(
+      getPasskeyPrfOutput({
+        rpId: "example.com",
+        credentialId: "",
+        prfSalt: new Uint8Array(32),
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  } finally {
+    if (ORIGINAL_NAVIGATOR) {
+      Object.defineProperty(globalThis, "navigator", ORIGINAL_NAVIGATOR);
+    } else {
+      Reflect.deleteProperty(globalThis, "navigator");
+    }
+  }
+});
+
+test("getPasskeyPrfOutput rejects unknown transports before WebAuthn", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      credentials: {
+        async get() {
+          throw new Error("credential assertion should not start");
+        },
+      },
+    },
+  });
+
+  try {
+    await expect(
+      getPasskeyPrfOutput({
+        rpId: "example.com",
+        credentialId: "AQIDBA",
+        transports: ["future" as unknown as AuthenticatorTransport],
+        prfSalt: new Uint8Array(32),
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  } finally {
+    if (ORIGINAL_NAVIGATOR) {
+      Object.defineProperty(globalThis, "navigator", ORIGINAL_NAVIGATOR);
+    } else {
+      Reflect.deleteProperty(globalThis, "navigator");
+    }
+  }
+});
+
 test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", async () => {
   const originalSalt = Uint8Array.from({ length: 32 }, (_, index) => index);
   const prfSalt = new Uint8Array(originalSalt);
@@ -70,7 +133,7 @@ test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", asy
             type: "public-key",
             rawId: new Uint8Array([1, 2, 3, 4]).buffer,
             response: {
-              getTransports: () => ["internal"],
+              getTransports: () => ["future", "internal"],
             },
             getClientExtensionResults: () => ({ prf: { enabled: true } }),
           };
@@ -109,6 +172,7 @@ test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", asy
 
     const result = await pending;
 
+    expect(result.transports).toEqual(["internal"]);
     expect(result.prfSalt).toEqual(originalSalt);
     expect(result.prfOutput).toEqual(originalSalt);
     expect(fallbackSalt).toEqual(originalSalt);

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -2,6 +2,7 @@ import { utf8ToBytes } from "@noble/hashes/utils.js";
 import { expect, test } from "@playwright/test";
 import {
   createSecretVault,
+  getSecretVaultPrfOutput,
   type PasskeySecretVault,
   parseSecretVault,
   unwrapSecretVault,
@@ -71,12 +72,48 @@ test("createSecretVault snapshots caller-owned byte inputs before async work", a
   ).resolves.toEqual(SECRET);
 });
 
+test("createSecretVault rejects unknown transports", async () => {
+  await expect(
+    createSecretVault({
+      credential: {
+        credentialId: "AQIDBA",
+        transports: ["future" as unknown as AuthenticatorTransport],
+        prfSalt: PRF_SALT,
+        prfOutput: PRF_OUTPUT,
+      },
+      secret: SECRET,
+    }),
+  ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+});
+
 test("unwrapSecretVault fails with the wrong PRF output", async () => {
   const vault = await createTestVault();
 
   await expect(
     unwrapSecretVault({ vault, prfOutput: new Uint8Array(32).fill(1) }),
   ).rejects.toMatchObject({ code: "DECRYPT_FAILED" });
+});
+
+test("unwrapSecretVault validates vault structure before decrypting", async () => {
+  const vault = await createTestVault();
+
+  await expect(
+    unwrapSecretVault({
+      vault: { ...vault, nonce: "AQ" },
+      prfOutput: PRF_OUTPUT,
+    }),
+  ).rejects.toMatchObject({ code: "VAULT_FORMAT_INVALID" });
+});
+
+test("getSecretVaultPrfOutput validates vault structure before WebAuthn", async () => {
+  const vault = await createTestVault();
+
+  await expect(
+    getSecretVaultPrfOutput({
+      rpId: "example.com",
+      vault: { ...vault, prfSalt: "AQ" },
+    }),
+  ).rejects.toMatchObject({ code: "VAULT_FORMAT_INVALID" });
 });
 
 test("secret vault AAD is independent of credential metadata and PRF salt", async () => {
@@ -169,7 +206,7 @@ test("parseSecretVault rejects a missing or non-object credential", async () => 
   );
 });
 
-test("parseSecretVault rejects non-string transports", async () => {
+test("parseSecretVault rejects invalid transports", async () => {
   const vault = await createTestVault();
 
   expectError(
@@ -177,6 +214,14 @@ test("parseSecretVault rejects non-string transports", async () => {
       parseSecretVault({
         ...vault,
         credential: { ...vault.credential, transports: ["internal", 42] },
+      }),
+    "VAULT_FORMAT_INVALID",
+  );
+  expectError(
+    () =>
+      parseSecretVault({
+        ...vault,
+        credential: { ...vault.credential, transports: ["future"] },
       }),
     "VAULT_FORMAT_INVALID",
   );


### PR DESCRIPTION
## Summary

This prepares Mera for release by aligning the library with its finalized project guidelines: simpler public APIs, tighter boundary validation, concise docs, and clean examples.

## Motivation

The library was written before the guidelines were finalized. This pass removes extra abstraction, makes public behavior easier to predict from types and function names, and keeps runtime validation focused on boundaries TypeScript cannot protect.

## Changes

- Fixed passkey credential restriction so an empty credential ID is rejected instead of widening the WebAuthn assertion.
- Revalidates secret vault objects before unwrap and PRF lookup, so public structural types are not trusted blindly.
- Narrows passkey transport metadata to WebAuthn's `AuthenticatorTransport[]` and validates unknown strings at browser, public input, and JSON boundaries.
- Reworked README examples to be runnable and focused on Mera behavior.
- Trimmed wordy JSDoc and docs drift to match the finalized style.
- Simplified exports and internals by removing thin or unused public surface.
- Updated Biome config and fixed warnings, including demo browser polyfill handling and CSS selector order.
- Added tests for credential restriction, vault validation, transport handling, and caller-owned buffer snapshots.

## Validation

- `npm run check`
- `npm run build`
- `npx playwright test test/passkey.test.ts test/secret.test.ts`
- `npm test`
- `npm --cache /private/tmp/mera-npm-cache run check:pack`
- `git diff --check`
