### PR TITLE
Strengthen static typing across the public API

### DIFF
--- a/demo/src/registry.ts
+++ b/demo/src/registry.ts
@@ -11,7 +11,7 @@ import type { PasskeyCredentialTransport } from "@category-labs/mera";
  */
 type DerivedWalletRecord = {
   credentialId: string;
-  transports?: PasskeyCredentialTransport[];
+  transports?: readonly PasskeyCredentialTransport[];
   label: string;
   accountCount: number;
 };

--- a/src/chains/evm.ts
+++ b/src/chains/evm.ts
@@ -41,10 +41,13 @@ function isEvmAddress(value: string): value is EvmAddress {
 function toChecksumAddress(lowercaseHex: string): EvmAddress {
   const hash = keccak_256(utf8ToBytes(lowercaseHex));
   let body = "";
-  for (let i = 0; i < lowercaseHex.length; i += 1) {
-    const char = lowercaseHex[i];
-    const hashNibble = (hash[i >> 1] >> (i % 2 === 0 ? 4 : 0)) & 0xf;
-    body += hashNibble >= 8 ? char.toUpperCase() : char;
+  for (const [i, hashByte] of hash
+    .subarray(0, lowercaseHex.length / 2)
+    .entries()) {
+    const high = lowercaseHex.charAt(i * 2);
+    const low = lowercaseHex.charAt(i * 2 + 1);
+    body += hashByte >> 4 >= 8 ? high.toUpperCase() : high;
+    body += (hashByte & 0xf) >= 8 ? low.toUpperCase() : low;
   }
   return `0x${body}`;
 }

--- a/src/derived.ts
+++ b/src/derived.ts
@@ -18,7 +18,7 @@ const DETERMINISTIC_PRF_SALT = sha256(DETERMINISTIC_PRF_DOMAIN);
  * frozen, so a shared buffer mutated by one caller would silently change every
  * later derivation.
  */
-function getDeterministicPrfSaltV1(): Uint8Array {
+function getDeterministicPrfSaltV1(): Uint8Array<ArrayBuffer> {
   return new Uint8Array(DETERMINISTIC_PRF_SALT);
 }
 

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -16,7 +16,7 @@ import type {
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
  * @internal
  */
-function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array {
+function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array<ArrayBuffer> {
   if (privateKey.length !== 32) {
     throw new MeraError(
       "INPUT_INVALID",
@@ -51,7 +51,7 @@ function createEd25519SigningSession({
 
   return {
     publicKey,
-    async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    async signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
       // Signing reads the buffer after an await; copy it now so a later mutation can't change the signed bytes.
       const messageCopy = copyBytes(message);
       return new Uint8Array(await ed25519.signAsync(messageCopy, key.use()));

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -9,7 +9,7 @@ import { MeraError } from "./errors.js";
  * @param value - Bytes to copy.
  * @returns A new `Uint8Array` with the same bytes as `value`.
  */
-function copyBytes(value: Uint8Array): Uint8Array {
+function copyBytes(value: Uint8Array): Uint8Array<ArrayBuffer> {
   return new Uint8Array(value);
 }
 

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -124,15 +124,9 @@ function createPasskey(
  * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
  * @returns Credential metadata for the created passkey.
  * @remarks
- * Invokes `navigator.credentials.create()`, which may show browser or
- * authenticator UI and create a discoverable passkey.
- *
- * The WebAuthn challenge is generated internally. The raw attestation response
- * is not returned.
- *
- * The credential is requested with fixed parameters: ES256 or RS256 key types,
- * attestation `"none"`, a required resident key, and required user
- * verification.
+ * The ceremony is the one documented on the `prfSalt` overload: the same
+ * browser or authenticator UI, internally generated challenge, and fixed
+ * WebAuthn parameters, minus the PRF salt evaluation.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF.
  * @throws MeraError with code `INPUT_INVALID` when `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -90,9 +90,9 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
 /**
  * Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
  *
- * When `prfSalt` is provided and the authenticator evaluates PRF at create
- * time, the result includes the first PRF output, so no second ceremony is
- * needed to open a derived account.
+ * When the authenticator evaluates PRF at create time, the result includes the
+ * first PRF output for `prfSalt`, so no second ceremony is needed to open a
+ * derived account.
  *
  * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
  * @returns Credential metadata, plus the first PRF output when it was evaluated during creation.
@@ -107,10 +107,40 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * attestation `"none"`, a required resident key, and required user
  * verification.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or returns a malformed create-time PRF output.
- * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
+function createPasskey(
+  options: CreatePasskeyInput & { prfSalt: Uint8Array },
+): Promise<CreatePasskeyResult>;
+/**
+ * Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
+ *
+ * Without `prfSalt`, no PRF evaluation happens during creation, so the result
+ * carries credential metadata only; a later `getPasskeyPrfOutput` call with a
+ * salt produces PRF output for this passkey.
+ *
+ * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
+ * @returns Credential metadata for the created passkey.
+ * @remarks
+ * Invokes `navigator.credentials.create()`, which may show browser or
+ * authenticator UI and create a discoverable passkey.
+ *
+ * The WebAuthn challenge is generated internally. The raw attestation response
+ * is not returned.
+ *
+ * The credential is requested with fixed parameters: ES256 or RS256 key types,
+ * attestation `"none"`, a required resident key, and required user
+ * verification.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF.
+ * @throws MeraError with code `INPUT_INVALID` when `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ */
+function createPasskey(
+  options: Omit<CreatePasskeyInput, "prfSalt">,
+): Promise<PasskeyCredentialMetadata>;
 async function createPasskey({
   rp,
   user,
@@ -146,7 +176,7 @@ async function createPasskey({
           { type: "public-key", alg: -7 },
           { type: "public-key", alg: -257 },
         ],
-        timeout,
+        ...(timeout !== undefined ? { timeout } : {}),
         attestation: "none",
         authenticatorSelection: {
           residentKey: "required",
@@ -176,19 +206,13 @@ async function createPasskey({
         ? response.getTransports()
         : undefined;
 
-    const result: CreatePasskeyResult = {
+    return {
       credentialId: base64UrlEncode(new Uint8Array(publicKeyCredential.rawId)),
+      ...(transports !== undefined ? { transports } : {}),
+      ...(prfSalt !== undefined && prf.results?.first
+        ? { prfOutput: copyPrfOutput(prf.results.first) }
+        : {}),
     };
-
-    if (transports !== undefined) {
-      result.transports = transports;
-    }
-
-    if (prfSalt !== undefined && prf.results?.first) {
-      result.prfOutput = copyPrfOutput(prf.results.first);
-    }
-
-    return result;
   } catch (error) {
     if (isMeraError(error)) {
       throw error;
@@ -242,7 +266,7 @@ async function getPasskeyPrfOutput({
     const publicKey: PublicKeyCredentialRequestOptions = {
       rpId,
       challenge: asArrayBuffer(challenge),
-      timeout,
+      ...(timeout !== undefined ? { timeout } : {}),
       userVerification: "required",
       extensions: { prf },
     };
@@ -262,9 +286,12 @@ async function getPasskeyPrfOutput({
             }),
           ),
           type: "public-key",
-          transports: allowCredential.transports as
-            | AuthenticatorTransport[]
-            | undefined,
+          ...(allowCredential.transports !== undefined
+            ? {
+                transports:
+                  allowCredential.transports as AuthenticatorTransport[],
+              }
+            : {}),
         },
       ];
     }
@@ -337,7 +364,7 @@ async function createPasskeyWithPrfOutput({
   const credential = await createPasskey({
     rp,
     user,
-    timeout,
+    ...(timeout !== undefined ? { timeout } : {}),
     prfSalt: prfSaltCopy,
   });
 
@@ -353,21 +380,18 @@ async function createPasskeyWithPrfOutput({
             : {}),
         },
         prfSalt: prfSaltCopy,
-        timeout,
+        ...(timeout !== undefined ? { timeout } : {}),
       })
     ).prfOutput;
 
-  const result: CreatePasskeyWithPrfOutputResult = {
+  return {
     credentialId: credential.credentialId,
+    ...(credential.transports !== undefined
+      ? { transports: credential.transports }
+      : {}),
     prfSalt: prfSaltCopy,
     prfOutput,
   };
-
-  if (credential.transports !== undefined) {
-    result.transports = credential.transports;
-  }
-
-  return result;
 }
 
 /**
@@ -428,15 +452,17 @@ function assertPublicKeyCredential(
  * [0, 255].
  * @internal
  */
-function copyPrfOutput(value: BufferSource | ArrayLike<number>): Uint8Array {
-  let output: Uint8Array;
+function copyPrfOutput(
+  value: BufferSource | ArrayLike<number>,
+): Uint8Array<ArrayBuffer> {
+  let output: Uint8Array<ArrayBuffer>;
 
   if (ArrayBuffer.isView(value)) {
-    output = new Uint8Array(
-      value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength),
+    output = copyBytes(
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength),
     );
   } else if (value instanceof ArrayBuffer) {
-    output = new Uint8Array(value.slice(0));
+    output = copyBytes(new Uint8Array(value));
   } else {
     output = Uint8Array.from(value, (byte) => {
       if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
@@ -456,8 +482,13 @@ function copyPrfOutput(value: BufferSource | ArrayLike<number>): Uint8Array {
   return output;
 }
 
-/** Options accepted by `createPasskey`. */
-type CreatePasskeyOptions = Parameters<typeof createPasskey>[0];
+/**
+ * Options accepted by `createPasskey`.
+ *
+ * Aliased directly rather than via `Parameters<typeof createPasskey>[0]`
+ * because `Parameters` sees only the last overload.
+ */
+type CreatePasskeyOptions = CreatePasskeyInput;
 /** Options accepted by `createPasskeyWithPrfOutput`. */
 type CreatePasskeyWithPrfOutputOptions = Parameters<
   typeof createPasskeyWithPrfOutput

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -133,8 +133,21 @@ function createPasskey(
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
 function createPasskey(
-  options: Omit<CreatePasskeyInput, "prfSalt">,
+  options: Omit<CreatePasskeyInput, "prfSalt"> & { prfSalt?: never },
 ): Promise<PasskeyCredentialMetadata>;
+/**
+ * Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
+ *
+ * Fallback overload for options where `prfSalt` presence is not statically
+ * known. The ceremony and failure modes are the ones documented on the
+ * `prfSalt` overload, with the salt evaluated only when present.
+ *
+ * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
+ * @returns Credential metadata, plus the first PRF output when `prfSalt` was provided and evaluated during creation.
+ */
+function createPasskey(
+  options: CreatePasskeyInput,
+): Promise<CreatePasskeyResult>;
 async function createPasskey({
   rp,
   user,

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -17,7 +17,9 @@ import type {
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
  * @internal
  */
-function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
+function getSecp256k1PublicKey(
+  privateKey: Uint8Array,
+): Uint8Array<ArrayBuffer> {
   try {
     return new Uint8Array(secp.getPublicKey(privateKey, false));
   } catch (cause) {
@@ -37,7 +39,9 @@ function getSecp256k1PublicKey(privateKey: Uint8Array): Uint8Array {
  * @throws MeraError with code `INPUT_INVALID` when the key length, prefix, or curve point is invalid.
  * @internal
  */
-function normalizeSecp256k1PublicKey(publicKey: Uint8Array): Uint8Array {
+function normalizeSecp256k1PublicKey(
+  publicKey: Uint8Array,
+): Uint8Array<ArrayBuffer> {
   try {
     return new Uint8Array(secp.Point.fromBytes(publicKey).toBytes(false));
   } catch (cause) {
@@ -84,7 +88,8 @@ function createSecp256k1SigningSession({
       // noble's "recovered" format is 65 bytes: the recovery ID, then r || s.
       return {
         compact: signature.slice(1),
-        recovery: signature[0],
+        // biome-ignore lint/style/noNonNullAssertion: the recovered format is fixed-width, so byte 0 always exists; noble types it as a plain Uint8Array.
+        recovery: signature[0]!,
       };
     },
     lock(): void {

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -44,7 +44,7 @@ function uint32Be(value: number): Uint8Array {
  * @param parts - Byte arrays to encode in order.
  * @returns A new byte array containing each part with a four-byte length prefix.
  */
-function canonicalEncode(parts: Uint8Array[]): Uint8Array {
+function canonicalEncode(parts: readonly Uint8Array[]): Uint8Array {
   return concatBytes(...parts.flatMap((part) => [uint32Be(part.length), part]));
 }
 
@@ -118,7 +118,7 @@ async function aesGcmDecrypt({
   encrypted: EncryptedBytes;
   wrappingKey: CryptoKey;
   aad: Uint8Array;
-}): Promise<Uint8Array> {
+}): Promise<Uint8Array<ArrayBuffer>> {
   try {
     const plaintext = await getCrypto().subtle.decrypt(
       {
@@ -192,7 +192,7 @@ type CreateSecretVaultInput = {
     /** Passkey credential ID as canonical unpadded base64url. */
     credentialId: string;
     /** Authenticator transports reported by the browser, when available. */
-    transports?: PasskeyCredentialTransport[];
+    transports?: readonly PasskeyCredentialTransport[];
     /** PRF salt for this secret. Must be exactly 32 bytes. */
     prfSalt: Uint8Array;
     /** First WebAuthn PRF output for `prfSalt`. Must be exactly 32 bytes. */
@@ -292,7 +292,7 @@ type UnwrapSecretVaultInput = {
 async function unwrapSecretVault({
   vault,
   prfOutput,
-}: UnwrapSecretVaultInput): Promise<Uint8Array> {
+}: UnwrapSecretVaultInput): Promise<Uint8Array<ArrayBuffer>> {
   const wrappingKey = await deriveWrappingKey(prfOutput);
 
   return aesGcmDecrypt({
@@ -341,7 +341,7 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     { min: 1 },
   );
 
-  const credential: PasskeySecretVault["credential"] = { credentialId };
+  let transports: PasskeyCredentialTransport[] | undefined;
 
   if (vault.credential.transports !== undefined) {
     if (
@@ -355,8 +355,13 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
         "credential.transports must be an array of strings or omitted",
       );
     }
-    credential.transports = [...vault.credential.transports];
+    transports = [...vault.credential.transports];
   }
+
+  const credential: PasskeySecretVault["credential"] = {
+    credentialId,
+    ...(transports !== undefined ? { transports } : {}),
+  };
 
   const prfSalt = readBase64Url(
     vault.prfSalt,
@@ -419,7 +424,7 @@ async function getSecretVaultPrfOutput({
     rpId,
     credential: vault.credential,
     prfSalt: base64UrlDecode(vault.prfSalt),
-    timeout,
+    ...(timeout !== undefined ? { timeout } : {}),
   });
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,7 @@ type LockableKey = {
    *
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
-  use(): Uint8Array;
+  use(): Uint8Array<ArrayBuffer>;
   /** Zeroes the session-owned key and permanently locks this handle. */
   lock(): void;
 };
@@ -33,9 +33,9 @@ type LockableKey = {
  */
 function createSigningKey(
   consumePrivateKey: Uint8Array,
-  derivePublicKey: (privateKey: Uint8Array) => Uint8Array,
-): { key: LockableKey; publicKey: Uint8Array } {
-  let activePrivateKey: Uint8Array | undefined;
+  derivePublicKey: (privateKey: Uint8Array) => Uint8Array<ArrayBuffer>,
+): { key: LockableKey; publicKey: Uint8Array<ArrayBuffer> } {
+  let activePrivateKey: Uint8Array<ArrayBuffer> | undefined;
 
   try {
     // Derive and store from the same owned snapshot, so the public key cannot
@@ -44,7 +44,7 @@ function createSigningKey(
     const publicKey = derivePublicKey(activePrivateKey);
 
     const key: LockableKey = {
-      use(): Uint8Array {
+      use(): Uint8Array<ArrayBuffer> {
         return requireUnlocked(activePrivateKey);
       },
       lock(): void {
@@ -71,7 +71,9 @@ function createSigningKey(
  * @returns The live session-owned private key.
  * @throws MeraError with code `SESSION_LOCKED` when `privateKey` is undefined.
  */
-function requireUnlocked(privateKey: Uint8Array | undefined): Uint8Array {
+function requireUnlocked(
+  privateKey: Uint8Array<ArrayBuffer> | undefined,
+): Uint8Array<ArrayBuffer> {
   if (privateKey === undefined) {
     throw new MeraError("SESSION_LOCKED", "Signing session is locked");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,23 +12,23 @@ type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});
 /** Metadata needed to ask WebAuthn for a previously created passkey. */
 type PasskeyCredentialMetadata = {
   /** Credential ID encoded as canonical unpadded base64url. */
-  credentialId: string;
+  readonly credentialId: string;
   /** Authenticator transports reported by the browser, when available. */
-  transports?: PasskeyCredentialTransport[];
+  readonly transports?: readonly PasskeyCredentialTransport[];
 };
 
 /** Result of a successful passkey assertion with the WebAuthn PRF extension. */
 type PasskeyPrfResult = {
   /** Credential ID selected by the browser, as canonical unpadded base64url. */
-  credentialId: string;
+  readonly credentialId: string;
   /** First PRF output from WebAuthn. Always 32 bytes. */
-  prfOutput: Uint8Array;
+  readonly prfOutput: Uint8Array<ArrayBuffer>;
 };
 
 /** Result of creating a passkey. */
 type CreatePasskeyResult = PasskeyCredentialMetadata & {
   /** First WebAuthn PRF output when `prfSalt` was provided and evaluated during creation. */
-  prfOutput?: Uint8Array;
+  readonly prfOutput?: Uint8Array<ArrayBuffer>;
 };
 
 /**
@@ -39,9 +39,9 @@ type CreatePasskeyResult = PasskeyCredentialMetadata & {
  */
 type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
   /** PRF salt that was evaluated. Always 32 bytes and never aliases the caller input. */
-  prfSalt: Uint8Array;
+  readonly prfSalt: Uint8Array<ArrayBuffer>;
   /** First WebAuthn PRF output for `prfSalt`. Always 32 bytes. */
-  prfOutput: Uint8Array;
+  readonly prfOutput: Uint8Array<ArrayBuffer>;
 };
 
 /**
@@ -51,23 +51,23 @@ type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
  */
 type PasskeySecretVault = {
   /** Secret-vault format version. */
-  version: 1;
+  readonly version: 1;
   /** Passkey credential that unlocks this secret. */
-  credential: PasskeyCredentialMetadata;
+  readonly credential: PasskeyCredentialMetadata;
   /** PRF salt for this secret, as canonical unpadded base64url. */
-  prfSalt: string;
+  readonly prfSalt: string;
   /** AES-GCM nonce as canonical unpadded base64url. */
-  nonce: string;
+  readonly nonce: string;
   /** AES-GCM ciphertext (including tag) as canonical unpadded base64url. */
-  ciphertext: string;
+  readonly ciphertext: string;
 };
 
 /** secp256k1 ECDSA signature returned by an unlocked signing session. */
 type Secp256k1Signature = {
   /** Compact 64-byte `r || s` ECDSA signature. */
-  compact: Uint8Array;
+  readonly compact: Uint8Array<ArrayBuffer>;
   /** Recovery ID (0 or 1) for the signature. */
-  recovery: number;
+  readonly recovery: number;
 };
 
 /** Inputs for creating an explicitly lockable curve signing session. */
@@ -83,7 +83,7 @@ type CreateSigningSessionOptions = {
 /** secp256k1 signing session that can sign 32-byte digests until `lock` is called. */
 type Secp256k1SigningSession = {
   /** Uncompressed secp256k1 public key for the session. */
-  publicKey: Uint8Array;
+  readonly publicKey: Uint8Array<ArrayBuffer>;
   /**
    * Signs a 32-byte digest without prehashing it.
    *
@@ -104,7 +104,7 @@ type Secp256k1SigningSession = {
 /** Ed25519 signing session that can sign messages until `lock` is called. */
 type Ed25519SigningSession = {
   /** 32-byte Ed25519 public key for the session. */
-  publicKey: Uint8Array;
+  readonly publicKey: Uint8Array<ArrayBuffer>;
   /**
    * Signs an arbitrary-length message with Ed25519.
    *
@@ -112,7 +112,7 @@ type Ed25519SigningSession = {
    * @returns A 64-byte Ed25519 signature (`R || s`).
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
-  signMessage(message: Uint8Array): Promise<Uint8Array>;
+  signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>>;
   /**
    * Zeroes the session-owned seed copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
    *

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -8,7 +8,7 @@ import { MeraError } from "./errors.js";
  * @returns Cryptographically random bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  */
-function randomBytes(length: number): Uint8Array {
+function randomBytes(length: number): Uint8Array<ArrayBuffer> {
   const output = new Uint8Array(length);
   getCrypto().getRandomValues(output);
   return output;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## What changed

Four related typing improvements, from an audit of underused TypeScript features:

**1. Stricter compiler flags.** Enabled `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` (neither is part of `strict`). The codebase already hand-enforced the exact-optional discipline via conditional spreads; the flag now makes the compiler own it, and it caught six sites passing explicit `undefined` for `timeout`/`transports`. The unchecked-index flag drove two fixes: the EIP-55 checksum loop now iterates hash bytes via `.entries()` (no unchecked indexing at all), and the noble recovered-signature byte read uses a single documented assertion bridging noble's `Uint8Array` typing of a fixed-width 65-byte format.

**2. `readonly` public result and vault types.** All result types (`PasskeySecretVault`, `PasskeyPrfResult`, `Secp256k1Signature`, session `publicKey`, etc.) and their `transports` arrays are now readonly. This complements — does not replace — the runtime copies: copies defend against buffer mutation across `await` at runtime; `readonly` catches accidental mutation at compile time and states the contract in the types. Required zero casts; four build-then-mutate sites restructured to the existing conditional-spread idiom.

**3. `Uint8Array<ArrayBuffer>` on buffer-producing returns.** Every returned buffer is a fresh allocation, so the ArrayBuffer backing is guaranteed — but bare `Uint8Array` return annotations widened it to `ArrayBufferLike` in the published `.d.ts`. Consumers on TS 5.7+ can now pass outputs straight to `BufferSource` APIs without widening errors. Inputs deliberately stay bare `Uint8Array`: ecosystem values are widely typed as `ArrayBufferLike` (e.g. `@scure/base` decode), and the internal copies already normalize the backing store. Strict in what we produce, liberal in what we accept.

**4. `createPasskey` overloads.** Calling without `prfSalt` now returns `Promise<PasskeyCredentialMetadata>` — no phantom optional `prfOutput` to dead-branch on. With `prfSalt` it returns `CreatePasskeyResult` as before.

## Reviewer notes

- `CreatePasskeyOptions` is now a direct alias of the input type instead of `Parameters<typeof createPasskey>[0]`, because `Parameters` sees only the last overload.
- `copyPrfOutput` copies views via a temporary aliasing view + `copyBytes` instead of `buffer.slice`; behavior is identical (fresh, never aliases input) but the result is provably `ArrayBuffer`-backed.
- The demo needed exactly one downstream fix for `readonly`: its own `DerivedWalletRecord.transports` field is now readonly too. This virality into consumer types is intentional.
- Verified: `npm run check`, `npm test` (56 passed, including e2e with virtual authenticator), plus demo typecheck.