### PR TITLE
[codex] make site source line count accurate

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1061,7 +1061,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
           </li>
           <li>
             <strong>The dependency is small and boring.</strong>
-            About 2,000 lines including its JSDoc, built from standard,
+            Under 2,000 lines including its JSDoc, built from standard,
             well-studied primitives: WebAuthn, HMAC-SHA-256,
             <a href="https://www.rfc-editor.org/rfc/rfc5869">HKDF-SHA-256</a>,
             and


### PR DESCRIPTION
## Why

The article said the source was "About 2,000 lines including its JSDoc," but the current `src` TypeScript total is 1,766 lines. The existing wording was close, but not the most directly checkable claim.

## What changed

- Replaced "About 2,000 lines" with "Under 2,000 lines."

## Validation

- `wc -l src/*.ts src/chains/*.ts` reports `1766 total`
- `npm run check`
