### PR TITLE
[codex] Trim stale demo faucet comment

### DIFF
--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -591,7 +591,7 @@ a {
 }
 
 /* Testnet faucet CTA: a subtle accent link riding on the balance baseline,
-   pushed to the right of the amount (replaces the old manual Refresh link). */
+   pushed to the right of the amount. */
 .faucet {
   margin-left: auto;
   font-size: 13px;


### PR DESCRIPTION
## Summary
Removes a historical note from the faucet CSS comment so it describes only current behavior.

## Validation
- npm run build
- npm --prefix demo run typecheck
- npm run check
- npm --prefix demo run build