### PR TITLE
[codex] Remove no-op demo Vite mode scripts

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,7 +1,5 @@
 # Quick start:
 #   npm run dev --prefix demo            # Testnet by default; toggle Testnet off in the UI for Mainnet
-#   npm run dev:mainnet --prefix demo    # Same runtime networks, explicit Vite mode
-#   npm run dev:testnet --prefix demo    # Same runtime networks, explicit Vite mode
 #
 # Or copy this file to .env and edit the values below.
 

--- a/demo/.env.mainnet
+++ b/demo/.env.mainnet
@@ -1,6 +1,0 @@
-# Loaded by `vite --mode mainnet` (npm run dev:mainnet).
-# Both runtime modes are available through the in-app Testnet toggle.
-VITE_ETHEREUM_MAINNET_RPC_URL=https://rpc.monad.xyz
-VITE_ETHEREUM_TESTNET_RPC_URL=https://testnet-rpc.monad.xyz
-VITE_SOLANA_MAINNET_RPC_URL=https://solana-rpc.publicnode.com
-VITE_SOLANA_TESTNET_RPC_URL=https://api.devnet.solana.com

--- a/demo/.env.testnet
+++ b/demo/.env.testnet
@@ -1,6 +1,0 @@
-# Loaded by `vite --mode testnet` (npm run dev:testnet).
-# Both runtime modes are available through the in-app Testnet toggle.
-VITE_ETHEREUM_MAINNET_RPC_URL=https://rpc.monad.xyz
-VITE_ETHEREUM_TESTNET_RPC_URL=https://testnet-rpc.monad.xyz
-VITE_SOLANA_MAINNET_RPC_URL=https://solana-rpc.publicnode.com
-VITE_SOLANA_TESTNET_RPC_URL=https://api.devnet.solana.com

--- a/demo/package.json
+++ b/demo/package.json
@@ -5,8 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:mainnet": "vite --mode mainnet",
-    "dev:testnet": "vite --mode testnet",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc"


### PR DESCRIPTION
## Why
The explicit Vite mode scripts looked like they selected a runtime network, but the app already switches networks with the in-app Testnet toggle. The deleted env files also duplicated the built-in RPC defaults, so keeping them documented a choice that did nothing.

## Summary
Removes the explicit mainnet/testnet Vite mode scripts, deletes the matching env files, and leaves `.env.example` as the single documented override point.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build