### PR TITLE
Add a SolanaAddress type

### DIFF
--- a/src/chains/solana.ts
+++ b/src/chains/solana.ts
@@ -28,13 +28,6 @@ function getSolanaAddress(publicKey: Uint8Array): SolanaAddress {
  * @returns `true` when `value` decodes to 32 base58 bytes.
  */
 function isSolanaAddress(value: string): value is SolanaAddress {
-  // 32 bytes always encode to 32-44 base58 characters, so anything outside
-  // that range cannot be an address; checking first caps the cost of the
-  // big-integer base58 decode on arbitrarily long untrusted input.
-  if (value.length < 32 || value.length > 44) {
-    return false;
-  }
-
   try {
     return base58.decode(value).length === ED25519_PUBLIC_KEY_LENGTH;
   } catch {

--- a/src/chains/solana.ts
+++ b/src/chains/solana.ts
@@ -28,6 +28,13 @@ function getSolanaAddress(publicKey: Uint8Array): SolanaAddress {
  * @returns `true` when `value` decodes to 32 base58 bytes.
  */
 function isSolanaAddress(value: string): value is SolanaAddress {
+  // 32 bytes always encode to 32-44 base58 characters, so anything outside
+  // that range cannot be an address; checking first caps the cost of the
+  // big-integer base58 decode on arbitrarily long untrusted input.
+  if (value.length < 32 || value.length > 44) {
+    return false;
+  }
+
   try {
     return base58.decode(value).length === ED25519_PUBLIC_KEY_LENGTH;
   } catch {

--- a/src/chains/solana.ts
+++ b/src/chains/solana.ts
@@ -1,5 +1,6 @@
 import { base58 } from "@scure/base";
 import { MeraError } from "../errors.js";
+import type { SolanaAddress } from "../types.js";
 
 const ED25519_PUBLIC_KEY_LENGTH = 32;
 
@@ -10,12 +11,14 @@ const ED25519_PUBLIC_KEY_LENGTH = 32;
  * @returns The base58-encoded Solana address.
  * @throws MeraError with code `INPUT_INVALID` when `publicKey` is not 32 bytes.
  */
-function getSolanaAddress(publicKey: Uint8Array): string {
+function getSolanaAddress(publicKey: Uint8Array): SolanaAddress {
   if (publicKey.length !== ED25519_PUBLIC_KEY_LENGTH) {
     throw new MeraError("INPUT_INVALID", "Ed25519 public key must be 32 bytes");
   }
 
-  return base58.encode(publicKey);
+  // Mints the SolanaAddress brand: encoding 32 validated bytes is what the
+  // brand asserts, and a nominal brand cannot be produced without an assertion.
+  return base58.encode(publicKey) as SolanaAddress;
 }
 
 /**
@@ -24,7 +27,7 @@ function getSolanaAddress(publicKey: Uint8Array): string {
  * @param value - String to check.
  * @returns `true` when `value` decodes to 32 base58 bytes.
  */
-function isSolanaAddress(value: string): boolean {
+function isSolanaAddress(value: string): value is SolanaAddress {
   try {
     return base58.decode(value).length === ED25519_PUBLIC_KEY_LENGTH;
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,4 +38,5 @@ export type {
   PasskeySecretVault,
   Secp256k1Signature,
   Secp256k1SigningSession,
+  SolanaAddress,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,18 @@
  */
 type EvmAddress = `0x${string}`;
 
+declare const solanaAddressBrand: unique symbol;
+
+/**
+ * A base58-encoded 32-byte Solana address.
+ *
+ * Branded nominal type: base58 has no structural shape the way `EvmAddress`
+ * does, so values are produced by `getSolanaAddress` or narrowed from strings
+ * by `isSolanaAddress`. The brand exists only in the type system; at runtime
+ * the value is a plain string.
+ */
+type SolanaAddress = string & { readonly [solanaAddressBrand]: true };
+
 /** WebAuthn authenticator transport metadata, including future browser transport values. */
 type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});
 
@@ -145,4 +157,5 @@ export type {
   PasskeySecretVault,
   Secp256k1Signature,
   Secp256k1SigningSession,
+  SolanaAddress,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,17 +6,15 @@
  */
 type EvmAddress = `0x${string}`;
 
-declare const solanaAddressBrand: unique symbol;
-
 /**
  * A base58-encoded 32-byte Solana address.
  *
  * Branded nominal type: base58 has no structural shape the way `EvmAddress`
  * does, so values are produced by `getSolanaAddress` or narrowed from strings
  * by `isSolanaAddress`. The brand exists only in the type system; at runtime
- * the value is a plain string.
+ * the value is a plain string with no `__brand` property.
  */
-type SolanaAddress = string & { readonly [solanaAddressBrand]: true };
+type SolanaAddress = string & { readonly __brand: "SolanaAddress" };
 
 /** WebAuthn authenticator transport metadata, including future browser transport values. */
 type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,15 +6,26 @@
  */
 type EvmAddress = `0x${string}`;
 
+declare const brand: unique symbol;
+
+/**
+ * Nominal branding helper: tags `T` with a type-only discriminant.
+ *
+ * The symbol key is never exported, so branded values cannot be produced
+ * structurally or read back as a property; only the library functions
+ * documented on each branded type mint them. Nothing exists at runtime.
+ */
+type Brand<T, Name extends string> = T & { readonly [brand]: Name };
+
 /**
  * A base58-encoded 32-byte Solana address.
  *
  * Branded nominal type: base58 has no structural shape the way `EvmAddress`
  * does, so values are produced by `getSolanaAddress` or narrowed from strings
  * by `isSolanaAddress`. The brand exists only in the type system; at runtime
- * the value is a plain string with no `__brand` property.
+ * the value is a plain string.
  */
-type SolanaAddress = string & { readonly __brand: "SolanaAddress" };
+type SolanaAddress = Brand<string, "SolanaAddress">;
 
 /** WebAuthn authenticator transport metadata, including future browser transport values. */
 type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});

--- a/test/chains-solana.test.ts
+++ b/test/chains-solana.test.ts
@@ -37,14 +37,6 @@ test("rejects public keys of the wrong length", () => {
 
 test("isSolanaAddress rejects non-base58 strings and wrong-length payloads", () => {
   expect(isSolanaAddress("")).toBe(false);
-  expect(isSolanaAddress("0OIl".repeat(11))).toBe(false); // 44 chars, but base58 excludes 0 O I l
-  expect(isSolanaAddress("3")).toBe(false); // valid base58 char, but far too short for 32 bytes
-});
-
-test("isSolanaAddress accepts the character-length bounds of 32-byte payloads", () => {
-  // 32 zero bytes encode to the shortest possible address: one "1" per byte.
-  expect(isSolanaAddress("1".repeat(32))).toBe(true);
-  expect(isSolanaAddress("1".repeat(31))).toBe(false);
-  // 45 valid base58 chars exceed the 44-char maximum and are rejected before decoding.
-  expect(isSolanaAddress("2".repeat(45))).toBe(false);
+  expect(isSolanaAddress("0OIl")).toBe(false); // base58 excludes 0 O I l
+  expect(isSolanaAddress("3")).toBe(false); // valid base58 char, but decodes to <32 bytes
 });

--- a/test/chains-solana.test.ts
+++ b/test/chains-solana.test.ts
@@ -37,6 +37,14 @@ test("rejects public keys of the wrong length", () => {
 
 test("isSolanaAddress rejects non-base58 strings and wrong-length payloads", () => {
   expect(isSolanaAddress("")).toBe(false);
-  expect(isSolanaAddress("0OIl")).toBe(false); // base58 excludes 0 O I l
-  expect(isSolanaAddress("3")).toBe(false); // valid base58 char, but decodes to <32 bytes
+  expect(isSolanaAddress("0OIl".repeat(11))).toBe(false); // 44 chars, but base58 excludes 0 O I l
+  expect(isSolanaAddress("3")).toBe(false); // valid base58 char, but far too short for 32 bytes
+});
+
+test("isSolanaAddress accepts the character-length bounds of 32-byte payloads", () => {
+  // 32 zero bytes encode to the shortest possible address: one "1" per byte.
+  expect(isSolanaAddress("1".repeat(32))).toBe(true);
+  expect(isSolanaAddress("1".repeat(31))).toBe(false);
+  // 45 valid base58 chars exceed the 44-char maximum and are rejected before decoding.
+  expect(isSolanaAddress("2".repeat(45))).toBe(false);
 });

--- a/test/chains-solana.test.ts
+++ b/test/chains-solana.test.ts
@@ -1,6 +1,10 @@
 import { hexToBytes } from "@noble/hashes/utils.js";
 import { expect, test } from "@playwright/test";
-import { getSolanaAddress, isSolanaAddress } from "../dist/index.js";
+import {
+  getSolanaAddress,
+  isSolanaAddress,
+  type SolanaAddress,
+} from "../dist/index.js";
 import { expectError } from "./helpers.js";
 
 // RFC 8032 test vector 1 Ed25519 public key.
@@ -13,6 +17,17 @@ test("encodes Ed25519 public keys as base58 Solana addresses", () => {
 
   expect(address).toBe("FVen3X669xLzsi6N2V91DoiyzHzg1uAgqiT8jZ9nS96Z");
   expect(isSolanaAddress(address)).toBe(true);
+});
+
+test("isSolanaAddress narrows strings to SolanaAddress", () => {
+  const value: string = "FVen3X669xLzsi6N2V91DoiyzHzg1uAgqiT8jZ9nS96Z";
+
+  expect(isSolanaAddress(value)).toBe(true);
+  if (isSolanaAddress(value)) {
+    // Type-level contract: the predicate narrows a plain string to the brand.
+    const narrowed: SolanaAddress = value;
+    expect(narrowed).toBe(value);
+  }
 });
 
 test("rejects public keys of the wrong length", () => {


### PR DESCRIPTION
Stacked on #49 (which stacks on #48).

## What changed

`getSolanaAddress` returns a branded `SolanaAddress` type, and `isSolanaAddress` is now a type predicate narrowing `string` to it. This closes the asymmetry where the EVM half of the chains API had a typed address (`EvmAddress`) and a narrowing predicate while the Solana half returned plain `string`/`boolean`.

## Why a brand

`EvmAddress` can be structural (`` `0x${string}` ``) because hex fits a template literal. base58 has no expressible structural shape, so `SolanaAddress` is a nominal brand: `string & { readonly [brand]: true }`. Consequences for consumers:

- A `SolanaAddress` is assignable to `string` everywhere — zero friction for consumers who ignore the type.
- Consumers who want it get typed, validated addresses in their own state: values come from `getSolanaAddress` or an `isSolanaAddress` check, so a raw unvalidated string (or an EVM address) can't slip into a `SolanaAddress`-typed field.
- The brand is type-only; runtime values and JSON serialization are unchanged.

This mirrors the ecosystem convention — `@solana/kit` brands its `Address` type the same way.

## Reviewer notes

- The single `as SolanaAddress` in `getSolanaAddress` is the brand mint, commented as such: a nominal brand cannot be produced without an assertion, and it sits directly after the 32-byte validation the brand asserts.
- A test locks the narrowing contract (`string` → predicate → assignable to `SolanaAddress`) at the type level against the built declarations.