### PR TITLE
[codex] Use credential metadata for PRF assertions

### DIFF
--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -178,8 +178,14 @@ async function openDerived(): Promise<ConnectResult> {
   const prfSalt = getDeterministicPrfSaltV1();
   const { prfOutput, credentialId } = await getPasskeyPrfOutput({
     rpId,
-    ...(known?.credentialId ? { credentialId: known.credentialId } : {}),
-    ...(known?.transports ? { transports: known.transports } : {}),
+    ...(known?.credentialId
+      ? {
+          credential: {
+            credentialId: known.credentialId,
+            ...(known.transports ? { transports: known.transports } : {}),
+          },
+        }
+      : {}),
     prfSalt,
   });
 
@@ -341,9 +347,16 @@ async function revealMnemonic(wallet: ConnectedWallet): Promise<string> {
   const prfSalt = getDeterministicPrfSaltV1();
   const { prfOutput } = await getPasskeyPrfOutput({
     rpId,
-    ...(wallet.credentialId ? { credentialId: wallet.credentialId } : {}),
-    ...(record?.credentialId === wallet.credentialId && record?.transports
-      ? { transports: record.transports }
+    ...(wallet.credentialId
+      ? {
+          credential: {
+            credentialId: wallet.credentialId,
+            ...(record?.credentialId === wallet.credentialId &&
+            record?.transports
+              ? { transports: record.transports }
+              : {}),
+          },
+        }
       : {}),
     prfSalt,
   });

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -8,7 +8,7 @@ import { isMeraError, MeraError } from "./errors.js";
 import type {
   CreatePasskeyResult,
   CreatePasskeyWithPrfOutputResult,
-  PasskeyCredentialTransport,
+  PasskeyCredentialMetadata,
   PasskeyPrfResult,
 } from "./types.js";
 import { randomBytes } from "./webcrypto.js";
@@ -62,10 +62,8 @@ type CreatePasskeyWithPrfOutputInput = Omit<
 type GetPasskeyPrfOutputInput = {
   /** Relying party ID for the WebAuthn assertion. */
   rpId: string;
-  /** Optional credential ID (canonical unpadded base64url) to restrict the assertion to one passkey. */
-  credentialId?: string;
-  /** Optional transports associated with `credentialId`. */
-  transports?: PasskeyCredentialTransport[];
+  /** Optional credential metadata to restrict the assertion to one passkey. */
+  credential?: PasskeyCredentialMetadata;
   /** PRF salt as 32 raw bytes. */
   prfSalt: Uint8Array;
   /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
@@ -199,7 +197,7 @@ async function createPasskey({
 /**
  * Requests a passkey PRF evaluation and returns the first output.
  *
- * When `credentialId` is omitted, WebAuthn may choose any discoverable credential for the relying party.
+ * When `credential` is omitted, WebAuthn may choose any discoverable credential for the relying party.
  *
  * @param options - Passkey PRF request inputs; fields are documented on {@link GetPasskeyPrfOutputOptions}.
  * @returns The selected credential ID and first WebAuthn PRF output.
@@ -211,14 +209,13 @@ async function createPasskey({
  * `prfSalt`: the same three inputs reproduce the same output, and a different
  * salt yields an unrelated output.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
- * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `credentialId` is empty or not canonical base64url.
+ * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function getPasskeyPrfOutput({
   rpId,
-  credentialId,
-  transports,
+  credential: allowCredential,
   prfSalt,
   challenge = randomBytes(32),
   timeout,
@@ -240,7 +237,7 @@ async function getPasskeyPrfOutput({
       extensions: { prf },
     };
 
-    if (credentialId !== undefined) {
+    if (allowCredential !== undefined) {
       // WebAuthn floors only randomly generated credential IDs at 16 bytes;
       // the encrypted-credential-source form has no stated minimum, so only
       // emptiness is rejected here: an empty ID must not silently widen the
@@ -250,10 +247,14 @@ async function getPasskeyPrfOutput({
       publicKey.allowCredentials = [
         {
           id: asArrayBuffer(
-            base64UrlDecode(credentialId, { minByteLength: 1 }),
+            base64UrlDecode(allowCredential.credentialId, {
+              minByteLength: 1,
+            }),
           ),
           type: "public-key",
-          transports: transports as AuthenticatorTransport[] | undefined,
+          transports: allowCredential.transports as
+            | AuthenticatorTransport[]
+            | undefined,
         },
       ];
     }
@@ -336,8 +337,12 @@ async function createPasskeyWithPrfOutput({
     (
       await getPasskeyPrfOutput({
         rpId: rp.id,
-        credentialId: credential.credentialId,
-        transports: credential.transports,
+        credential: {
+          credentialId: credential.credentialId,
+          ...(credential.transports !== undefined
+            ? { transports: credential.transports }
+            : {}),
+        },
         prfSalt: prfSaltCopy,
         timeout,
       })

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -414,8 +414,7 @@ async function getSecretVaultPrfOutput({
 }: GetSecretVaultPrfOutputInput): Promise<PasskeyPrfResult> {
   return getPasskeyPrfOutput({
     rpId,
-    credentialId: vault.credential.credentialId,
-    transports: vault.credential.transports,
+    credential: vault.credential,
     prfSalt: base64UrlDecode(vault.prfSalt),
     challenge,
     timeout,

--- a/test/passkey.e2e.ts
+++ b/test/passkey.e2e.ts
@@ -52,10 +52,10 @@ test("creates a PRF-capable passkey and returns stable PRF output @e2e", async (
       });
       const second = await mera.getPasskeyPrfOutput({
         rpId: "localhost",
-        credentialId: credential.credentialId,
+        credential,
         prfSalt: salt,
       });
-      // No credentialId: WebAuthn selects a discoverable credential for the
+      // No credential: WebAuthn selects a discoverable credential for the
       // relying party, so this is a distinct path from the pinned call above.
       const discovered = await mera.getPasskeyPrfOutput({
         rpId: "localhost",
@@ -63,7 +63,7 @@ test("creates a PRF-capable passkey and returns stable PRF output @e2e", async (
       });
       const other = await mera.getPasskeyPrfOutput({
         rpId: "localhost",
-        credentialId: credential.credentialId,
+        credential,
         prfSalt: otherSalt,
       });
 
@@ -109,7 +109,7 @@ test("createPasskeyWithPrfOutput returns the first PRF output in one call @e2e",
       // Same salt against the same credential reproduces the PRF output.
       const repeated = await mera.getPasskeyPrfOutput({
         rpId: "localhost",
-        credentialId: created.credentialId,
+        credential: created,
         prfSalt: created.prfSalt,
       });
 

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -142,7 +142,7 @@ test("getPasskeyPrfOutput rejects an empty credentialId without prompting", asyn
     await expect(
       getPasskeyPrfOutput({
         rpId: "example.com",
-        credentialId: "",
+        credential: { credentialId: "" },
         prfSalt: new Uint8Array(32),
       }),
     ).rejects.toMatchObject({ code: "INPUT_INVALID" });


### PR DESCRIPTION
## Motivation

`getPasskeyPrfOutput` accepted `credentialId` and `transports` as independent optional fields, but transports only matter when a credential ID is present. That left an ignored input combination and duplicated the existing exported `PasskeyCredentialMetadata` shape.

## What changed

- Replaced `credentialId?: string` and `transports?: PasskeyCredentialTransport[]` with `credential?: PasskeyCredentialMetadata`.
- Kept discoverable credential behavior unchanged when `credential` is omitted.
- Updated `createPasskeyWithPrfOutput` and `getSecretVaultPrfOutput` to pass credential metadata as one object.
- Updated demo, unit tests, and e2e tests to use the new pinned-credential shape.

## Public API impact

This is a pre-release breaking options-shape change for `getPasskeyPrfOutput`. Pinned assertions now pass `credential: { credentialId, transports? }`; unpinned discoverable assertions still omit the field entirely.

## Verification

- `npm run build`
- `npm exec -- tsc -p tsconfig.test.json`
- `npx playwright test test/passkey.test.ts test/passkey.e2e.ts` (passed outside sandbox for e2e Chromium launch)
- `npm test` (passed outside sandbox so Playwright could launch Chromium)
- `npm run check`
- `npm --cache /private/tmp/mera-npm-cache run check:pack`
