### PR TITLE
[codex] Remove dead coverage ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ dist/
 node_modules/
 playwright-report/
 test-results/
-coverage/
 .claude
 .DS_Store


### PR DESCRIPTION
## Why
The ignore list should describe generated files this repo actually creates. There is no coverage script, dependency, or Playwright setting that writes a `coverage/` directory today, so the entry is leftover boilerplate.

Removing it keeps `.gitignore` a little more honest and avoids teaching future readers that coverage output exists when it does not.

## What changed
- Remove the unused `coverage/` entry from `.gitignore`.

## Validation
- `npm run check`