### PR TITLE
[codex] docs: document unwrap prf output handling

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -283,6 +283,11 @@ type UnwrapSecretVaultInput = {
 /**
  * Decrypts the secret from a secret vault.
  *
+ * @remarks
+ * `prfOutput` is copied before async cryptographic work starts; post-call
+ * mutation does not change the decryption result. The caller-owned buffer is
+ * not modified or zeroed.
+ *
  * @param options - Vault and PRF output; fields are documented on {@link UnwrapSecretVaultOptions}.
  * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`. The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it.
  * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -284,8 +284,8 @@ type UnwrapSecretVaultInput = {
  * Decrypts the secret from a secret vault.
  *
  * @remarks
- * `prfOutput` is copied before async cryptographic work starts; post-call
- * mutation does not change the decryption result. The caller-owned buffer is
+ * `prfOutput` is copied before async cryptographic work starts, so post-call
+ * mutation does not change the decryption result; the caller-owned buffer is
  * not modified or zeroed.
  *
  * @param options - Vault and PRF output; fields are documented on {@link UnwrapSecretVaultOptions}.


### PR DESCRIPTION
Summary: Adds unwrapSecretVault remarks for prfOutput copying and caller-owned buffer behavior. Validation: npm run check, npm run build.