### PR TITLE
[codex] Align Solana suggested recipient label

### DIFF
--- a/demo/src/SolanaAccountCard.tsx
+++ b/demo/src/SolanaAccountCard.tsx
@@ -222,7 +222,7 @@ function SolanaAccountCard({
                 onClick={showChip ? switchToManual : restoreSuggestion}
                 disabled={busy}
               >
-                {showChip ? "Change" : `Use ${suggestedLabel}`}
+                {showChip ? "Change" : `${suggestedLabel}`}
               </button>
             )}
           </span>


### PR DESCRIPTION
## Why
The suggested-recipient restore button should read consistently across chains. The account-name-only label is cleaner in the compact chip UI than adding an extra verb.

## Summary
Changes the Solana recipient restore button to match the Ethereum card label style.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build