### PR TITLE
[codex] narrow site PRF availability claim

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -394,8 +394,8 @@
           the
           <a href="https://www.w3.org/TR/webauthn-3/#prf-extension"
             >WebAuthn PRF extension</a
-          >, part of the standard behind passkeys, which ships today in almost
-          all authenticators.
+          >, part of the standard behind passkeys. PRF ships today in the
+          authenticators bundled with major operating systems and browsers.
         </p>
 
         <h2 id="the-current-state-of-crypto-onboarding">


### PR DESCRIPTION
## Why

The article said PRF "ships today in almost all authenticators," but the README compatibility table lists several unsupported authenticators and the article later uses a narrower, checkable claim.

## What changed

- Split the opening PRF sentence.
- Replaced the broad "almost all authenticators" wording with the narrower OS/browser-bundled authenticator claim already used later in the article.

## Validation

- `npm run check`
