### PR TITLE
Fix and tighten secret.ts JSDoc

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -94,7 +94,7 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * time, the result includes the first PRF output, so no second ceremony is
  * needed to open a derived account.
  *
- * @param options - Passkey creation inputs.
+ * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
  * @returns Credential metadata, plus the first PRF output when it was evaluated during creation.
  * @remarks
  * Invokes `navigator.credentials.create()`, which may show browser or
@@ -200,7 +200,7 @@ async function createPasskey({
  *
  * When `credentialId` is omitted, WebAuthn may choose any discoverable credential for the relying party.
  *
- * @param options - Passkey PRF request inputs.
+ * @param options - Passkey PRF request inputs; fields are documented on {@link GetPasskeyPrfOutputOptions}.
  * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks
  * Invokes `navigator.credentials.get()`, which may show browser or
@@ -283,7 +283,7 @@ async function getPasskeyPrfOutput({
  * time. Equivalent to `createPasskey` followed, when `prfOutput` is absent, by
  * `getPasskeyPrfOutput` with the same salt.
  *
- * @param options - Passkey creation inputs. `rp.id` is required so the fallback ceremony can target the same relying party. `prfSalt` must be exactly 32 bytes.
+ * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyWithPrfOutputOptions}. `rp.id` is required so the fallback ceremony can target the same relying party. `prfSalt` must be exactly 32 bytes.
  * @returns Credential metadata and the first PRF output.
  * @remarks
  * Invokes `navigator.credentials.create()`. On authenticators that do not

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -19,7 +19,7 @@ type CreatePasskeyInput = {
   rp: PublicKeyCredentialRpEntity;
   /** User identity passed to WebAuthn. `id` is copied before use. */
   user: {
-    /** Stable user handle for the relying party. Must be 1 to 64 bytes when provided. Defaults to 32 cryptographically random bytes. */
+    /** Stable user handle for the relying party. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). Defaults to 32 cryptographically random bytes. */
     id?: Uint8Array;
     /** User name displayed or stored by the authenticator. */
     name: string;
@@ -33,9 +33,10 @@ type CreatePasskeyInput = {
   /** WebAuthn attestation preference. Defaults to `"none"`. */
   attestation?: AttestationConveyancePreference;
   /**
-   * Optional 32-byte PRF salt to evaluate during creation. When provided and the authenticator supports PRF eval at create time, the returned `prfOutput` lets a derived-mode flow open the account in a single ceremony.
-   *
-   * Authenticators that do not support PRF eval during creation silently ignore this field; callers should fall back to `getPasskeyPrfOutput` if `prfOutput` is undefined.
+   * Optional 32-byte PRF salt to evaluate during creation. Authenticators that
+   * do not support PRF eval at create time silently ignore it and the result
+   * omits `prfOutput`; a later `getPasskeyPrfOutput` with the same salt
+   * returns it.
    */
   prfSalt?: Uint8Array;
 };
@@ -89,21 +90,18 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
 /**
  * Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
  *
- * When `prfSalt` is provided and the authenticator supports PRF eval at create time, the result includes `prfOutput` and a derived-mode flow can open the account without a second ceremony.
+ * When `prfSalt` is provided and the authenticator evaluates PRF at create
+ * time, the result includes the first PRF output, so no second ceremony is
+ * needed to open a derived account.
  *
  * @param options - Passkey creation inputs.
- * @param options.rp - Relying party identity passed to WebAuthn.
- * @param options.user - User identity passed to WebAuthn.
- * @param options.user.id - Stable relying-party user handle. Must be 1 to 64 bytes when provided. Defaults to 32 cryptographically random bytes.
- * @param options.user.name - User name displayed or stored by the authenticator.
- * @param options.user.displayName - Human-readable display name for the authenticator UI.
- * @param options.challenge - WebAuthn challenge. Defaults to 32 cryptographically random bytes.
- * @param options.timeout - WebAuthn timeout in milliseconds. Browser defaults apply when omitted.
- * @param options.attestation - WebAuthn attestation preference. Defaults to `"none"`.
- * @param options.prfSalt - Optional 32-byte PRF salt to evaluate at create time.
- * @returns Credential metadata and, when `prfSalt` was provided and the authenticator supports it, the first PRF output.
- * @remarks Side effects: invokes `navigator.credentials.create()`, which may show browser or authenticator UI and create a discoverable passkey.
- * @remarks Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
+ * @returns Credential metadata, plus the first PRF output when it was evaluated during creation.
+ * @remarks
+ * Invokes `navigator.credentials.create()`, which may show browser or
+ * authenticator UI and create a discoverable passkey.
+ *
+ * The credential is requested with fixed parameters: ES256 or RS256 key types,
+ * a required resident key, and required user verification.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or returns a malformed create-time PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
@@ -203,17 +201,14 @@ async function createPasskey({
  * When `credentialId` is omitted, WebAuthn may choose any discoverable credential for the relying party.
  *
  * @param options - Passkey PRF request inputs.
- * @param options.rpId - Relying party ID for the WebAuthn request.
- * @param options.credentialId - Optional credential ID to restrict the assertion to one passkey.
- * @param options.transports - Optional transports associated with `credentialId`.
- * @param options.prfSalt - PRF salt. Must be exactly 32 bytes.
- * @param options.challenge - WebAuthn challenge. Defaults to 32 cryptographically random bytes.
- * @param options.timeout - WebAuthn timeout in milliseconds. Browser defaults apply when omitted.
- * @returns The selected credential ID and first WebAuthn PRF output for wallet derivation or unlock flows.
+ * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks
- * Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
+ * Invokes `navigator.credentials.get()`, which may show browser or
+ * authenticator UI.
  *
- * Caller assumptions: `prfSalt` must be stable for flows that need stable PRF output.
+ * The PRF output is a deterministic function of the credential, `rpId`, and
+ * `prfSalt`: the same three inputs reproduce the same output, and a different
+ * salt yields an unrelated output.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes or `credentialId` is not canonical base64url.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
@@ -283,18 +278,25 @@ async function getPasskeyPrfOutput({
 }
 
 /**
- * Creates a passkey and returns the first WebAuthn PRF output, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time.
- *
- * This is the canonical "open this account right after creating it" entry point. It is equivalent to calling `createPasskey` and, when `prfOutput` is undefined, `getPasskeyPrfOutput` with the same salt. The lower-level entry points remain available for callers that want to drive the two ceremonies independently (for example, to show UI between them).
+ * Creates a passkey and returns the first WebAuthn PRF output, falling back to
+ * a second ceremony only when the authenticator does not evaluate PRF at create
+ * time. Equivalent to `createPasskey` followed, when `prfOutput` is absent, by
+ * `getPasskeyPrfOutput` with the same salt.
  *
  * @param options - Passkey creation inputs. `rp.id` is required so the fallback ceremony can target the same relying party. `prfSalt` must be exactly 32 bytes.
  * @returns Credential metadata and the first PRF output.
  * @remarks
- * Side effects: invokes `navigator.credentials.create()`. On authenticators that do not evaluate PRF during creation, also invokes `navigator.credentials.get()` — which means a second browser prompt for the user.
+ * Invokes `navigator.credentials.create()`. On authenticators that do not
+ * evaluate PRF during creation, also invokes `navigator.credentials.get()` — a
+ * second browser prompt.
  *
- * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of the input does not change the fallback ceremony or returned salt.
+ * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of
+ * the input does not change the fallback ceremony or returned salt.
  *
- * Caller assumptions: call from a secure browser context where WebAuthn and PRF are available.
+ * If the fallback ceremony fails, the passkey from the completed creation
+ * ceremony still exists on the authenticator, but the thrown error does not
+ * carry its metadata; composing `createPasskey` and `getPasskeyPrfOutput`
+ * directly keeps the credential ID across that failure.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or does not return PRF output on the fallback ceremony.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
@@ -357,8 +359,6 @@ function assertCredentialApiAvailable(): void {
 /**
  * Narrows a WebAuthn result to a public-key credential with extension results.
  *
- * @param credential - Credential returned by WebAuthn.
- * @returns The credential narrowed to the PRF-aware public-key credential shape.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn returned no usable public-key credential.
  */
 function assertPublicKeyCredential(

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -359,6 +359,8 @@ function assertCredentialApiAvailable(): void {
 /**
  * Narrows a WebAuthn result to a public-key credential with extension results.
  *
+ * @param credential - Credential returned by WebAuthn.
+ * @returns The credential narrowed to the PRF-aware public-key credential shape.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn returned no usable public-key credential.
  */
 function assertPublicKeyCredential(

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -37,7 +37,7 @@ function canonicalEncode(parts: Uint8Array[]): Uint8Array {
 // HKDF info and AAD for the secret vault. The HKDF info keeps the wrapping key
 // distinct from any other key derived from the same PRF output. The AAD is a
 // precomputed constant (domain ‖ version): a secret vault has no public key to
-// bind, unlike a per-account vault.
+// bind.
 const SECRET_WRAP_INFO = utf8ToBytes("mera.v1.wrap.secret");
 const SECRET_AAD_DOMAIN = utf8ToBytes("mera.v1.secret.aad");
 const SECRET_AAD_VERSION = 1;
@@ -147,9 +147,7 @@ function readBase64Url(
   try {
     bytes = base64UrlDecode(value);
   } catch (cause) {
-    throw new MeraError(errorCode, `${name} must be base64url`, {
-      cause,
-    });
+    throw new MeraError(errorCode, `${name} must be base64url`, { cause });
   }
 
   if (typeof byteLength === "number" && bytes.length !== byteLength) {
@@ -193,15 +191,23 @@ type CreateSecretVaultInput = {
 /**
  * Encrypts an arbitrary secret into a passkey-protected vault.
  *
- * The secret is opaque: no curve, no public key, no length or scalar checks. An AES-256-GCM wrapping key is derived from the PRF output with secret-specific HKDF info, and the secret is encrypted under canonical AAD.
+ * An AES-256-GCM wrapping key is derived from the PRF output with
+ * secret-specific HKDF info, and the secret is encrypted under fixed
+ * additional authenticated data (AAD).
  *
  * @remarks
- * The input byte buffers are copied before async cryptographic work starts; post-call mutation does not change the vault being produced. Caller-owned input buffers are not modified or zeroed.
+ * The input byte buffers are copied before async cryptographic work starts;
+ * post-call mutation does not change the vault being produced. Caller-owned
+ * input buffers are not modified or zeroed.
  *
- * Security: a vault is bound to its `prfOutput` only — not to the credential ID, salt, or nonce (the AAD is a fixed constant). Use a fresh `prfSalt` per secret. Secrets wrapped under one reused PRF output share a wrapping key, so their ciphertexts are interchangeable by anyone who can rewrite stored vault JSON.
+ * Security: a vault is bound to its `prfOutput` only — not to the credential
+ * ID, salt, or nonce. Secrets wrapped under one reused PRF output share a
+ * wrapping key, so their ciphertexts are interchangeable by anyone who can
+ * rewrite stored vault JSON; a fresh `prfSalt` per secret avoids the shared key.
  * @param options - Credential material and the secret to wrap.
  * @returns A JSON-safe secret vault.
- * @throws MeraError with code `INPUT_INVALID` when the credential ID is empty, the PRF salt or output is not 32 bytes, or `secret` is empty.
+ * @throws MeraError with code `INPUT_INVALID` when the credential ID is empty or not canonical base64url, the PRF salt or output is not 32 bytes, or `secret` is empty.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 async function createSecretVault({
   credential,
@@ -264,10 +270,10 @@ type UnwrapSecretVaultInput = {
  * Decrypts the secret from a secret vault.
  *
  * @param options - Vault and PRF output.
- * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`.
- * @remarks Side effects: callers should zero the returned buffer when finished.
+ * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`. The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it.
  * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
  * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 async function unwrapSecretVault({
   vault,
@@ -288,12 +294,12 @@ async function unwrapSecretVault({
 /**
  * Parses and validates untrusted secret-vault JSON or objects.
  *
- * Only version 1 vaults are accepted. The credential, PRF salt, nonce, and ciphertext are canonicalized to base64url and length-checked.
- *
- * Fields outside the version-1 schema — unknown top-level keys and unknown `credential` keys — are ignored and absent from the returned vault.
+ * Only version 1 vaults are accepted. The credential ID, PRF salt, nonce, and
+ * ciphertext are validated as canonical base64url and length-checked. Unknown
+ * fields are dropped from the returned vault.
  *
  * @param value - Secret vault as JSON text or an untrusted object.
- * @returns A canonicalized secret vault.
+ * @returns A validated secret vault.
  * @throws MeraError with code `VAULT_FORMAT_INVALID` when required structure, version, or encoded data is invalid.
  */
 function parseSecretVault(value: unknown): PasskeySecretVault {
@@ -376,12 +382,14 @@ type GetSecretVaultPrfOutputInput = {
 /**
  * Performs the WebAuthn assertion needed to unlock a secret vault.
  *
- * Reads the credential metadata and PRF salt from a parsed vault; pass JSON through `parseSecretVault` first.
+ * Reads the credential metadata and PRF salt from a parsed vault and delegates
+ * to `getPasskeyPrfOutput`.
  *
  * @param options - Secret-vault PRF inputs.
  * @returns The selected credential ID and first WebAuthn PRF output.
- * @remarks Side effects: invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
- * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a 32-byte PRF output.
+ * @remarks Invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
+ * @throws MeraError with code `INPUT_INVALID` when the vault's `prfSalt` or `credentialId` is not canonical base64url (already validated for vaults from `parseSecretVault`).
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function getSecretVaultPrfOutput({

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -218,7 +218,7 @@ type CreateSecretVaultInput = {
  * ID, salt, or nonce. Secrets wrapped under one reused PRF output share a
  * wrapping key, so their ciphertexts are interchangeable by anyone who can
  * rewrite stored vault JSON; a fresh `prfSalt` per secret avoids the shared key.
- * @param options - Credential material and the secret to wrap.
+ * @param options - Credential material and the secret to wrap; fields are documented on {@link CreateSecretVaultOptions}.
  * @returns A JSON-safe secret vault.
  * @throws MeraError with code `INPUT_INVALID` when the credential ID is empty or not canonical base64url, the PRF salt or output is not 32 bytes, or `secret` is empty.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
@@ -283,7 +283,7 @@ type UnwrapSecretVaultInput = {
 /**
  * Decrypts the secret from a secret vault.
  *
- * @param options - Vault and PRF output.
+ * @param options - Vault and PRF output; fields are documented on {@link UnwrapSecretVaultOptions}.
  * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`. The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it.
  * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
  * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
@@ -399,7 +399,7 @@ type GetSecretVaultPrfOutputInput = {
  * Reads the credential metadata and PRF salt from a parsed vault and delegates
  * to `getPasskeyPrfOutput`.
  *
- * @param options - Secret-vault PRF inputs.
+ * @param options - Secret-vault PRF inputs; fields are documented on {@link GetSecretVaultPrfOutputOptions}.
  * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks Invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.


### PR DESCRIPTION
Documentation fixes from the review — this one carries real accuracy bugs, not just wordiness:

- `createSecretVault` claimed "no length or scalar checks" while its own `@throws` documents the non-empty check — the contradictory sentence is gone.
- Missing `@throws` completed against the actual code paths: `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable (both `createSecretVault` and `unwrapSecretVault` reach `getCrypto()`), `INPUT_INVALID` on `getSecretVaultPrfOutput` for hand-built vaults, and non-canonical-base64url credential IDs on `createSecretVault`.
- `unwrapSecretVault`'s "@remarks Side effects: callers should zero the returned buffer" was both mislabeled (not a side effect) and a caller instruction; it now states the fact: the returned buffer is a fresh allocation the library neither retains nor zeroes.
- The Security paragraph is fact-first: reused PRF output ⇒ shared wrapping key ⇒ interchangeable ciphertexts; the fresh-salt-per-secret consequence follows from that instead of leading as an instruction.
- "canonicalized to base64url" → "validated as canonical base64url" (`readBase64Url` transforms nothing); AAD expanded once as "additional authenticated data (AAD)"; the stale "unlike a per-account vault" comparison (an abstraction that no longer exists) is dropped; remaining "Side effects:" labels stripped.

One incidental formatting collapse rode along (`{ cause }` onto one line in `readBase64Url`). Full suite passes (51/51).

**Stack 9/16** — based on #31; merge after it.