### PR TITLE
[codex] fix site package import snippet

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -788,7 +788,7 @@ clientDataJSON
   createSecp256k1SigningSession,
   getEvmAddress,
   getPasskeyPrfOutput,
-} from "mera"
+} from "@category-labs/mera"
 import { deriveWalletPrivateKey } from "./wallet-derivation"
 
 const rpId = "account.example.com"


### PR DESCRIPTION
## Why

The article's only TypeScript sample imported from `"mera"`, but the package is published and documented as `@category-labs/mera`. Copying the sample would fail.

## What changed

- Updated the sample import source to `@category-labs/mera`.

## Validation

- `npm run check`
