### PR TITLE
[codex] Run Biome check in CI

### DIFF
--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    name: Lint
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,29 +29,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run lint
-        run: npm run lint
-
-  format:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          check-latest: true
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Check formatting
-        run: npm exec -- biome format .
+      - name: Run Biome checks
+        run: npm run check
 
   compile:
     name: Compile


### PR DESCRIPTION
## Why
The CI workflow had separate Lint and Format jobs with duplicated checkout, Node setup, and dependency install steps. More importantly, those jobs did not run the documented `npm run check` command, so local checks and CI did not exercise exactly the same Biome command.

`npm run check` runs `biome check .`, which is Biome’s combined check command: it validates formatting, runs lint rules, and applies the configured assist checks in one pass. This is not relying on a weaker replacement for lint plus format; it is the canonical Biome check entrypoint the README already tells contributors to run.

## What changed
- Replace the separate Lint and Format jobs with one Check job.
- Run `npm run check` in CI instead of mixing `npm run lint` with a raw `npm exec -- biome format .` invocation.

## Validation
- `npm run check`