### PR TITLE
[codex] docs: dedupe secp256k1 session factory docs

### DIFF
--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -54,9 +54,6 @@ function normalizeSecp256k1PublicKey(
 /**
  * Wraps a secp256k1 private key in an explicitly lockable signing session.
  *
- * `signDigest` signs exactly 32 bytes without prehashing. `lock` zeroes the
- * session-owned private-key copy and makes future signing fail.
- *
  * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
  * @returns An unlocked secp256k1 signing session.
  * @throws MeraError with code `INPUT_INVALID` when `consumePrivateKey` is not a valid secp256k1 scalar.


### PR DESCRIPTION
Summary: Removes duplicated secp256k1 signing-session behavior from the factory JSDoc and leaves it on the session type. Validation: npm run check, npm run build.