### PR TITLE
Relocate single-caller helpers and collapse redundant checks

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -50,20 +50,5 @@ function isMeraError(error: unknown): error is MeraError {
   return error instanceof MeraError;
 }
 
-/**
- * Returns the active private key for a signing session, or throws if the
- * session has been locked. Used by curve-specific session helpers to gate
- * `signDigest`/`signMessage` after `lock()`.
- *
- * @throws MeraError with code `SESSION_LOCKED` when `privateKey` is undefined.
- */
-function requireUnlocked(privateKey: Uint8Array | undefined): Uint8Array {
-  if (privateKey === undefined) {
-    throw new MeraError("SESSION_LOCKED", "Signing session is locked");
-  }
-
-  return privateKey;
-}
-
 export type { MeraErrorCode };
-export { isMeraError, MeraError, requireUnlocked };
+export { isMeraError, MeraError };

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -54,18 +54,14 @@ type EncryptedBytes = {
   ciphertext: Uint8Array;
 };
 
-async function deriveWrappingKey({
-  prfOutput,
-  info,
-}: {
-  prfOutput: Uint8Array;
-  info: Uint8Array;
-}): Promise<CryptoKey> {
+// Derives the vault wrapping key. The 32-byte check validates caller-supplied
+// PRF output at the public boundary before it becomes key material.
+async function deriveWrappingKey(prfOutput: Uint8Array): Promise<CryptoKey> {
   if (prfOutput.length !== PRF_OUTPUT_LENGTH) {
-    throw new MeraError("INPUT_INVALID", "prfOutput must be 32 bytes");
+    throw new MeraError("INPUT_INVALID", "PRF output must be 32 bytes");
   }
 
-  return hkdfSha256AesGcmKey(prfOutput, info);
+  return hkdfSha256AesGcmKey(prfOutput, SECRET_WRAP_INFO);
 }
 
 // AES-256-GCM encrypt. subtle.encrypt copies its inputs synchronously and the
@@ -233,10 +229,7 @@ async function createSecretVault({
   const secretCopy = copyBytes(secret);
 
   try {
-    const wrappingKey = await deriveWrappingKey({
-      info: SECRET_WRAP_INFO,
-      prfOutput: prfOutputCopy,
-    });
+    const wrappingKey = await deriveWrappingKey(prfOutputCopy);
     const encrypted = await aesGcmEncrypt({
       plaintext: secretCopy,
       wrappingKey,
@@ -280,10 +273,7 @@ async function unwrapSecretVault({
   vault,
   prfOutput,
 }: UnwrapSecretVaultInput): Promise<Uint8Array> {
-  const wrappingKey = await deriveWrappingKey({
-    info: SECRET_WRAP_INFO,
-    prfOutput,
-  });
+  const wrappingKey = await deriveWrappingKey(prfOutput);
 
   return aesGcmDecrypt({
     encrypted: {
@@ -311,10 +301,6 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
 
   if (!isRecord(vault)) {
     throw new MeraError("VAULT_FORMAT_INVALID", "Vault must be an object");
-  }
-
-  if (!("version" in vault)) {
-    throw new MeraError("VAULT_FORMAT_INVALID", "Vault version is required");
   }
 
   if (vault.version !== 1) {
@@ -375,6 +361,18 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
   return { version: 1, credential, prfSalt, nonce, ciphertext };
 }
 
+/** Inputs for the WebAuthn assertion that unlocks a secret vault. */
+type GetSecretVaultPrfOutputInput = {
+  /** Relying party ID for the WebAuthn assertion. */
+  rpId: string;
+  /** Parsed secret vault. */
+  vault: PasskeySecretVault;
+  /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
+  challenge?: Uint8Array;
+  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
+  timeout?: number;
+};
+
 /**
  * Performs the WebAuthn assertion needed to unlock a secret vault.
  *
@@ -391,16 +389,7 @@ async function getSecretVaultPrfOutput({
   vault,
   challenge,
   timeout,
-}: {
-  /** Relying party ID for the WebAuthn assertion. */
-  rpId: string;
-  /** Parsed secret vault. */
-  vault: PasskeySecretVault;
-  /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
-  challenge?: Uint8Array;
-  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
-  timeout?: number;
-}): Promise<PasskeyPrfResult> {
+}: GetSecretVaultPrfOutputInput): Promise<PasskeyPrfResult> {
   return getPasskeyPrfOutput({
     rpId,
     credentialId: vault.credential.credentialId,

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,5 @@
 import { copyBytes } from "./encoding.js";
-import { requireUnlocked } from "./errors.js";
+import { MeraError } from "./errors.js";
 
 /**
  * Handle to a session-owned private key whose lifetime is gated by `lock`.
@@ -46,7 +46,10 @@ function createSigningKey(
 
     const key: LockableKey = {
       use(): Uint8Array {
-        return requireUnlocked(activePrivateKey);
+        if (activePrivateKey === undefined) {
+          throw new MeraError("SESSION_LOCKED", "Signing session is locked");
+        }
+        return activePrivateKey;
       },
       lock(): void {
         if (activePrivateKey !== undefined) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -46,10 +46,7 @@ function createSigningKey(
 
     const key: LockableKey = {
       use(): Uint8Array {
-        if (activePrivateKey === undefined) {
-          throw new MeraError("SESSION_LOCKED", "Signing session is locked");
-        }
-        return activePrivateKey;
+        return requireUnlocked(activePrivateKey);
       },
       lock(): void {
         if (activePrivateKey !== undefined) {
@@ -66,6 +63,21 @@ function createSigningKey(
   } finally {
     consumePrivateKey.fill(0);
   }
+}
+
+/**
+ * Returns the active private key, or throws once the session has been locked.
+ *
+ * @param privateKey - Session-owned private key, or `undefined` after `lock`.
+ * @returns The live session-owned private key.
+ * @throws MeraError with code `SESSION_LOCKED` when `privateKey` is undefined.
+ */
+function requireUnlocked(privateKey: Uint8Array | undefined): Uint8Array {
+  if (privateKey === undefined) {
+    throw new MeraError("SESSION_LOCKED", "Signing session is locked");
+  }
+
+  return privateKey;
 }
 
 export { createSigningKey };


### PR DESCRIPTION
Indirection/redundancy cleanups from the simplification review, no behavior change:

- `requireUnlocked` lived in `errors.ts` but is session logic — moved into `session.ts` as a module-private guard (its export is gone; `errors.ts` is back to error primitives only). The named guard stays because `return requireUnlocked(activePrivateKey)` reads the invariant directly at the call site.
- `deriveWrappingKey` took an `info` parameter that was `SECRET_WRAP_INFO` at both call sites — the constant is baked in and the object bag dropped. The 32-byte boundary check stays (it guards caller-supplied PRF output before it becomes key material) and its message now matches the salt check's style ("PRF output must be 32 bytes").
- `parseSecretVault`'s separate "version is required" branch was subsumed by `version !== 1` (a missing version fails that check with the same code); collapsed to one check.
- `getSecretVaultPrfOutput` declared its option bag inline while every sibling uses a named `*Input` type near the function — hoisted to `GetSecretVaultPrfOutputInput` for consistency.

Tests: full suite passes; vault tests assert error codes, which are unchanged.

**Stack 5/19** — based on #27; merge after it.