### PR TITLE
[codex] Drop inert Ethereum demo badge class

### DIFF
--- a/demo/src/EthereumAccountCard.tsx
+++ b/demo/src/EthereumAccountCard.tsx
@@ -179,7 +179,7 @@ function EthereumAccountCard({
   return (
     <section className="card">
       <div className="card-head">
-        <span className="badge chain-ethereum">Ethereum · {mode}</span>
+        <span className="badge">Ethereum · {mode}</span>
         <button type="button" className="link" onClick={onLock}>
           Lock
         </button>


### PR DESCRIPTION
## Summary
Removes the unused Ethereum badge modifier class from the demo card while preserving the base badge styling.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build