### PR TITLE
Tighten AGENTS.md JSDoc guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,13 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 ### Documentation and Examples
 
 - Public SDK functions should have complete, accurate JSDoc.
-- Use appropriate JSDoc tags to describe the API contract, return behavior, caller assumptions, observable side effects, and failure modes.
+- Use appropriate JSDoc tags to describe the API contract, return behavior, input constraints, observable side effects, and failure modes.
 - Document security-sensitive behavior explicitly, especially for key material, randomness, WebAuthn prompts, encryption nonces, storage formats, and mutation/zeroing behavior.
 - Document thrown `MeraError` codes with the appropriate JSDoc tag.
 - Examples should be runnable, concise, and focused on library behavior, not on provider boilerplate.
 - README examples should reflect actual tested behavior.
 - Keep documentation prose neutral: name keys, secrets, and passkeys plainly ("the passkey", "one encrypted secret") rather than attributing them to the reader ("your passkey", "a secret you provide" / "you own").
-- Internal helpers with non-obvious invariants should have short comments or docstrings.
+- Internal helpers with non-obvious invariants should have short `//` comments or full JSDoc.
 - Document observable behavior, not caller instructions: state what a function does to its inputs and outputs (for example, "the input is copied before use; the original buffer is not modified") rather than what the caller may or should do with them. Callers derive correct usage from the stated facts.
 - When a comment or doc gives a rationale, explain the mechanism, not just the claim: a reader should see *why* from the text (for example, "signing reads the buffer after an await, so copy it first") rather than having to reconstruct the cause.
 - For section-style JSDoc/TSDoc block tags, use one tag per semantic section and continue with paragraphs until the next block tag. Put the tag on its own line when the content is multi-sentence. Repeat only naturally repeatable tags such as `@param`, `@throws`, `@example`, and `@see`; do not repeat section-style tags such as `@remarks` just to split paragraphs.


### PR DESCRIPTION
Two word-level fixes from the release-review discussion, closing the readings that let tagged JSDoc get collapsed during the doc pass:

- "short comments or docstrings" → "short `//` comments or full JSDoc" — the old disjunction could be read as licensing an untagged `/** one-liner */` on internal helpers, which is neither a comment nor real JSDoc. The intended options are a plain `//` comment or a proper tagged docblock.
- "caller assumptions" → "input constraints" in the JSDoc-tags line — the old phrase sat oddly against the "document observable behavior, not caller instructions" rule two lines below (and had spawned the `@remarks Caller assumptions:` labels the stack removes). What the docs actually keep is input constraints stated as facts.

**Stack 19/19** — based on #41; merge last.