### PR TITLE
[codex] docs: cover curve points in input errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,7 +6,7 @@
  * - `PRF_UNAVAILABLE`: the authenticator did not enable or return a usable 32-byte WebAuthn PRF output.
  * - `SESSION_LOCKED`: a signing call was made after `lock()`.
  * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key, or tampered ciphertext or additional authenticated data).
- * - `INPUT_INVALID`: a caller-supplied value at a public boundary did not satisfy a length, range, encoding, or scalar constraint.
+ * - `INPUT_INVALID`: a caller-supplied value at a public boundary did not satisfy a length, range, encoding, or curve (scalar or point) constraint.
  * - `VAULT_FORMAT_INVALID`: untrusted vault data (JSON or object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version.
  */
 type MeraErrorCode =


### PR DESCRIPTION
Summary: Broadens INPUT_INVALID docs to cover curve scalar and point constraints. Validation: npm run check, npm run build.