### PR TITLE
[codex] Document dist test imports

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 
 const desktopChrome = devices["Desktop Chrome"];
 
+// Tests import built dist/ output, including internals via deep paths like
+// ../dist/session.js, so they exercise the shipped artifact and the browser e2e
+// page can load the same JS. Run via `npm test`, which rebuilds first; bare
+// `playwright test` can run against stale dist/.
 export default defineConfig({
   testDir: "./test",
   fullyParallel: true,


### PR DESCRIPTION
## Why
The test suite intentionally imports built `dist/` files, including deep internal paths like `../dist/session.js`. That is useful because it exercises the shipped artifact rather than TypeScript sources, and the browser e2e page has to load built JavaScript anyway.

The tradeoff is easy to miss: running bare `playwright test` can use stale `dist/` output. A short comment in the Playwright config documents the mechanism and points readers back to `npm test`, which rebuilds before running the suite.

## What changed
- Add a Playwright config comment explaining the built-output test architecture.
- Note the stale-dist hazard of running Playwright directly.

## Validation
- `npm run check`