### PR TITLE
[codex] Drop unused Solana RPC URL field

### DIFF
--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -41,7 +41,6 @@ const KNOWN_CLUSTERS: Record<string, { cluster: Cluster; mode: NetworkMode }> =
 type SolanaContext = {
   cluster: Cluster;
   connection: Connection;
-  rpcUrl: string;
   symbol: "SOL";
 };
 
@@ -71,7 +70,7 @@ async function resolveSolanaContext(
       `The ${networkMode} RPC is on the ${known.cluster} cluster, which belongs to ${known.mode}.`,
     );
   }
-  return { cluster: known.cluster, connection, rpcUrl, symbol: "SOL" };
+  return { cluster: known.cluster, connection, symbol: "SOL" };
 }
 
 /**


### PR DESCRIPTION
## Summary
Removes the unread rpcUrl field from SolanaContext while keeping the local RPC URL used to construct the connection.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build