### PR TITLE
[codex] Clarify passkey user handle default

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -19,7 +19,17 @@ type CreatePasskeyInput = {
   rp: PublicKeyCredentialRpEntity;
   /** User identity passed to WebAuthn. `id` is copied before use. */
   user: {
-    /** Stable user handle for the relying party. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). Defaults to 32 cryptographically random bytes. */
+    /**
+     * User handle for the relying party. Must be 1 to 64 bytes when provided
+     * (WebAuthn's user-handle limit).
+     *
+     * Authenticators key discoverable credentials by `(rp.id, user.id)`.
+     * Passing the same `rp.id` and `user.id` lets creation replace the existing
+     * passkey for that user handle. When omitted, a fresh 32-byte random handle
+     * is generated for each call, so repeated calls add parallel passkeys
+     * instead of replacing one, and the generated handle is not correlated with
+     * an app account.
+     */
     id?: Uint8Array;
     /** User name displayed or stored by the authenticator. */
     name: string;

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -23,12 +23,10 @@ type CreatePasskeyInput = {
      * User handle for the relying party. Must be 1 to 64 bytes when provided
      * (WebAuthn's user-handle limit).
      *
-     * Authenticators key discoverable credentials by `(rp.id, user.id)`.
-     * Passing the same `rp.id` and `user.id` lets creation replace the existing
-     * passkey for that user handle. When omitted, a fresh 32-byte random handle
-     * is generated for each call, so repeated calls add parallel passkeys
-     * instead of replacing one, and the generated handle is not correlated with
-     * an app account.
+     * This value is stored as the WebAuthn user handle for the discoverable
+     * credential. When omitted, a fresh 32-byte random handle is generated for
+     * each call, so repeated calls do not share a stable user handle. The
+     * generated handle is not correlated with an app account.
      */
     id?: Uint8Array;
     /** User name displayed or stored by the authenticator. */


### PR DESCRIPTION
## Motivation

`user.id` defaults to fresh random bytes, which is a privacy-preserving default for account-less PRF flows. The old field docs called the handle "stable" while also saying it defaulted randomly, which made the default behavior unclear.

## What changed

- Expanded the `user.id` JSDoc on passkey creation options.
- Clarified that a provided `user.id` is stored as the WebAuthn user handle for the discoverable credential.
- Clarified that omitting `user.id` generates a fresh 32-byte random handle each call, so repeated calls do not share a stable user handle.
- Clarified that the generated handle is not correlated with an app account.

## Public API impact

No runtime or type behavior changes. This only clarifies the existing optional `user.id` default.

## Verification

- `npm test`
- `npm run check`
- `npm --cache /private/tmp/mera-npm-cache run check:pack`
