### PR TITLE
Typecheck tests and drop a no-op Playwright flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "check:pack": "npm run build && node scripts/verify-tarball.mjs && publint --strict",
     "format": "biome format --write .",
     "lint": "biome lint .",
-    "test": "npm run build && playwright test",
-    "test:e2e": "npm run build && playwright test --project=chromium --grep @e2e"
+    "test": "npm run build && tsc -p tsconfig.test.json && playwright test",
+    "test:e2e": "npm run build && playwright test --grep @e2e"
   },
   "dependencies": {
     "@noble/ed25519": "^3.1.0",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["test/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
From the review: the repo's strict-typing convention was unenforced for the ~900 lines of tests — `tsconfig.json` only includes `src/`, and Playwright transpiles tests with esbuild (no type checking), so type drift between tests and the built `.d.ts` could land silently.

- New `tsconfig.test.json` (extends the root config; `noEmit`, covers `test/**` and `playwright.config.ts`), wired into `npm test` between the build and the Playwright run.
- `test:e2e` drops `--project=chromium` — the Playwright config defines exactly one project, so the flag implied a multi-browser setup that doesn't exist.

`npm test` passes end-to-end with the new typecheck step (52/52).

**Stack 15/16** — based on #37; merge after it.