### PR TITLE
[codex] simplify site password manager sync copy

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1031,8 +1031,8 @@ const address = getEvmAddress(session.publicKey)</code></pre>
           </li>
           <li>
             <strong>Backup is passkey sync.</strong>
-            A password manager with sync, which most now provide, makes the
-            passkey available across devices.
+            A synced password manager makes the passkey available across
+            devices.
           </li>
           <li>
             <strong>A new device is a sign-in.</strong>


### PR DESCRIPTION
## Why

The article said most password managers now provide sync, but that market claim is not supported by the README or the code and is not needed for the user-benefit point.

## What changed

- Removed the unsupported aside.
- Kept the concrete claim that a synced password manager makes the passkey available across devices.

## Validation

- `npm run check`
