### PR TITLE
[codex] Fix demo default network comment

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,5 +1,5 @@
 # Quick start:
-#   npm run dev --prefix demo            # Mainnet by default; toggle Testnet in the UI
+#   npm run dev --prefix demo            # Testnet by default; toggle Testnet off in the UI for Mainnet
 #   npm run dev:mainnet --prefix demo    # Same runtime networks, explicit Vite mode
 #   npm run dev:testnet --prefix demo    # Same runtime networks, explicit Vite mode
 #


### PR DESCRIPTION
## Summary
Fixes the demo quick-start comment so it matches the app's testnet default.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build