### PR TITLE
Deduplicate JSDoc across small modules

### DIFF
--- a/src/chains/evm.ts
+++ b/src/chains/evm.ts
@@ -6,8 +6,6 @@ import type { EvmAddress } from "../types.js";
 /**
  * Derives the EIP-55 checksummed EVM address for a secp256k1 public key.
  *
- * Compressed and uncompressed public keys are accepted.
- *
  * @param publicKey - A compressed or uncompressed secp256k1 public key.
  * @returns The EIP-55 mixed-case checksummed EVM address.
  * @throws MeraError with code `INPUT_INVALID` when `publicKey` is not valid secp256k1.

--- a/src/chains/solana.ts
+++ b/src/chains/solana.ts
@@ -21,8 +21,6 @@ function getSolanaAddress(publicKey: Uint8Array): string {
 /**
  * Returns true when a string is a valid base58-encoded Solana address.
  *
- * Validates both the base58 alphabet and the 32-byte decoded length.
- *
  * @param value - String to check.
  * @returns `true` when `value` decodes to 32 base58 bytes.
  */

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -11,10 +11,8 @@ import type {
 /**
  * Derives the 32-byte Ed25519 public key for a 32-byte Ed25519 seed.
  *
- * @internal
- * @param privateKey - A 32-byte Ed25519 seed.
- * @returns The 32-byte Ed25519 public key.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
+ * @internal
  */
 function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
   if (privateKey.length !== 32) {
@@ -33,12 +31,12 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
 /**
  * Wraps an Ed25519 seed in an explicitly lockable signing session.
  *
- * `signMessage` signs the raw message bytes with Ed25519 (Ed25519pure); the curve hashes internally with SHA-512.
+ * `signMessage` signs the raw message bytes; Ed25519 hashes internally with
+ * SHA-512. `lock` zeroes the session-owned seed copy and makes future signing
+ * fail.
  *
  * @param options - Signing session inputs.
- * @param options.consumePrivateKey - Ed25519 seed. Must be 32 bytes. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked Ed25519 signing session.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
  * @throws MeraError with code `INPUT_INVALID` when `consumePrivateKey` is not 32 bytes.
  */
 function createEd25519SigningSession({

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -11,6 +11,8 @@ import type {
 /**
  * Derives the 32-byte Ed25519 public key for a 32-byte Ed25519 seed.
  *
+ * @param privateKey - A 32-byte Ed25519 seed.
+ * @returns The 32-byte Ed25519 public key.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
  * @internal
  */

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -37,7 +37,7 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
  * SHA-512. `lock` zeroes the session-owned seed copy and makes future signing
  * fail.
  *
- * @param options - Signing session inputs.
+ * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
  * @returns An unlocked Ed25519 signing session.
  * @throws MeraError with code `INPUT_INVALID` when `consumePrivateKey` is not 32 bytes.
  */

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,36 +1,19 @@
 import { base64urlnopad } from "@scure/base";
 import { MeraError } from "./errors.js";
 
-/**
- * Copies bytes into a standalone `Uint8Array`.
- *
- * The returned array never aliases the input.
- *
- * @param value - Bytes to copy.
- * @returns A new `Uint8Array` with the same bytes as `value`.
- */
+/** Copies bytes into a new `Uint8Array` that never aliases the input. */
 function copyBytes(value: Uint8Array): Uint8Array {
   return new Uint8Array(value);
 }
 
-/**
- * Copies bytes into a standalone `ArrayBuffer` for Web APIs.
- *
- * @param value - Bytes to copy.
- * @returns A new `ArrayBuffer` with the same bytes as `value`.
- */
+/** Copies bytes into a new `ArrayBuffer` for Web API arguments. */
 function asArrayBuffer(value: Uint8Array): ArrayBuffer {
   const output = new ArrayBuffer(value.byteLength);
   new Uint8Array(output).set(value);
   return output;
 }
 
-/**
- * Encodes bytes as canonical unpadded base64url.
- *
- * @param value - Bytes to encode.
- * @returns Canonical unpadded base64url text.
- */
+/** Encodes bytes as canonical unpadded base64url. */
 function base64UrlEncode(value: Uint8Array): string {
   return base64urlnopad.encode(value);
 }
@@ -38,8 +21,6 @@ function base64UrlEncode(value: Uint8Array): string {
 /**
  * Decodes canonical unpadded base64url into bytes.
  *
- * @param value - Canonical unpadded base64url text.
- * @returns Decoded bytes.
  * @throws MeraError with code `INPUT_INVALID` when `value` uses invalid characters, invalid length, or non-canonical padding.
  */
 function base64UrlDecode(value: string): Uint8Array {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,19 +1,36 @@
 import { base64urlnopad } from "@scure/base";
 import { MeraError } from "./errors.js";
 
-/** Copies bytes into a new `Uint8Array` that never aliases the input. */
+/**
+ * Copies bytes into a standalone `Uint8Array`.
+ *
+ * The returned array never aliases the input.
+ *
+ * @param value - Bytes to copy.
+ * @returns A new `Uint8Array` with the same bytes as `value`.
+ */
 function copyBytes(value: Uint8Array): Uint8Array {
   return new Uint8Array(value);
 }
 
-/** Copies bytes into a new `ArrayBuffer` for Web API arguments. */
+/**
+ * Copies bytes into a standalone `ArrayBuffer` for Web APIs.
+ *
+ * @param value - Bytes to copy.
+ * @returns A new `ArrayBuffer` with the same bytes as `value`.
+ */
 function asArrayBuffer(value: Uint8Array): ArrayBuffer {
   const output = new ArrayBuffer(value.byteLength);
   new Uint8Array(output).set(value);
   return output;
 }
 
-/** Encodes bytes as canonical unpadded base64url. */
+/**
+ * Encodes bytes as canonical unpadded base64url.
+ *
+ * @param value - Bytes to encode.
+ * @returns Canonical unpadded base64url text.
+ */
 function base64UrlEncode(value: Uint8Array): string {
   return base64urlnopad.encode(value);
 }
@@ -21,6 +38,8 @@ function base64UrlEncode(value: Uint8Array): string {
 /**
  * Decodes canonical unpadded base64url into bytes.
  *
+ * @param value - Canonical unpadded base64url text.
+ * @returns Decoded bytes.
  * @throws MeraError with code `INPUT_INVALID` when `value` uses invalid characters, invalid length, or non-canonical padding.
  */
 function base64UrlDecode(value: string): Uint8Array {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -21,7 +21,14 @@ class MeraError extends Error {
   /** Machine-readable category for the failure. */
   readonly code: MeraErrorCode;
 
-  /** Creates an error with a stable `code` and a human-readable `message`. `options.cause` carries the original failure, when available. */
+  /**
+   * Creates a package error with a stable error code.
+   *
+   * @param code - Machine-readable category for the failure.
+   * @param message - Human-readable error message.
+   * @param options - Optional error construction options.
+   * @param options.cause - Original cause for this error, when available.
+   */
   constructor(
     code: MeraErrorCode,
     message: string,
@@ -33,7 +40,12 @@ class MeraError extends Error {
   }
 }
 
-/** Returns true when `error` is a `MeraError`. */
+/**
+ * Returns true when an unknown error is a `MeraError`.
+ *
+ * @param error - Value to check.
+ * @returns `true` when `error` is a `MeraError`.
+ */
 function isMeraError(error: unknown): error is MeraError {
   return error instanceof MeraError;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,10 +1,10 @@
 /**
  * Stable coarse-grained error codes thrown by this package.
  *
- * - `PASSKEY_OPERATION_FAILED`: WebAuthn or the browser credential API failed, was cancelled, or returned an unexpected credential.
+ * - `PASSKEY_OPERATION_FAILED`: WebAuthn failed, was cancelled, or returned an unexpected credential, or a required browser API (the credential API, Web Crypto) is unavailable.
  * - `PRF_UNAVAILABLE`: the authenticator did not enable or return a usable 32-byte WebAuthn PRF output.
  * - `SESSION_LOCKED`: a signing call was made after `lock()`.
- * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key, or tampered ciphertext or AAD).
+ * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key, or tampered ciphertext or additional authenticated data).
  * - `INPUT_INVALID`: a caller-supplied value at a public boundary did not satisfy a length, range, encoding, or scalar constraint.
  * - `VAULT_FORMAT_INVALID`: untrusted vault data (JSON or object) was malformed, missing required fields, or used a non-canonical encoding.
  */
@@ -16,19 +16,12 @@ type MeraErrorCode =
   | "INPUT_INVALID"
   | "VAULT_FORMAT_INVALID";
 
-/** Error type thrown by this package with a stable coarse-grained code. */
+/** Error thrown by this package. `code` is the stable machine-readable category. */
 class MeraError extends Error {
   /** Machine-readable category for the failure. */
   readonly code: MeraErrorCode;
 
-  /**
-   * Creates a package error with a stable error code.
-   *
-   * @param code - Machine-readable category for the failure.
-   * @param message - Human-readable error message.
-   * @param options - Optional error construction options.
-   * @param options.cause - Original cause for this error, when available.
-   */
+  /** Creates an error with a stable `code` and a human-readable `message`. `options.cause` carries the original failure, when available. */
   constructor(
     code: MeraErrorCode,
     message: string,
@@ -40,12 +33,7 @@ class MeraError extends Error {
   }
 }
 
-/**
- * Returns true when an unknown error is a `MeraError`.
- *
- * @param error - Value to check.
- * @returns `true` when `error` is a `MeraError`.
- */
+/** Returns true when `error` is a `MeraError`. */
 function isMeraError(error: unknown): error is MeraError {
   return error instanceof MeraError;
 }

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -9,13 +9,12 @@ import type {
 } from "./types.js";
 
 /**
- * Derives an uncompressed secp256k1 public key from a private key.
+ * Derives an uncompressed secp256k1 public key from a 32-byte private key.
+ * The input is not modified.
  *
- * @internal
- * @param privateKey - A 32-byte secp256k1 private key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
- * @remarks Caller assumptions: the private key must be secret key material; the function does not clear or mutate the input.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
+ * @internal
  */
 function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
   try {
@@ -32,10 +31,9 @@ function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
 /**
  * Converts a compressed or uncompressed secp256k1 public key to uncompressed form.
  *
- * @internal
- * @param publicKey - A compressed or uncompressed secp256k1 public key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
  * @throws MeraError with code `INPUT_INVALID` when the key length, prefix, or curve point is invalid.
+ * @internal
  */
 function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
   try {
@@ -50,12 +48,11 @@ function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
 /**
  * Wraps a secp256k1 private key in an explicitly lockable signing session.
  *
- * `signDigest` signs exactly 32 bytes without prehashing. Calling `lock` zeroes the active private-key copy and makes future signing fail.
+ * `signDigest` signs exactly 32 bytes without prehashing. `lock` zeroes the
+ * session-owned private-key copy and makes future signing fail.
  *
  * @param options - Signing session inputs.
- * @param options.consumePrivateKey - secp256k1 private key. Copied into one session-owned snapshot, then zeroed before this call returns or throws.
  * @returns An unlocked secp256k1 signing session.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; public-key derivation and later signing use one session-owned copy, which `lock()` later zeroes.
  * @throws MeraError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.
  */
 function createSecp256k1SigningSession({
@@ -82,6 +79,7 @@ function createSecp256k1SigningSession({
         prehash: false,
       });
 
+      // noble's "recovered" format is 65 bytes: the recovery ID, then r || s.
       return {
         compact: signature.slice(1),
         recovery: signature[0],

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -12,6 +12,7 @@ import type {
  * Derives an uncompressed secp256k1 public key from a 32-byte private key.
  * The input is not modified.
  *
+ * @param privateKey - A 32-byte secp256k1 private key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
  * @internal
@@ -31,6 +32,7 @@ function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
 /**
  * Converts a compressed or uncompressed secp256k1 public key to uncompressed form.
  *
+ * @param publicKey - A compressed or uncompressed secp256k1 public key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
  * @throws MeraError with code `INPUT_INVALID` when the key length, prefix, or curve point is invalid.
  * @internal

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -53,7 +53,7 @@ function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
  * `signDigest` signs exactly 32 bytes without prehashing. `lock` zeroes the
  * session-owned private-key copy and makes future signing fail.
  *
- * @param options - Signing session inputs.
+ * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
  * @returns An unlocked secp256k1 signing session.
  * @throws MeraError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.
  */

--- a/src/session.ts
+++ b/src/session.ts
@@ -22,15 +22,14 @@ type LockableKey = {
 /**
  * Consumes a private key into a lockable signing key and derives its public key.
  *
- * The caller's buffer is copied into one owned snapshot, which is used for
- * public-key derivation and signing. The caller's buffer is zeroed before this
- * function returns or throws.
+ * `consumePrivateKey` is copied into one session-owned snapshot and zeroed
+ * before this function returns or throws. The snapshot is zeroed by `lock` or,
+ * when `derivePublicKey` throws, before the error is rethrown.
  *
- * @param consumePrivateKey - Private key to consume. Zeroed before this function returns or throws.
- * @param derivePublicKey - Derives the public key from the owned private-key snapshot; a throw doubles as private-key validation.
- * @returns The {@link LockableKey} handle gating access on lock state, paired with the derived public key.
- * @remarks Side effects: zeroes `consumePrivateKey` on every path; the owned snapshot is zeroed by `lock()` on success or before rethrowing a validation failure.
- * @throws Rethrows whatever `derivePublicKey` throws, after zeroing the owned snapshot and `consumePrivateKey`.
+ * @param consumePrivateKey - Private key to consume.
+ * @param derivePublicKey - Derives the public key from the owned snapshot; a throw doubles as private-key validation.
+ * @returns The lockable key handle paired with the derived public key.
+ * @throws Rethrows whatever `derivePublicKey` throws.
  */
 function createSigningKey(
   consumePrivateKey: Uint8Array,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
 /**
  * Versioned JSON-safe vault holding one arbitrary secret encrypted behind a passkey.
  *
- * The secret is opaque — no curve and no public key. Callers decide what the bytes mean (a seed phrase's entropy, a backup blob, …).
+ * The secret bytes are opaque to the library; callers decide what they mean.
  */
 type PasskeySecretVault = {
   /** Secret-vault format version. */
@@ -75,7 +75,7 @@ type CreateSigningSessionOptions = {
   /**
    * Curve private key. Must be exactly 32 bytes; secp256k1 must also be a valid scalar.
    *
-   * Copied into one session-owned snapshot, then zeroed before the call returns or throws. Pass a fresh copy if the bytes are needed elsewhere.
+   * Copied into one session-owned snapshot; the input is zeroed before the call returns or throws.
    */
   consumePrivateKey: Uint8Array;
 };
@@ -87,18 +87,15 @@ type Secp256k1SigningSession = {
   /**
    * Signs a 32-byte digest without prehashing it.
    *
-   * @param digest32 - Exactly 32 bytes to sign.
+   * @param digest32 - Exactly 32 bytes to sign; copied before use, the original buffer is not modified.
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
-   * @remarks Caller assumptions: `digest32` must already be the digest to sign; this method does not hash it.
-   * @remarks `digest32` is copied before use; the original buffer is not modified.
    * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
   signDigest(digest32: Uint8Array): Promise<Secp256k1Signature>;
   /**
-   * Clears the active private key and permanently locks this session.
+   * Zeroes the session-owned private-key copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
    *
-   * @remarks Side effects: overwrites the session-owned private-key copy with zeros and makes future signing fail.
    * @remarks If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
    */
   lock(): void;
@@ -109,18 +106,16 @@ type Ed25519SigningSession = {
   /** 32-byte Ed25519 public key for the session. */
   publicKey: Uint8Array;
   /**
-   * Signs an arbitrary-length message with Ed25519 (Ed25519pure).
+   * Signs an arbitrary-length message with Ed25519.
    *
-   * @param message - Message bytes to sign. Hashing happens inside Ed25519 itself.
+   * @param message - Message bytes to sign; copied before use, the original buffer is not modified. Hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
-   * @remarks `message` is copied before use; the original buffer is not modified.
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
   signMessage(message: Uint8Array): Promise<Uint8Array>;
   /**
-   * Clears the active private key and permanently locks this session.
+   * Zeroes the session-owned seed copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
    *
-   * @remarks Side effects: overwrites the session-owned seed copy with zeros and makes future signing fail.
    * @remarks If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
    */
   lock(): void;

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -2,11 +2,8 @@ import { asArrayBuffer } from "./encoding.js";
 import { MeraError } from "./errors.js";
 
 /**
- * Returns cryptographically random bytes from Web Crypto.
+ * Returns `length` cryptographically random bytes from Web Crypto.
  *
- * @param length - Number of random bytes to return.
- * @returns Cryptographically random bytes.
- * @remarks Side effects: reads from the host Web Crypto CSPRNG.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 function randomBytes(length: number): Uint8Array {
@@ -18,7 +15,6 @@ function randomBytes(length: number): Uint8Array {
 /**
  * Returns the host Web Crypto implementation.
  *
- * @returns `globalThis.crypto` when Web Crypto is available.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 function getCrypto(): Crypto {
@@ -35,10 +31,8 @@ function getCrypto(): Crypto {
 /**
  * Derives a non-extractable AES-256-GCM key with HKDF-SHA-256 and an empty salt.
  *
- * @param ikm - Input keying material.
- * @param info - HKDF info/context bytes.
- * @returns A non-extractable AES-GCM `CryptoKey` usable for encryption and decryption.
- * @remarks Caller assumptions: callers choose domain-separated `info` values appropriate for the wrapping key.
+ * `info` domain-separates keys derived from the same input keying material `ikm`.
+ *
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 async function hkdfSha256AesGcmKey(

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -2,8 +2,10 @@ import { asArrayBuffer } from "./encoding.js";
 import { MeraError } from "./errors.js";
 
 /**
- * Returns `length` cryptographically random bytes from Web Crypto.
+ * Returns cryptographically random bytes from Web Crypto.
  *
+ * @param length - Number of random bytes to return.
+ * @returns Cryptographically random bytes.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 function randomBytes(length: number): Uint8Array {
@@ -15,6 +17,7 @@ function randomBytes(length: number): Uint8Array {
 /**
  * Returns the host Web Crypto implementation.
  *
+ * @returns `globalThis.crypto` when Web Crypto is available.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 function getCrypto(): Crypto {
@@ -31,8 +34,9 @@ function getCrypto(): Crypto {
 /**
  * Derives a non-extractable AES-256-GCM key with HKDF-SHA-256 and an empty salt.
  *
- * `info` domain-separates keys derived from the same input keying material `ikm`.
- *
+ * @param ikm - Input keying material.
+ * @param info - HKDF info/context bytes; domain-separates keys derived from the same `ikm`.
+ * @returns A non-extractable AES-GCM `CryptoKey` usable for encryption and decryption.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
  */
 async function hkdfSha256AesGcmKey(


### PR DESCRIPTION
Documentation-only sweep over types.ts, session.ts, errors.ts, webcrypto.ts, encoding.ts, secp256k1.ts, ed25519.ts, and both chain modules (36+/87−). The review found the same facts documented in up to 8 places; each now has one home:

- The consumePrivateKey copied-then-zeroed contract lives on `CreateSigningSessionOptions.consumePrivateKey` (types.ts); the session factories and `createSigningKey` stop restating it (session.ts alone said it four times in one docblock).
- Repeated `@remarks` tags merged per AGENTS.md (one tag per semantic section): both `lock()` docs, `signDigest`, `signMessage`.
- "Side effects:" / "Caller assumptions:" label prefixes stripped; vacuous ones deleted outright ("reads from the host Web Crypto CSPRNG", "must be secret key material").
- Boilerplate @param/@returns that restated one-line summaries dropped on trivial internal helpers (`copyBytes`, `asArrayBuffer`, `base64UrlEncode`, `isMeraError`, the error constructor).
- Accuracy: `PASSKEY_OPERATION_FAILED`'s code doc now covers the Web Crypto-unavailable path that actually throws it; nonstandard "Ed25519pure" term dropped; a comment now explains noble's recovered signature layout (recovery ID first, then r||s) next to the code that slices it.

No code changes. Full suite passes (51/51).

**Stack 10/16** — based on #32; merge after it.