### PR TITLE
[codex] docs: trim create passkey remarks

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -98,7 +98,7 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * @returns Credential metadata, plus the first PRF output when it was evaluated during creation.
  * @remarks
  * Invokes `navigator.credentials.create()`, which may show browser or
- * authenticator UI and create a discoverable passkey.
+ * authenticator UI.
  *
  * The WebAuthn challenge is generated internally. The raw attestation response
  * is not returned.


### PR DESCRIPTION
Summary: Trims repeated discoverable-passkey wording from createPasskey remarks. Validation: npm run check, npm run build.