### PR TITLE
[codex] Select e2e tests by file

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format": "biome format --write .",
     "lint": "biome lint .",
     "test": "npm run build && tsc -p tsconfig.test.json && playwright test",
-    "test:e2e": "npm test -- passkey.e2e.ts"
+    "test:e2e": "npm test -- --project chromium-e2e"
   },
   "dependencies": {
     "@noble/ed25519": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format": "biome format --write .",
     "lint": "biome lint .",
     "test": "npm run build && tsc -p tsconfig.test.json && playwright test",
-    "test:e2e": "npm run build && playwright test --grep @e2e"
+    "test:e2e": "npm test -- passkey.e2e.ts"
   },
   "dependencies": {
     "@noble/ed25519": "^3.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,23 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const desktopChrome = devices["Desktop Chrome"];
+
 export default defineConfig({
   testDir: "./test",
-  testMatch: /.*\.(test|e2e)\.ts/,
   fullyParallel: true,
   projects: [
     {
       name: "chromium",
+      testMatch: /.*\.test\.ts/,
       use: {
-        ...devices["Desktop Chrome"],
+        ...desktopChrome,
+      },
+    },
+    {
+      name: "chromium-e2e",
+      testMatch: /.*\.e2e\.ts/,
+      use: {
+        ...desktopChrome,
       },
     },
   ],

--- a/test/passkey.e2e.ts
+++ b/test/passkey.e2e.ts
@@ -33,7 +33,7 @@ async function withVirtualAuthenticator(
   }
 }
 
-test("creates a PRF-capable passkey and returns stable PRF output @e2e", async ({
+test("creates a PRF-capable passkey and returns stable PRF output", async ({
   page,
 }) => {
   await withVirtualAuthenticator(page, async () => {
@@ -89,7 +89,7 @@ test("creates a PRF-capable passkey and returns stable PRF output @e2e", async (
   });
 });
 
-test("createPasskeyWithPrfOutput returns the first PRF output in one call @e2e", async ({
+test("createPasskeyWithPrfOutput returns the first PRF output in one call", async ({
   page,
 }) => {
   await withVirtualAuthenticator(page, async () => {
@@ -128,7 +128,7 @@ test("createPasskeyWithPrfOutput returns the first PRF output in one call @e2e",
   });
 });
 
-test("createSecretVault round-trips a secret through a real passkey ceremony @e2e", async ({
+test("createSecretVault round-trips a secret through a real passkey ceremony", async ({
   page,
 }) => {
   await withVirtualAuthenticator(page, async () => {


### PR DESCRIPTION
## Why
The e2e suite was identified two ways at once: by living in `.e2e.ts` files and by adding `@e2e` to each test title. The filename convention is the better suite boundary because it scales at the file level: when another e2e file is added, Playwright can include it automatically without adding tags to every test name.

The first version of this PR selected `passkey.e2e.ts` directly, which was too narrow. This version defines a dedicated `chromium-e2e` Playwright project that matches all `*.e2e.ts` files, then has `npm run test:e2e` run that project through `npm test`. That keeps the full build and test-typecheck path while avoiding a hard-coded single test file.

## What changed
- Remove `@e2e` suffixes from the three passkey e2e test titles.
- Split Playwright projects by test filename convention: `*.test.ts` for the normal Chromium project and `*.e2e.ts` for `chromium-e2e`.
- Change `test:e2e` to run `npm test -- --project chromium-e2e`.

## Validation
- `npm run check`
- `npm run test:e2e -- --list` confirms the e2e project selects `passkey.e2e.ts` through the `*.e2e.ts` convention.
- `npm run test:e2e`