### PR TITLE
[codex] Remove default Dependabot PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
     labels:
       - "dependencies"
     commit-message:
@@ -34,7 +33,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Why
Both Dependabot update blocks set `open-pull-requests-limit: 5`, but five is already the default limit for version-update pull requests. Keeping the explicit value makes the config look intentionally customized even though it does not change behavior.

Removing the repeated default keeps the file focused on settings that actually matter: schedule, labels, commit messages, and grouping.

## What changed
- Remove `open-pull-requests-limit: 5` from the npm update block.
- Remove `open-pull-requests-limit: 5` from the GitHub Actions update block.

## Validation
- `npm run check`