### PR TITLE
[codex] Add crypto unavailable error code

### DIFF
--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -365,6 +365,8 @@ function describeError(error: unknown): string {
         return "Couldn't unlock the account with that passkey.";
       case "SESSION_LOCKED":
         return "Your session is locked — connect again.";
+      case "CRYPTO_UNAVAILABLE":
+        return "This browser doesn't provide the Web Crypto APIs this demo needs.";
       case "PASSKEY_OPERATION_FAILED":
         return "The passkey request was cancelled or failed.";
       case "VAULT_FORMAT_INVALID":

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,8 @@
 /**
  * Stable coarse-grained error codes thrown by this package.
  *
- * - `PASSKEY_OPERATION_FAILED`: WebAuthn failed, was cancelled, or returned an unexpected credential, or a required browser API (the credential API, Web Crypto) is unavailable.
+ * - `PASSKEY_OPERATION_FAILED`: WebAuthn failed, was cancelled, returned an unexpected credential, or the credential API is unavailable.
+ * - `CRYPTO_UNAVAILABLE`: Web Crypto is unavailable.
  * - `PRF_UNAVAILABLE`: the authenticator did not enable or return a usable 32-byte WebAuthn PRF output.
  * - `SESSION_LOCKED`: a signing call was made after `lock()`.
  * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key, or tampered ciphertext or additional authenticated data).
@@ -10,6 +11,7 @@
  */
 type MeraErrorCode =
   | "PASSKEY_OPERATION_FAILED"
+  | "CRYPTO_UNAVAILABLE"
   | "PRF_UNAVAILABLE"
   | "SESSION_LOCKED"
   | "DECRYPT_FAILED"

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -104,6 +104,7 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * a required resident key, and required user verification.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or returns a malformed create-time PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function createPasskey({
@@ -211,6 +212,7 @@ async function createPasskey({
  * salt yields an unrelated output.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `credentialId` is empty or not canonical base64url.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function getPasskeyPrfOutput({
@@ -307,6 +309,7 @@ async function getPasskeyPrfOutput({
  * directly keeps the credential ID across that failure.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or does not return PRF output on the fallback ceremony.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function createPasskeyWithPrfOutput({

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -221,7 +221,7 @@ type CreateSecretVaultInput = {
  * @param options - Credential material and the secret to wrap; fields are documented on {@link CreateSecretVaultOptions}.
  * @returns A JSON-safe secret vault.
  * @throws MeraError with code `INPUT_INVALID` when the credential ID is empty or not canonical base64url, the PRF salt or output is not 32 bytes, or `secret` is empty.
- * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  */
 async function createSecretVault({
   credential,
@@ -287,7 +287,7 @@ type UnwrapSecretVaultInput = {
  * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`. The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it.
  * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
  * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
- * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  */
 async function unwrapSecretVault({
   vault,

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -6,7 +6,7 @@ import { MeraError } from "./errors.js";
  *
  * @param length - Number of random bytes to return.
  * @returns Cryptographically random bytes.
- * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  */
 function randomBytes(length: number): Uint8Array {
   const output = new Uint8Array(length);
@@ -18,14 +18,11 @@ function randomBytes(length: number): Uint8Array {
  * Returns the host Web Crypto implementation.
  *
  * @returns `globalThis.crypto` when Web Crypto is available.
- * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  */
 function getCrypto(): Crypto {
   if (!globalThis.crypto?.subtle || !globalThis.crypto.getRandomValues) {
-    throw new MeraError(
-      "PASSKEY_OPERATION_FAILED",
-      "Web Crypto is unavailable",
-    );
+    throw new MeraError("CRYPTO_UNAVAILABLE", "Web Crypto is unavailable");
   }
 
   return globalThis.crypto;
@@ -37,7 +34,7 @@ function getCrypto(): Crypto {
  * @param ikm - Input keying material.
  * @param info - HKDF info/context bytes; domain-separates keys derived from the same `ikm`.
  * @returns A non-extractable AES-GCM `CryptoKey` usable for encryption and decryption.
- * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when Web Crypto is unavailable.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  */
 async function hkdfSha256AesGcmKey(
   ikm: Uint8Array,

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
   copyPrfOutput,
+  createPasskey,
   createPasskeyWithPrfOutput,
   getPasskeyPrfOutput,
 } from "../dist/passkey.js";
@@ -10,6 +11,15 @@ const ORIGINAL_NAVIGATOR = Object.getOwnPropertyDescriptor(
   globalThis,
   "navigator",
 );
+const ORIGINAL_CRYPTO = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+
+function restoreGlobalCrypto(): void {
+  if (ORIGINAL_CRYPTO) {
+    Object.defineProperty(globalThis, "crypto", ORIGINAL_CRYPTO);
+  } else {
+    Reflect.deleteProperty(globalThis, "crypto");
+  }
+}
 
 test("copyPrfOutput copies a plain ArrayBuffer without aliasing", () => {
   const source = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
@@ -72,6 +82,43 @@ test("copyPrfOutput rejects PRF output that is not 32 bytes", () => {
   expectError(() => copyPrfOutput(new ArrayBuffer(33)), "PRF_UNAVAILABLE");
   // Valid byte values, so a plain array fails on length, not element checks.
   expectError(() => copyPrfOutput([1, 2, 3]), "PRF_UNAVAILABLE");
+});
+
+test("passkey helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable", async () => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: undefined,
+  });
+
+  try {
+    const user = { name: "nad", displayName: "nad" };
+    const prfSalt = new Uint8Array(32);
+
+    await expect(
+      createPasskey({
+        rp: { id: "example.com", name: "Mera Test" },
+        user,
+        prfSalt,
+      }),
+    ).rejects.toMatchObject({ code: "CRYPTO_UNAVAILABLE" });
+
+    await expect(
+      getPasskeyPrfOutput({
+        rpId: "example.com",
+        prfSalt,
+      }),
+    ).rejects.toMatchObject({ code: "CRYPTO_UNAVAILABLE" });
+
+    await expect(
+      createPasskeyWithPrfOutput({
+        rp: { id: "example.com", name: "Mera Test" },
+        user,
+        prfSalt,
+      }),
+    ).rejects.toMatchObject({ code: "CRYPTO_UNAVAILABLE" });
+  } finally {
+    restoreGlobalCrypto();
+  }
 });
 
 test("getPasskeyPrfOutput rejects an empty credentialId without prompting", async () => {

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -10,6 +10,7 @@ import { expectError } from "./helpers.js";
 
 const PRF_OUTPUT = new Uint8Array(32).fill(7);
 const PRF_SALT = new Uint8Array(32).fill(9);
+const ORIGINAL_CRYPTO = Object.getOwnPropertyDescriptor(globalThis, "crypto");
 // A real 12-word BIP-39 phrase stands in for an opaque secret; the library
 // neither knows nor cares that these bytes are a mnemonic.
 const SECRET = utf8ToBytes(
@@ -28,6 +29,14 @@ async function createTestVault(
     },
     secret,
   });
+}
+
+function restoreGlobalCrypto(): void {
+  if (ORIGINAL_CRYPTO) {
+    Object.defineProperty(globalThis, "crypto", ORIGINAL_CRYPTO);
+  } else {
+    Reflect.deleteProperty(globalThis, "crypto");
+  }
 }
 
 test("creates a secret vault and unwraps the exact bytes", async () => {
@@ -77,6 +86,26 @@ test("unwrapSecretVault fails with the wrong PRF output", async () => {
   await expect(
     unwrapSecretVault({ vault, prfOutput: new Uint8Array(32).fill(1) }),
   ).rejects.toMatchObject({ code: "DECRYPT_FAILED" });
+});
+
+test("secret vault helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable", async () => {
+  const vault = await createTestVault();
+
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: undefined,
+  });
+
+  try {
+    await expect(createTestVault()).rejects.toMatchObject({
+      code: "CRYPTO_UNAVAILABLE",
+    });
+    await expect(
+      unwrapSecretVault({ vault, prfOutput: PRF_OUTPUT }),
+    ).rejects.toMatchObject({ code: "CRYPTO_UNAVAILABLE" });
+  } finally {
+    restoreGlobalCrypto();
+  }
 });
 
 test("secret vault AAD is independent of credential metadata and PRF salt", async () => {


### PR DESCRIPTION
## Motivation

Pure Web Crypto failures should not look like passkey ceremony failures. `PASSKEY_OPERATION_FAILED` was previously used when Web Crypto was missing, including in secret-vault helpers that do not invoke WebAuthn at all. That made the stable error code less literal and could show callers the wrong recovery message.

## What changed

- Added `CRYPTO_UNAVAILABLE` to `MeraErrorCode`.
- Updated Web Crypto helpers to throw `CRYPTO_UNAVAILABLE` when `globalThis.crypto`, `subtle`, or `getRandomValues` is unavailable.
- Updated public JSDoc on passkey and secret-vault APIs to document the new thrown code.
- Added demo messaging for the new code.
- Added tests for missing Web Crypto through passkey helpers and secret-vault helpers.

## Public API impact

This is a pre-release breaking error-code change: callers that handled missing Web Crypto as `PASSKEY_OPERATION_FAILED` should now handle `CRYPTO_UNAVAILABLE`. WebAuthn credential API absence, cancellation, failed ceremonies, and unexpected WebAuthn results remain `PASSKEY_OPERATION_FAILED`.

## Verification

- `npm run build`
- `npm exec -- tsc -p tsconfig.test.json`
- `npx playwright test test/passkey.test.ts test/secret.test.ts`
- `npm test` (passed outside sandbox so Playwright could launch Chromium)
- `npm run check`
- `npm --cache /private/tmp/mera-npm-cache run check:pack`
