### PR TITLE
[codex] docs: standardize ed25519 private key wording

### DIFF
--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -9,9 +9,9 @@ import type {
 } from "./types.js";
 
 /**
- * Derives the 32-byte Ed25519 public key for a 32-byte Ed25519 seed.
+ * Derives the 32-byte Ed25519 public key for a 32-byte Ed25519 private key.
  *
- * @param privateKey - A 32-byte Ed25519 seed.
+ * @param privateKey - A 32-byte Ed25519 private key (the seed).
  * @returns The 32-byte Ed25519 public key.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
  * @internal
@@ -31,11 +31,11 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array<ArrayBuffer> {
 }
 
 /**
- * Wraps an Ed25519 seed in an explicitly lockable signing session.
+ * Wraps an Ed25519 private key in an explicitly lockable signing session.
  *
  * `signMessage` signs the raw message bytes; Ed25519 hashes internally with
- * SHA-512. `lock` zeroes the session-owned seed copy and makes future signing
- * fail.
+ * SHA-512. `lock` zeroes the session-owned private-key copy and makes future
+ * signing fail.
  *
  * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
  * @returns An unlocked Ed25519 signing session.

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ type Ed25519SigningSession = {
    */
   signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>>;
   /**
-   * Zeroes the session-owned seed copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
+   * Zeroes the session-owned private-key copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
    *
    * @remarks If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
    */


### PR DESCRIPTION
Summary: Standardizes Ed25519 docs on private-key terminology while retaining seed as a parenthetical. Validation: npm run check, npm run build.