### PR TITLE
[codex] Use viem wallet client directly in demo

### DIFF
--- a/demo/src/EthereumAccountCard.tsx
+++ b/demo/src/EthereumAccountCard.tsx
@@ -6,13 +6,16 @@ import {
   useMemo,
   useState,
 } from "react";
-import { formatEther, getAddress, isAddress, parseEther } from "viem";
-import { toPasskeyAccount } from "./account";
 import {
-  createTransactionClient,
-  type EthereumContext,
-  explorerTxUrl,
-} from "./chains/ethereum";
+  createWalletClient,
+  formatEther,
+  getAddress,
+  http,
+  isAddress,
+  parseEther,
+} from "viem";
+import { toPasskeyAccount } from "./account";
+import { type EthereumContext, explorerTxUrl } from "./chains/ethereum";
 import { type AccountMode, describeError } from "./connect";
 import { QrCode } from "./QrCode";
 import { shorten, trimAmount } from "./ui";
@@ -136,7 +139,11 @@ function EthereumAccountCard({
     setSigned(null);
     setTxHash(null);
     try {
-      const transactionClient = createTransactionClient(account, chain, rpcUrl);
+      const transactionClient = createWalletClient({
+        account,
+        chain,
+        transport: http(rpcUrl),
+      });
       const request = await transactionClient.prepareTransactionRequest({
         to: getAddress(to),
         value: parseEther(amount),

--- a/demo/src/chains/ethereum.ts
+++ b/demo/src/chains/ethereum.ts
@@ -1,13 +1,4 @@
-import {
-  type Account,
-  type Chain,
-  createPublicClient,
-  createWalletClient as createViemTransactionClient,
-  type HttpTransport,
-  http,
-  type PublicClient,
-  type WalletClient as ViemTransactionClient,
-} from "viem";
+import { type Chain, createPublicClient, http, type PublicClient } from "viem";
 import { foundry, mainnet, monad, monadTestnet, sepolia } from "viem/chains";
 import { cachePerNetwork, type NetworkMode } from "../network";
 
@@ -74,21 +65,6 @@ async function resolveEthereumContext(
  */
 const getEthereumContext = cachePerNetwork(resolveEthereumContext);
 
-/**
- * Creates a viem transaction client bound to a passkey-backed account and chain.
- */
-function createTransactionClient(
-  account: Account,
-  chain: Chain,
-  rpcUrl: string,
-): ViemTransactionClient<HttpTransport, Chain, Account> {
-  return createViemTransactionClient({
-    account,
-    chain,
-    transport: http(rpcUrl),
-  });
-}
-
 /** Builds a block-explorer transaction URL for a chain. */
 function explorerTxUrl(chain: Chain, hash: string): string | undefined {
   const base = chain.blockExplorers?.default.url;
@@ -96,4 +72,4 @@ function explorerTxUrl(chain: Chain, hash: string): string | undefined {
 }
 
 export type { EthereumContext };
-export { createTransactionClient, explorerTxUrl, getEthereumContext };
+export { explorerTxUrl, getEthereumContext };


### PR DESCRIPTION
## Summary
Removes the demo-only transaction-client wrapper and constructs viem's wallet client directly at the call site.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build