### PR TITLE
Rename PasskeyAccountError to MeraError

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 - Public SDK functions should have complete, accurate JSDoc.
 - Use appropriate JSDoc tags to describe the API contract, return behavior, caller assumptions, observable side effects, and failure modes.
 - Document security-sensitive behavior explicitly, especially for key material, randomness, WebAuthn prompts, encryption nonces, storage formats, and mutation/zeroing behavior.
-- Document thrown `PasskeyAccountError` codes with the appropriate JSDoc tag.
+- Document thrown `MeraError` codes with the appropriate JSDoc tag.
 - Examples should be runnable, concise, and focused on library behavior, not on provider boilerplate.
 - README examples should reflect actual tested behavior.
 - Keep documentation prose neutral: name keys, secrets, and passkeys plainly ("the passkey", "one encrypted secret") rather than attributing them to the reader ("your passkey", "a secret you provide" / "you own").

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Names only — your editor's hover surfaces the full JSDoc.
 - **Signing sessions** — `createSecp256k1SigningSession`, `createEd25519SigningSession`
 - **Secret vault** — `createSecretVault`, `unwrapSecretVault`, `parseSecretVault`, `getSecretVaultPrfOutput`
 - **Chain addresses** — `getEvmAddress`, `isEvmAddress`, `getSolanaAddress`, `isSolanaAddress`
