### PR TITLE
[codex] docs: trim passkey prf options param docs

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -338,7 +338,7 @@ async function getPasskeyPrfOutput({
  * time. Equivalent to `createPasskey` followed, when `prfOutput` is absent, by
  * `getPasskeyPrfOutput` with the same salt.
  *
- * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyWithPrfOutputOptions}. `rp.id` is required so the fallback ceremony can target the same relying party. `prfSalt` must be exactly 32 bytes.
+ * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyWithPrfOutputOptions}.
  * @returns Credential metadata and the first PRF output.
  * @remarks
  * Invokes `navigator.credentials.create()`. On authenticators that do not


### PR DESCRIPTION
Summary: Trims createPasskeyWithPrfOutput parameter docs so field details live on the linked options type. Validation: npm run check, npm run build.