### PR TITLE
[codex] clarify site library boundary

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,7 @@
     </title>
     <meta
       name="description"
-      content="How mera turns a passkey into ordinary private keys — any derivation scheme, any chain — with no smart accounts and no on-chain infrastructure."
+      content="How a passkey becomes ordinary private keys — any derivation scheme, any chain — with no smart accounts and no on-chain infrastructure."
     >
     <meta property="og:type" content="article">
     <meta property="og:site_name" content="mera">
@@ -18,7 +18,7 @@
     >
     <meta
       property="og:description"
-      content="How mera turns a passkey into ordinary private keys — any derivation scheme, any chain — with no smart accounts and no on-chain infrastructure."
+      content="How a passkey becomes ordinary private keys — any derivation scheme, any chain — with no smart accounts and no on-chain infrastructure."
     >
     <meta property="og:image" content="/og.png">
     <meta property="og:image:type" content="image/png">
@@ -388,10 +388,10 @@
         </p>
 
         <p>
-          mera is a TypeScript library that turns a passkey into a full-fledged
-          signing keypair — an ordinary account on any chain. It does so without
-          smart accounts or third-party trust assumptions. mera is powered by
-          the
+          mera is a TypeScript library that turns a passkey into stable,
+          authenticator-bound entropy — enough for an ordinary account on any
+          chain — without smart accounts or third-party trust assumptions. mera
+          is powered by the
           <a href="https://www.w3.org/TR/webauthn-3/#prf-extension"
             >WebAuthn PRF extension</a
           >, part of the standard behind passkeys, which ships today in almost

--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,7 @@
     </title>
     <meta
       name="description"
-      content="How a passkey becomes ordinary private keys — any derivation scheme, any chain — with no smart accounts and no on-chain infrastructure."
+      content="How a passkey becomes ordinary private keys with any derivation scheme and any chain, without smart accounts or on-chain infrastructure."
     >
     <meta property="og:type" content="article">
     <meta property="og:site_name" content="mera">
@@ -18,7 +18,7 @@
     >
     <meta
       property="og:description"
-      content="How a passkey becomes ordinary private keys — any derivation scheme, any chain — with no smart accounts and no on-chain infrastructure."
+      content="How a passkey becomes ordinary private keys with any derivation scheme and any chain, without smart accounts or on-chain infrastructure."
     >
     <meta property="og:image" content="/og.png">
     <meta property="og:image:type" content="image/png">

--- a/site/index.html
+++ b/site/index.html
@@ -388,10 +388,10 @@
         </p>
 
         <p>
-          mera is a TypeScript library that lets an app get the same 32 bytes
-          from the same passkey each time — enough for the app to derive an
-          ordinary account on any chain — without smart accounts or third-party
-          trust assumptions. mera is powered by the
+          mera is a TypeScript library that lets an app get the same 32 secret
+          bytes from the same passkey each time. The app can use those bytes to
+          derive an ordinary account on any chain, without smart accounts or
+          third-party trust assumptions. mera is powered by the
           <a href="https://www.w3.org/TR/webauthn-3/#prf-extension"
             >WebAuthn PRF extension</a
           >, part of the standard behind passkeys, which ships today in almost

--- a/site/index.html
+++ b/site/index.html
@@ -388,10 +388,10 @@
         </p>
 
         <p>
-          mera is a TypeScript library that turns a passkey into stable,
-          authenticator-bound entropy — enough for an ordinary account on any
-          chain — without smart accounts or third-party trust assumptions. mera
-          is powered by the
+          mera is a TypeScript library that lets an app get the same 32 bytes
+          from the same passkey each time — enough for the app to derive an
+          ordinary account on any chain — without smart accounts or third-party
+          trust assumptions. mera is powered by the
           <a href="https://www.w3.org/TR/webauthn-3/#prf-extension"
             >WebAuthn PRF extension</a
           >, part of the standard behind passkeys, which ships today in almost


### PR DESCRIPTION
## Why

The article credited mera with turning a passkey into ordinary private keys, but `site/WRITING.md` says derivation belongs to the app and mera should be described as producing entropy and signing sessions.

## What changed

- Reworded the HTML description metadata so it describes the article flow without assigning derivation to mera.
- Rewrote the opening library sentence around getting the same 32 secret bytes from the same passkey, and removed "full-fledged."

## Validation

- `npm run check`
