### PR TITLE
[codex] Clarify tarball verification comment

### DIFF
--- a/scripts/verify-tarball.mjs
+++ b/scripts/verify-tarball.mjs
@@ -16,8 +16,8 @@ const REQUIRED_FILES = [
 
 // `npm pack --dry-run --json` reports the exact tarball file list without
 // writing a .tgz to disk. `--ignore-scripts` skips the `prepack` rebuild so
-// this inspects the dist `check:pack` already built (and lints with `publint`)
-// rather than building a second time.
+// this inspects the dist `check:pack` already built rather than building a
+// second time.
 const packOutput = execFileSync(
   "npm",
   ["pack", "--dry-run", "--json", "--ignore-scripts"],


### PR DESCRIPTION
## Why
The `verify-tarball` script comment explains why `npm pack --ignore-scripts` is used: `check:pack` has already built `dist/`, so the script should inspect that output rather than triggering `prepack` and building again.

The old parenthetical about `publint` belonged to the broader `check:pack` script, not to this tarball inspection step. Removing it keeps the comment focused on the mechanism in this file.

## What changed
- Remove the confusing `publint` parenthetical from the `--ignore-scripts` comment.

## Validation
- `npm run check`