-- **Errors** — `PasskeyAccountError`, `isPasskeyAccountError`, `PasskeyAccountErrorCode`
+- **Errors** — `MeraError`, `isMeraError`, `MeraErrorCode`
 
 ## Detailed docs
 

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -10,7 +10,7 @@ import {
   getPasskeyPrfOutput,
   getSecretVaultPrfOutput,
   getSolanaAddress,
-  isPasskeyAccountError,
+  isMeraError,
   parseSecretVault,
   type Secp256k1SigningSession,
   unwrapSecretVault,
@@ -357,7 +357,7 @@ async function revealMnemonic(wallet: ConnectedWallet): Promise<string> {
 
 /** Turns library and chain errors into short, friendly status text. */
 function describeError(error: unknown): string {
-  if (isPasskeyAccountError(error)) {
+  if (isMeraError(error)) {
     switch (error.code) {
       case "PRF_UNAVAILABLE":
         return "This browser or authenticator doesn't support the WebAuthn PRF extension this demo needs.";

--- a/src/chains/evm.ts
+++ b/src/chains/evm.ts
@@ -10,7 +10,7 @@ import type { EvmAddress } from "../types.js";
  *
  * @param publicKey - A compressed or uncompressed secp256k1 public key.
  * @returns The EIP-55 mixed-case checksummed EVM address.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `publicKey` is not valid secp256k1.
+ * @throws MeraError with code `INPUT_INVALID` when `publicKey` is not valid secp256k1.
  */
 function getEvmAddress(publicKey: Uint8Array): EvmAddress {
   const uncompressed = normalizeSecp256k1PublicKey(publicKey);

--- a/src/chains/solana.ts
+++ b/src/chains/solana.ts
@@ -1,5 +1,5 @@
 import { base58 } from "@scure/base";
-import { PasskeyAccountError } from "../errors.js";
+import { MeraError } from "../errors.js";
 
 const ED25519_PUBLIC_KEY_LENGTH = 32;
 
@@ -8,14 +8,11 @@ const ED25519_PUBLIC_KEY_LENGTH = 32;
  *
  * @param publicKey - A 32-byte Ed25519 public key.
  * @returns The base58-encoded Solana address.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `publicKey` is not 32 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when `publicKey` is not 32 bytes.
  */
 function getSolanaAddress(publicKey: Uint8Array): string {
   if (publicKey.length !== ED25519_PUBLIC_KEY_LENGTH) {
-    throw new PasskeyAccountError(
-      "INPUT_INVALID",
-      "Ed25519 public key must be 32 bytes",
-    );
+    throw new MeraError("INPUT_INVALID", "Ed25519 public key must be 32 bytes");
   }
 
   return base58.encode(publicKey);

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -1,7 +1,7 @@
 import * as ed25519 from "@noble/ed25519";
 import { sha512 } from "@noble/hashes/sha2.js";
 import { copyBytes } from "./encoding.js";
-import { PasskeyAccountError } from "./errors.js";
+import { MeraError } from "./errors.js";
 import { createSigningKey } from "./session.js";
 import type {
   CreateSigningSessionOptions,
@@ -14,11 +14,11 @@ import type {
  * @internal
  * @param privateKey - A 32-byte Ed25519 seed.
  * @returns The 32-byte Ed25519 public key.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
  */
 function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
   if (privateKey.length !== 32) {
-    throw new PasskeyAccountError(
+    throw new MeraError(
       "INPUT_INVALID",
       "Ed25519 private key must be 32 bytes",
     );
@@ -39,7 +39,7 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
  * @param options.consumePrivateKey - Ed25519 seed. Must be 32 bytes. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked Ed25519 signing session.
  * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not 32 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when `consumePrivateKey` is not 32 bytes.
  */
 function createEd25519SigningSession({
   consumePrivateKey,

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,6 +1,6 @@
 import { concatBytes, utf8ToBytes } from "@noble/hashes/utils.js";
 import { base64urlnopad } from "@scure/base";
-import { PasskeyAccountError } from "./errors.js";
+import { MeraError } from "./errors.js";
 
 /**
  * Copies bytes into a standalone `Uint8Array`.
@@ -41,13 +41,13 @@ function base64UrlEncode(value: Uint8Array): string {
  *
  * @param value - Canonical unpadded base64url text.
  * @returns Decoded bytes.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `value` uses invalid characters, invalid length, or non-canonical padding.
+ * @throws MeraError with code `INPUT_INVALID` when `value` uses invalid characters, invalid length, or non-canonical padding.
  */
 function base64UrlDecode(value: string): Uint8Array {
   try {
     return base64urlnopad.decode(value);
   } catch (cause) {
-    throw new PasskeyAccountError("INPUT_INVALID", "value must be base64url", {
+    throw new MeraError("INPUT_INVALID", "value must be base64url", {
       cause,
     });
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,7 +8,7 @@
  * - `INPUT_INVALID`: a caller-supplied value at a public boundary did not satisfy a length, range, encoding, or scalar constraint.
  * - `VAULT_FORMAT_INVALID`: untrusted vault data (JSON or object) was malformed, missing required fields, or used a non-canonical encoding.
  */
-type PasskeyAccountErrorCode =
+type MeraErrorCode =
   | "PASSKEY_OPERATION_FAILED"
   | "PRF_UNAVAILABLE"
   | "SESSION_LOCKED"
@@ -17,9 +17,9 @@ type PasskeyAccountErrorCode =
   | "VAULT_FORMAT_INVALID";
 
 /** Error type thrown by this package with a stable coarse-grained code. */
-class PasskeyAccountError extends Error {
+class MeraError extends Error {
   /** Machine-readable category for the failure. */
-  readonly code: PasskeyAccountErrorCode;
+  readonly code: MeraErrorCode;
 
   /**
    * Creates a package error with a stable error code.
@@ -30,24 +30,24 @@ class PasskeyAccountError extends Error {
    * @param options.cause - Original cause for this error, when available.
    */
   constructor(
-    code: PasskeyAccountErrorCode,
+    code: MeraErrorCode,
     message: string,
     options?: { cause?: unknown },
   ) {
     super(message, options);
-    this.name = "PasskeyAccountError";
+    this.name = "MeraError";
     this.code = code;
   }
 }
 
 /**
- * Returns true when an unknown error is a `PasskeyAccountError`.
+ * Returns true when an unknown error is a `MeraError`.
  *
  * @param error - Value to check.
- * @returns `true` when `error` is a `PasskeyAccountError`.
+ * @returns `true` when `error` is a `MeraError`.
  */
-function isPasskeyAccountError(error: unknown): error is PasskeyAccountError {
-  return error instanceof PasskeyAccountError;
+function isMeraError(error: unknown): error is MeraError {
+  return error instanceof MeraError;
 }
 
 /**
@@ -55,18 +55,15 @@ function isPasskeyAccountError(error: unknown): error is PasskeyAccountError {
  * session has been locked. Used by curve-specific session helpers to gate
  * `signDigest`/`signMessage` after `lock()`.
  *
- * @throws PasskeyAccountError with code `SESSION_LOCKED` when `privateKey` is undefined.
+ * @throws MeraError with code `SESSION_LOCKED` when `privateKey` is undefined.
  */
 function requireUnlocked(privateKey: Uint8Array | undefined): Uint8Array {
   if (privateKey === undefined) {
-    throw new PasskeyAccountError(
-      "SESSION_LOCKED",
-      "Signing session is locked",
-    );
+    throw new MeraError("SESSION_LOCKED", "Signing session is locked");
   }
 
   return privateKey;
 }
 
-export type { PasskeyAccountErrorCode };
-export { isPasskeyAccountError, PasskeyAccountError, requireUnlocked };
+export type { MeraErrorCode };
+export { isMeraError, MeraError, requireUnlocked };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ export { getEvmAddress, isEvmAddress } from "./chains/evm.js";
 export { getSolanaAddress, isSolanaAddress } from "./chains/solana.js";
 export { createDeterministicPrfSalt } from "./derived.js";
 export { createEd25519SigningSession } from "./ed25519.js";
-export type { PasskeyAccountErrorCode } from "./errors.js";
-export { isPasskeyAccountError, PasskeyAccountError } from "./errors.js";
+export type { MeraErrorCode } from "./errors.js";
+export { isMeraError, MeraError } from "./errors.js";
 export type {
   CreatePasskeyOptions,
   CreatePasskeyWithPrfOutputOptions,

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -4,7 +4,7 @@ import {
   base64UrlEncode,
   copyBytes,
 } from "./encoding.js";
-import { isPasskeyAccountError, PasskeyAccountError } from "./errors.js";
+import { isMeraError, MeraError } from "./errors.js";
 import type {
   CreatePasskeyResult,
   CreatePasskeyWithPrfOutputResult,
@@ -104,9 +104,9 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * @returns Credential metadata and, when `prfSalt` was provided and the authenticator supports it, the first PRF output.
  * @remarks Side effects: invokes `navigator.credentials.create()`, which may show browser or authenticator UI and create a discoverable passkey.
  * @remarks Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
- * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF.
+ * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function createPasskey({
   rp,
@@ -120,17 +120,11 @@ async function createPasskey({
     assertCredentialApiAvailable();
 
     if (prfSalt !== undefined && prfSalt.length !== 32) {
-      throw new PasskeyAccountError(
-        "INPUT_INVALID",
-        "PRF salt must be 32 bytes",
-      );
+      throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
     }
 
     if (user.id !== undefined && (user.id.length < 1 || user.id.length > 64)) {
-      throw new PasskeyAccountError(
-        "INPUT_INVALID",
-        "user.id must be 1 to 64 bytes",
-      );
+      throw new MeraError("INPUT_INVALID", "user.id must be 1 to 64 bytes");
     }
 
     const prfExtension =
@@ -166,7 +160,7 @@ async function createPasskey({
     const prf = publicKeyCredential.getClientExtensionResults().prf;
 
     if (!prf?.enabled) {
-      throw new PasskeyAccountError(
+      throw new MeraError(
         "PRF_UNAVAILABLE",
         "Authenticator did not enable PRF",
       );
@@ -190,25 +184,20 @@ async function createPasskey({
     if (prfSalt !== undefined && prf.results?.first) {
       const prfOutput = copyPrfOutput(prf.results.first);
       if (prfOutput.length !== 32) {
-        throw new PasskeyAccountError(
-          "PRF_UNAVAILABLE",
-          "PRF output must be 32 bytes",
-        );
+        throw new MeraError("PRF_UNAVAILABLE", "PRF output must be 32 bytes");
       }
       result.prfOutput = prfOutput;
     }
 
     return result;
   } catch (error) {
-    if (isPasskeyAccountError(error)) {
+    if (isMeraError(error)) {
       throw error;
     }
 
-    throw new PasskeyAccountError(
-      "PASSKEY_OPERATION_FAILED",
-      "Passkey creation failed",
-      { cause: error },
-    );
+    throw new MeraError("PASSKEY_OPERATION_FAILED", "Passkey creation failed", {
+      cause: error,
+    });
   }
 }
 
@@ -229,9 +218,9 @@ async function createPasskey({
  * Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
  *
  * Caller assumptions: `prfSalt` must be stable for flows that need stable PRF output.
- * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes or `credentialId` is not canonical base64url.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
+ * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes or `credentialId` is not canonical base64url.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function getPasskeyPrfOutput({
   rpId,
@@ -245,10 +234,7 @@ async function getPasskeyPrfOutput({
     assertCredentialApiAvailable();
 
     if (prfSalt.length !== 32) {
-      throw new PasskeyAccountError(
-        "INPUT_INVALID",
-        "PRF salt must be 32 bytes",
-      );
+      throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
     }
 
     const prf = { eval: { first: asArrayBuffer(prfSalt) } };
@@ -277,7 +263,7 @@ async function getPasskeyPrfOutput({
       publicKeyCredential.getClientExtensionResults().prf?.results?.first;
 
     if (!first) {
-      throw new PasskeyAccountError(
+      throw new MeraError(
         "PRF_UNAVAILABLE",
         "Authenticator did not return PRF output",
       );
@@ -285,10 +271,7 @@ async function getPasskeyPrfOutput({
 
     const prfOutput = copyPrfOutput(first);
     if (prfOutput.length !== 32) {
-      throw new PasskeyAccountError(
-        "PRF_UNAVAILABLE",
-        "PRF output must be 32 bytes",
-      );
+      throw new MeraError("PRF_UNAVAILABLE", "PRF output must be 32 bytes");
     }
 
     return {
@@ -296,11 +279,11 @@ async function getPasskeyPrfOutput({
       prfOutput,
     };
   } catch (error) {
-    if (isPasskeyAccountError(error)) {
+    if (isMeraError(error)) {
       throw error;
     }
 
-    throw new PasskeyAccountError(
+    throw new MeraError(
       "PASSKEY_OPERATION_FAILED",
       "Passkey assertion failed",
       { cause: error },
@@ -321,9 +304,9 @@ async function getPasskeyPrfOutput({
  * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of the input does not change the fallback ceremony or returned salt.
  *
  * Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
- * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or does not return PRF output on the fallback ceremony.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or does not return PRF output on the fallback ceremony.
+ * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function createPasskeyWithPrfOutput({
   rp,
@@ -372,14 +355,11 @@ async function createPasskeyWithPrfOutput({
 /**
  * Asserts that the WebAuthn credential API is available.
  *
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable.
  */
 function assertCredentialApiAvailable(): void {
   if (!globalThis.navigator?.credentials) {
-    throw new PasskeyAccountError(
-      "PASSKEY_OPERATION_FAILED",
-      "WebAuthn is unavailable",
-    );
+    throw new MeraError("PASSKEY_OPERATION_FAILED", "WebAuthn is unavailable");
   }
 }
 
@@ -388,13 +368,13 @@ function assertCredentialApiAvailable(): void {
  *
  * @param credential - Credential returned by WebAuthn.
  * @returns The credential narrowed to the PRF-aware public-key credential shape.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn returned no usable public-key credential.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn returned no usable public-key credential.
  */
 function assertPublicKeyCredential(
   credential: Credential | null,
 ): PublicKeyCredentialWithPrf {
   if (credential?.type !== "public-key" || !("rawId" in credential)) {
-    throw new PasskeyAccountError(
+    throw new MeraError(
       "PASSKEY_OPERATION_FAILED",
       "WebAuthn returned no public key credential",
     );
@@ -403,7 +383,7 @@ function assertPublicKeyCredential(
   const publicKeyCredential = credential as PublicKeyCredentialWithPrf;
 
   if (typeof publicKeyCredential.getClientExtensionResults !== "function") {
-    throw new PasskeyAccountError(
+    throw new MeraError(
       "PASSKEY_OPERATION_FAILED",
       "WebAuthn extension results are unavailable",
     );
@@ -425,7 +405,7 @@ function assertPublicKeyCredential(
  * bare `Uint8Array.from(value)` would instead silently coerce malformed values
  * (mod 256, `NaN` -> 0) into HKDF key material.
  *
- * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when a plain array-like
+ * @throws MeraError with code `PRF_UNAVAILABLE` when a plain array-like
  * contains a value that is not an integer in [0, 255].
  * @internal
  */
@@ -445,7 +425,7 @@ function copyPrfOutput(value: BufferSource | ArrayLike<number>): Uint8Array {
   // instead of being silently coerced (mod 256, NaN -> 0) into key material.
   return Uint8Array.from(value, (byte) => {
     if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
-      throw new PasskeyAccountError(
+      throw new MeraError(
         "PRF_UNAVAILABLE",
         "PRF output must contain only byte values (integers 0-255)",
       );

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -1,6 +1,6 @@
 import * as secp from "@noble/secp256k1";
 import { copyBytes } from "./encoding.js";
-import { PasskeyAccountError } from "./errors.js";
+import { MeraError } from "./errors.js";
 import { createSigningKey } from "./session.js";
 import type {
   CreateSigningSessionOptions,
@@ -15,13 +15,13 @@ import type {
  * @param privateKey - A 32-byte secp256k1 private key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
  * @remarks Caller assumptions: the private key must be secret key material; the function does not clear or mutate the input.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
+ * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
  */
 function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
   try {
     return new Uint8Array(secp.getPublicKey(privateKey, false));
   } catch (cause) {
-    throw new PasskeyAccountError(
+    throw new MeraError(
       "INPUT_INVALID",
       "Private key is not a valid secp256k1 scalar",
       { cause },
@@ -35,17 +35,15 @@ function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
  * @internal
  * @param publicKey - A compressed or uncompressed secp256k1 public key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when the key length, prefix, or curve point is invalid.
+ * @throws MeraError with code `INPUT_INVALID` when the key length, prefix, or curve point is invalid.
  */
 function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
   try {
     return new Uint8Array(secp.Point.fromBytes(publicKey).toBytes(false));
   } catch (cause) {
-    throw new PasskeyAccountError(
-      "INPUT_INVALID",
-      "Public key is not valid secp256k1",
-      { cause },
-    );
+    throw new MeraError("INPUT_INVALID", "Public key is not valid secp256k1", {
+      cause,
+    });
   }
 }
 
@@ -58,7 +56,7 @@ function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
  * @param options.consumePrivateKey - secp256k1 private key. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked secp256k1 signing session.
  * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.
+ * @throws MeraError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.
  */
 function createSecp256k1SigningSession({
   consumePrivateKey,
@@ -72,10 +70,7 @@ function createSecp256k1SigningSession({
     publicKey,
     async signDigest(digest32: Uint8Array): Promise<Secp256k1Signature> {
       if (digest32.length !== 32) {
-        throw new PasskeyAccountError(
-          "INPUT_INVALID",
-          "Digest must be 32 bytes",
-        );
+        throw new MeraError("INPUT_INVALID", "Digest must be 32 bytes");
       }
 
       // Signing reads the buffer after an await; copy it now so a later mutation can't change the signed bytes.

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -7,7 +7,7 @@ import {
   uint32Be,
   utf8ToBytes,
 } from "./encoding.js";
-import { PasskeyAccountError, type PasskeyAccountErrorCode } from "./errors.js";
+import { MeraError, type MeraErrorCode } from "./errors.js";
 import { getPasskeyPrfOutput } from "./passkey.js";
 import type {
   PasskeyCredentialTransport,
@@ -52,10 +52,7 @@ async function deriveWrappingKey({
   info: Uint8Array;
 }): Promise<CryptoKey> {
   if (prfOutput.length !== PRF_OUTPUT_LENGTH) {
-    throw new PasskeyAccountError(
-      "INPUT_INVALID",
-      "prfOutput must be 32 bytes",
-    );
+    throw new MeraError("INPUT_INVALID", "prfOutput must be 32 bytes");
   }
 
   return hkdfSha256AesGcmKey(prfOutput, info);
@@ -114,11 +111,9 @@ async function aesGcmDecrypt({
     );
     return new Uint8Array(plaintext);
   } catch (error) {
-    throw new PasskeyAccountError(
-      "DECRYPT_FAILED",
-      "Unable to decrypt ciphertext",
-      { cause: error },
-    );
+    throw new MeraError("DECRYPT_FAILED", "Unable to decrypt ciphertext", {
+      cause: error,
+    });
   }
 }
 
@@ -126,42 +121,37 @@ function parseJsonVault(value: string): unknown {
   try {
     return JSON.parse(value);
   } catch (error) {
-    throw new PasskeyAccountError(
-      "VAULT_FORMAT_INVALID",
-      "Vault JSON is invalid",
-      { cause: error },
-    );
+    throw new MeraError("VAULT_FORMAT_INVALID", "Vault JSON is invalid", {
+      cause: error,
+    });
   }
 }
 
 function readBase64Url(
   value: unknown,
   name: string,
-  errorCode: PasskeyAccountErrorCode,
+  errorCode: MeraErrorCode,
   byteLength?: number | { min: number },
 ): string {
   if (typeof value !== "string") {
-    throw new PasskeyAccountError(errorCode, `${name} must be base64url`);
+    throw new MeraError(errorCode, `${name} must be base64url`);
   }
 
   let bytes: Uint8Array;
   try {
     bytes = base64UrlDecode(value);
   } catch (cause) {
-    throw new PasskeyAccountError(errorCode, `${name} must be base64url`, {
+    throw new MeraError(errorCode, `${name} must be base64url`, {
       cause,
     });
   }
 
   if (typeof byteLength === "number" && bytes.length !== byteLength) {
-    throw new PasskeyAccountError(
-      errorCode,
-      `${name} must be ${byteLength} bytes`,
-    );
+    throw new MeraError(errorCode, `${name} must be ${byteLength} bytes`);
   }
 
   if (typeof byteLength === "object" && bytes.length < byteLength.min) {
-    throw new PasskeyAccountError(
+    throw new MeraError(
       errorCode,
       `${name} must be at least ${byteLength.min} bytes`,
     );
@@ -205,7 +195,7 @@ type CreateSecretVaultInput = {
  * Security: a vault is bound to its `prfOutput` only — not to the credential ID, salt, or nonce (the AAD is a fixed constant). Use a fresh `prfSalt` per secret. Secrets wrapped under one reused PRF output share a wrapping key, so their ciphertexts are interchangeable by anyone who can rewrite stored vault JSON.
  * @param options - Credential material and the secret to wrap.
  * @returns A JSON-safe secret vault.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when the credential ID is empty, the PRF salt or output is not 32 bytes, or `secret` is empty.
+ * @throws MeraError with code `INPUT_INVALID` when the credential ID is empty, the PRF salt or output is not 32 bytes, or `secret` is empty.
  */
 async function createSecretVault({
   credential,
@@ -221,11 +211,11 @@ async function createSecretVault({
   );
 
   if (prfSalt.length !== PRF_SALT_LENGTH) {
-    throw new PasskeyAccountError("INPUT_INVALID", "PRF salt must be 32 bytes");
+    throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
   }
 
   if (secret.length === 0) {
-    throw new PasskeyAccountError("INPUT_INVALID", "secret must not be empty");
+    throw new MeraError("INPUT_INVALID", "secret must not be empty");
   }
 
   const prfSaltCopy = copyBytes(prfSalt);
@@ -273,8 +263,8 @@ type UnwrapSecretVaultInput = {
  * @param options - Vault and PRF output.
  * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`.
  * @remarks Side effects: callers should zero the returned buffer when finished.
- * @throws PasskeyAccountError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
- * @throws PasskeyAccountError with code `DECRYPT_FAILED` when authentication fails.
+ * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
+ * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
  */
 async function unwrapSecretVault({
   vault,
@@ -304,34 +294,25 @@ async function unwrapSecretVault({
  *
  * @param value - Secret vault as JSON text or an untrusted object.
  * @returns A canonicalized secret vault.
- * @throws PasskeyAccountError with code `VAULT_FORMAT_INVALID` when required structure, version, or encoded data is invalid.
+ * @throws MeraError with code `VAULT_FORMAT_INVALID` when required structure, version, or encoded data is invalid.
  */
 function parseSecretVault(value: unknown): PasskeySecretVault {
   const vault = typeof value === "string" ? parseJsonVault(value) : value;
 
   if (!isRecord(vault)) {
-    throw new PasskeyAccountError(
-      "VAULT_FORMAT_INVALID",
-      "Vault must be an object",
-    );
+    throw new MeraError("VAULT_FORMAT_INVALID", "Vault must be an object");
   }
 
   if (!("version" in vault)) {
-    throw new PasskeyAccountError(
-      "VAULT_FORMAT_INVALID",
-      "Vault version is required",
-    );
+    throw new MeraError("VAULT_FORMAT_INVALID", "Vault version is required");
   }
 
   if (vault.version !== 1) {
-    throw new PasskeyAccountError(
-      "VAULT_FORMAT_INVALID",
-      "Vault version must be 1",
-    );
+    throw new MeraError("VAULT_FORMAT_INVALID", "Vault version must be 1");
   }
 
   if (!isRecord(vault.credential)) {
-    throw new PasskeyAccountError(
+    throw new MeraError(
       "VAULT_FORMAT_INVALID",
       "Vault credential must be an object",
     );
@@ -353,7 +334,7 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
         (transport) => typeof transport !== "string",
       )
     ) {
-      throw new PasskeyAccountError(
+      throw new MeraError(
         "VAULT_FORMAT_INVALID",
         "credential.transports must be an array of strings or omitted",
       );
@@ -392,8 +373,8 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
  * @param options - Secret-vault PRF inputs.
  * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
- * @throws PasskeyAccountError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function getSecretVaultPrfOutput({
   rpId,

--- a/src/session.ts
+++ b/src/session.ts
@@ -12,7 +12,7 @@ type LockableKey = {
   /**
    * Returns the live session-owned key for immediate use.
    *
-   * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
+   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
   use(): Uint8Array;
   /** Zeroes the session-owned key and permanently locks this handle. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,8 +103,8 @@ type Secp256k1SigningSession = {
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
    * @remarks Caller assumptions: `digest32` must already be the digest to sign; this method does not hash it.
    * @remarks `digest32` is copied before use; the original buffer is not modified.
-   * @throws PasskeyAccountError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
-   * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
+   * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
+   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
   signDigest(digest32: Uint8Array): Promise<Secp256k1Signature>;
   /**
@@ -126,7 +126,7 @@ type Ed25519SigningSession = {
    * @param message - Message bytes to sign. Hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
    * @remarks `message` is copied before use; the original buffer is not modified.
-   * @throws PasskeyAccountError with code `SESSION_LOCKED` after `lock` has been called.
+   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
   signMessage(message: Uint8Array): Promise<Uint8Array>;
   /**

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -1,5 +1,5 @@
 import { asArrayBuffer } from "./encoding.js";
-import { PasskeyAccountError } from "./errors.js";
+import { MeraError } from "./errors.js";
 
 /**
  * Returns cryptographically random bytes from Web Crypto.
@@ -7,7 +7,7 @@ import { PasskeyAccountError } from "./errors.js";
  * @param length - Number of random bytes to return.
  * @returns Cryptographically random bytes.
  * @remarks Side effects: reads from the host Web Crypto CSPRNG.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 function randomBytes(length: number): Uint8Array {
   const output = new Uint8Array(length);
@@ -19,11 +19,11 @@ function randomBytes(length: number): Uint8Array {
  * Returns the host Web Crypto implementation.
  *
  * @returns `globalThis.crypto` when Web Crypto is available.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 function getCrypto(): Crypto {
   if (!globalThis.crypto?.subtle || !globalThis.crypto.getRandomValues) {
-    throw new PasskeyAccountError(
+    throw new MeraError(
       "PASSKEY_OPERATION_FAILED",
       "Web Crypto is unavailable",
     );
@@ -39,7 +39,7 @@ function getCrypto(): Crypto {
  * @param info - HKDF info/context bytes.
  * @returns A non-extractable AES-GCM `CryptoKey` usable for encryption and decryption.
  * @remarks Caller assumptions: callers choose domain-separated `info` values appropriate for the wrapping key.
- * @throws PasskeyAccountError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 async function hkdfSha256AesGcmKey(
   ikm: Uint8Array,


### PR DESCRIPTION
Pre-release naming fix from the simplification review: the error class named an "account" abstraction that no longer exists anywhere in the API, and helpers like `getSolanaAddress` throwing a *PasskeyAccount*Error was unpredictable from the name. `MeraError` matches the package identity, and the error class is the package's permanent error boundary — renaming it later would be breaking.

- Mechanical rename: `PasskeyAccountError` → `MeraError`, `isPasskeyAccountError` → `isMeraError`, `PasskeyAccountErrorCode` → `MeraErrorCode` (incl. `error.name`), across src, README, AGENTS.md, and the demo.
- Biome reflow of the now-shorter `throw` statements; no behavior change.

Tests: `npm run check` and the full Playwright suite pass (51/51).

**Stack 1/16** — this series splits the pre-release simplification pass into small reviewable PRs; merge in order (each PR is based on the previous one and retargets automatically when its base merges).