### PR TITLE
[codex] docs: trim copy bytes jsdoc

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -3,9 +3,6 @@ import { MeraError } from "./errors.js";
 
 /**
  * Copies bytes into a standalone `Uint8Array`.
- *
- * The returned array never aliases the input.
- *
  * @param value - Bytes to copy.
  * @returns A new `Uint8Array` with the same bytes as `value`.
  */


### PR DESCRIPTION
Summary: Removes a redundant no-aliasing sentence from copyBytes JSDoc. Validation: npm run check, npm run build.