### PR TITLE
[codex] Remove redundant compile CI job

### DIFF
--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -53,27 +53,6 @@ jobs:
       - name: Check formatting
         run: npm exec -- biome format .
 
-  compile:
-    name: Compile
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          check-latest: true
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Compile library
-        run: npm run build
-
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
The standalone Compile job does not provide unique coverage. A TypeScript compile failure already fails multiple remaining CI paths: `npm test` starts with `npm run build`, `npm run check:pack` starts with `npm run build`, and the demo job explicitly builds the library before building the demo.

Removing the extra job reduces CI setup duplication without losing compile protection. The only external follow-up is branch protection: if `Compile` is listed as a required status check, that required check should be removed when this PR merges.

## What changed
- Delete the standalone Compile job from the workflow.
- Leave the existing test, demo, and publish-check build paths intact.

## Validation
- `npm run check`