### PR TITLE
[codex] Use singular demo derived wallet storage

### DIFF
--- a/demo/src/AccountCard.tsx
+++ b/demo/src/AccountCard.tsx
@@ -77,7 +77,7 @@ function AccountCard({
 
   // On testnet, suggest sending to another of the user's own HD accounts — a
   // self-owned recipient that needs no second address. Deriving it here is free
-  // (cached) and invisible: no pill or registry bump until the user reveals it.
+  // (cached) and invisible: no pill or stored-account bump until the user reveals it.
   const isTestnet = networkMode === "testnet";
   const suggestion = useMemo(() => {
     if (!isTestnet || wallet.mode !== "derived") return null;

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -10,8 +10,8 @@ import {
   type ConnectResult,
   describeError,
 } from "./connect";
+import { setDerivedAccountCount } from "./derivedWallet";
 import type { NetworkMode } from "./network";
-import { setDerivedAccountCount } from "./registry";
 
 /** Root component: holds the connected wallet + accounts, fetches network info. */
 function App(): ReactElement {

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -15,6 +15,7 @@ import {
   type Secp256k1SigningSession,
   unwrapSecretVault,
 } from "@category-labs/mera";
+import { currentDerivedWallet, rememberDerivedWallet } from "./derivedWallet";
 import {
   deriveEthereumPrivateKey,
   deriveSolanaSeed,
@@ -22,7 +23,6 @@ import {
   mnemonicToSeed,
   prfOutputToMnemonic,
 } from "./hd";
-import { currentDerivedWallet, rememberDerivedWallet } from "./registry";
 
 /** The two account modes the demo offers (mera itself is mode-agnostic). */
 type AccountMode = "wrapped" | "derived";

--- a/demo/src/derivedWallet.ts
+++ b/demo/src/derivedWallet.ts
@@ -16,11 +16,11 @@ type DerivedWalletRecord = {
   accountCount: number;
 };
 
-const REGISTRY_KEY = "mera.demo.derivedWallets";
+const STORAGE_KEY = "mera.demo.derivedWallet";
 
 function currentDerivedWallet(): DerivedWalletRecord | undefined {
   try {
-    const raw = localStorage.getItem(REGISTRY_KEY);
+    const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return undefined;
     const parsed: unknown = JSON.parse(raw);
     return isDerivedWalletRecord(parsed) ? parsed : undefined;
@@ -30,7 +30,7 @@ function currentDerivedWallet(): DerivedWalletRecord | undefined {
 }
 
 function rememberDerivedWallet(record: DerivedWalletRecord): void {
-  localStorage.setItem(REGISTRY_KEY, JSON.stringify(record));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
 }
 
 /** Persists a new account count so a later sign-in restores every account. */


### PR DESCRIPTION
## Why
The module name `registry` and plural storage key implied a collection of wallet records, but the demo stores exactly one derived-wallet record and overwrites it on each write. Singular names make the storage model match the actual behavior.

## Summary
Renames the demo derived-wallet storage module and localStorage key to singular names.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build