### PR TITLE
[codex] Remove inert WebAuthn ceremony options

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -26,12 +26,8 @@ type CreatePasskeyInput = {
     /** Human-readable display name for the authenticator UI. */
     displayName: string;
   };
-  /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
-  challenge?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
   timeout?: number;
-  /** WebAuthn attestation preference. Defaults to `"none"`. */
-  attestation?: AttestationConveyancePreference;
   /**
    * Optional 32-byte PRF salt to evaluate during creation. Authenticators that
    * do not support PRF eval at create time silently ignore it and the result
@@ -66,8 +62,6 @@ type GetPasskeyPrfOutputInput = {
   credential?: PasskeyCredentialMetadata;
   /** PRF salt as 32 raw bytes. */
   prfSalt: Uint8Array;
-  /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
-  challenge?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
   timeout?: number;
 };
@@ -98,8 +92,12 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * Invokes `navigator.credentials.create()`, which may show browser or
  * authenticator UI and create a discoverable passkey.
  *
+ * The WebAuthn challenge is generated internally. The raw attestation response
+ * is not returned.
+ *
  * The credential is requested with fixed parameters: ES256 or RS256 key types,
- * a required resident key, and required user verification.
+ * attestation `"none"`, a required resident key, and required user
+ * verification.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or returns a malformed create-time PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -108,12 +106,12 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
 async function createPasskey({
   rp,
   user,
-  challenge = randomBytes(32),
   timeout,
-  attestation = "none",
   prfSalt,
 }: CreatePasskeyInput): Promise<CreatePasskeyResult> {
   try {
+    const challenge = randomBytes(32);
+
     assertCredentialApiAvailable();
 
     if (prfSalt !== undefined && prfSalt.length !== 32) {
@@ -141,7 +139,7 @@ async function createPasskey({
           { type: "public-key", alg: -257 },
         ],
         timeout,
-        attestation,
+        attestation: "none",
         authenticatorSelection: {
           residentKey: "required",
           requireResidentKey: true,
@@ -205,6 +203,9 @@ async function createPasskey({
  * Invokes `navigator.credentials.get()`, which may show browser or
  * authenticator UI.
  *
+ * The WebAuthn challenge is generated internally. The raw assertion response is
+ * not returned.
+ *
  * The PRF output is a deterministic function of the credential, `rpId`, and
  * `prfSalt`: the same three inputs reproduce the same output, and a different
  * salt yields an unrelated output.
@@ -217,10 +218,11 @@ async function getPasskeyPrfOutput({
   rpId,
   credential: allowCredential,
   prfSalt,
-  challenge = randomBytes(32),
   timeout,
 }: GetPasskeyPrfOutputInput): Promise<PasskeyPrfResult> {
   try {
+    const challenge = randomBytes(32);
+
     assertCredentialApiAvailable();
 
     if (prfSalt.length !== 32) {
@@ -301,6 +303,9 @@ async function getPasskeyPrfOutput({
  * evaluate PRF during creation, also invokes `navigator.credentials.get()` — a
  * second browser prompt.
  *
+ * WebAuthn challenges are generated internally. Raw attestation and assertion
+ * responses are not returned.
+ *
  * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of
  * the input does not change the fallback ceremony or returned salt.
  *
@@ -316,9 +321,7 @@ async function getPasskeyPrfOutput({
 async function createPasskeyWithPrfOutput({
   rp,
   user,
-  challenge,
   timeout,
-  attestation,
   prfSalt,
 }: CreatePasskeyWithPrfOutputInput): Promise<CreatePasskeyWithPrfOutputResult> {
   const prfSaltCopy = copyBytes(prfSalt);
@@ -326,9 +329,7 @@ async function createPasskeyWithPrfOutput({
   const credential = await createPasskey({
     rp,
     user,
-    challenge,
     timeout,
-    attestation,
     prfSalt: prfSaltCopy,
   });
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -387,8 +387,6 @@ type GetSecretVaultPrfOutputInput = {
   rpId: string;
   /** Parsed secret vault. */
   vault: PasskeySecretVault;
-  /** WebAuthn challenge. Defaults to 32 cryptographically random bytes. */
-  challenge?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
   timeout?: number;
 };
@@ -401,22 +399,26 @@ type GetSecretVaultPrfOutputInput = {
  *
  * @param options - Secret-vault PRF inputs; fields are documented on {@link GetSecretVaultPrfOutputOptions}.
  * @returns The selected credential ID and first WebAuthn PRF output.
- * @remarks Invokes `navigator.credentials.get()`, which may show browser or authenticator UI.
+ * @remarks
+ * Invokes `navigator.credentials.get()`, which may show browser or
+ * authenticator UI.
+ *
+ * The WebAuthn challenge is generated internally and the raw assertion
+ * response is not returned.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when the vault's `prfSalt` or `credentialId` is not canonical base64url (already validated for vaults from `parseSecretVault`).
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 async function getSecretVaultPrfOutput({
   rpId,
   vault,
-  challenge,
   timeout,
 }: GetSecretVaultPrfOutputInput): Promise<PasskeyPrfResult> {
   return getPasskeyPrfOutput({
     rpId,
     credential: vault.credential,
     prfSalt: base64UrlDecode(vault.prfSalt),
-    challenge,
     timeout,
   });
 }

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -121,6 +121,81 @@ test("passkey helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable",
   }
 });
 
+test("passkey helpers generate internal challenges and request no attestation", async () => {
+  let createOptions: PublicKeyCredentialCreationOptions | undefined;
+  let getOptions: PublicKeyCredentialRequestOptions | undefined;
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      credentials: {
+        async create({ publicKey }: CredentialCreationOptions) {
+          createOptions = publicKey;
+          return {
+            type: "public-key",
+            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+            response: {
+              getTransports: () => ["internal"],
+            },
+            getClientExtensionResults: () => ({
+              prf: {
+                enabled: true,
+                results: { first: new Uint8Array(32).buffer },
+              },
+            }),
+          };
+        },
+        async get({ publicKey }: CredentialRequestOptions) {
+          getOptions = publicKey;
+          return {
+            type: "public-key",
+            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+            getClientExtensionResults: () => ({
+              prf: { results: { first: new Uint8Array(32).buffer } },
+            }),
+          };
+        },
+      },
+    },
+  });
+
+  try {
+    await createPasskey({
+      rp: { id: "example.com", name: "Mera Test" },
+      user: {
+        id: new Uint8Array([1]),
+        name: "nad",
+        displayName: "nad",
+      },
+      prfSalt: new Uint8Array(32),
+    });
+    await getPasskeyPrfOutput({
+      rpId: "example.com",
+      prfSalt: new Uint8Array(32),
+    });
+
+    if (createOptions === undefined || getOptions === undefined) {
+      throw new Error("expected WebAuthn options to be captured");
+    }
+
+    expect(createOptions.challenge).toBeInstanceOf(ArrayBuffer);
+    expect(new Uint8Array(createOptions.challenge as ArrayBuffer)).toHaveLength(
+      32,
+    );
+    expect(createOptions.attestation).toBe("none");
+    expect(getOptions.challenge).toBeInstanceOf(ArrayBuffer);
+    expect(new Uint8Array(getOptions.challenge as ArrayBuffer)).toHaveLength(
+      32,
+    );
+  } finally {
+    if (ORIGINAL_NAVIGATOR) {
+      Object.defineProperty(globalThis, "navigator", ORIGINAL_NAVIGATOR);
+    } else {
+      Reflect.deleteProperty(globalThis, "navigator");
+    }
+  }
+});
+
 test("getPasskeyPrfOutput rejects an empty credentialId without prompting", async () => {
   // A malformed stored ID must fail closed instead of silently widening the
   // assertion to any discoverable credential for the relying party.


### PR DESCRIPTION
## Motivation

`challenge` and `attestation` were public inputs, but this SDK does not return raw WebAuthn attestation or assertion responses. That means caller-supplied challenges and attestation preferences had no observable SDK output in the current client-side-only API.

## What changed

- Removed public `challenge` options from passkey PRF and secret-vault PRF APIs.
- Removed public `attestation` from passkey creation options.
- Generate fresh 32-byte WebAuthn challenges internally.
- Always request `attestation: "none"` for passkey creation.
- Document that raw attestation/assertion responses are not returned.
- Added a unit test that captures WebAuthn options and verifies internal challenge generation plus fixed no-attestation behavior.

## Public API impact

This is a pre-release breaking options-shape change. Consumers can no longer pass WebAuthn challenges or attestation preferences through these client-side helpers. If server-verified ceremonies become an intended workflow later, the API should add both caller challenge input and returned raw WebAuthn response data together.

## Verification

- `npm run build`
- `npm exec -- tsc -p tsconfig.test.json`
- `npx playwright test test/passkey.test.ts`
- `npm test` (passed outside sandbox so Playwright could launch Chromium)
- `npm run check`
- `npm --cache /private/tmp/mera-npm-cache run check:pack`
