### PR TITLE
Move project commands to the README Development section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,9 @@ This file should stay stable and process-oriented.
 
 - architectural decisions
 - coding and API design principles
-- testing and verification workflow
 - safety and review expectations
-- essential project commands
+
+Project commands and the testing workflow live in the README's Development section.
 
 ### What Not to Include
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Recovery phrases become JavaScript strings when displayed or exported. Unlike `U
 
 **Dependency scope.** Runtime dependencies are `@noble/*` and `@scure/*` only. The root `devDependencies` (build/test tooling) and the unpublished `demo/` app never ship to library consumers.
 
+## Development
+
+```sh
+npm ci
+npm test            # build, typecheck the tests, run the full Playwright suite
+npm run test:e2e    # end-to-end passkey ceremonies only (virtual authenticator)
+npm run check       # Biome lint + format
+npm run check:pack  # verify the publishable tarball
+```
+
 ## License
 
 Licensed under either of [Apache License](./LICENSE-APACHE), Version


### PR DESCRIPTION
AGENTS.md's own scope section promised "testing and verification workflow" and "essential project commands" but contained neither — and per maintainer preference those belong in the README, not AGENTS.md. So:

- README gains a short Development section (`npm ci` / `test` / `test:e2e` / `check` / `check:pack`, one line of context each).
- AGENTS.md's What-to-Include list drops the two items and points at the README's Development section instead.

**Stack 12/16** — based on #34; merge after it.