### PR TITLE
[codex] Clarify demo credential pinning docs

### DIFF
--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -50,7 +50,7 @@ type AccountSlot = {
  */
 type ConnectedWallet = {
   mode: AccountMode;
-  /** Credential to pin on the next sign-in (derived mode); absent otherwise. */
+  /** Credential to pin when re-running a ceremony for this wallet; derived mode only, absent otherwise. */
   credentialId?: string;
   /** Returns the account at `index`, deriving and caching it on first use. */
   deriveAccount(index: number): AccountSlot;


### PR DESCRIPTION
## Why
The old comment said `credentialId` pins the next sign-in, but sign-in pinning comes from the stored derived-wallet record. That mismatch pointed readers at the wrong mechanism and made the field look broader than it is.

## Summary
Updates the `ConnectedWallet.credentialId` comment so it describes ceremony pinning for this wallet, currently used by backup-phrase reveal.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check