### PR TITLE
docs: rework public copy to follow the writing rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Passkey-backed signing for multichain accounts: one passkey, many chains.
 mera turns a WebAuthn passkey into stable, authenticator-bound entropy for wallet apps. The browser's WebAuthn PRF extension gives mera 32 bytes per ceremony; apps can feed those bytes into their chosen derivation scheme or wrap an app-held secret (a recovery phrase, a private key) into a passkey-encrypted vault. None of it needs a smart-account deploy or a custom on-chain verifier program.
 
 - Signing sessions for secp256k1 and Ed25519, address helpers for EVM and Solana.
-- One OS-authentication prompt unlocks a whole session of signatures.
+- One user-verification prompt unlocks a whole session of signatures.
 - Key derivation stays app-owned; mera hands the app entropy.
+- Cross-platform: a native iOS or Android app tied to the same domain can use the same passkey and derive the same accounts.
 
 ## Modes
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # mera
 
-Passkey-backed signing for multichain accounts: one biometric, many chains.
+Passkey-backed signing for multichain accounts: one passkey, many chains.
 
 mera turns a WebAuthn passkey into stable, authenticator-bound entropy for wallet apps. The browser's WebAuthn PRF extension gives mera 32 bytes per ceremony; apps can feed those bytes into their chosen derivation scheme or wrap an app-held secret (a recovery phrase, a private key) into a passkey-encrypted vault. None of it needs a smart-account deploy or a custom on-chain verifier program.
 
 - Signing sessions for secp256k1 and Ed25519, address helpers for EVM and Solana.
-- One biometric unlocks a whole session of signatures.
+- One OS-authentication prompt unlocks a whole session of signatures.
 - Key derivation stays app-owned; mera hands the app entropy.
 
 ## Modes

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # mera
 
-Passkey-backed signing for multichain accounts — one biometric, many chains.
+Passkey-backed signing for multichain accounts: one biometric, many chains.
 
-mera turns a WebAuthn passkey into stable, authenticator-bound entropy for wallet apps. The browser's WebAuthn PRF extension gives mera 32 bytes per ceremony; apps can feed those bytes into their chosen wallet derivation scheme or wrap an app-held secret — a recovery phrase, a private key — into a passkey-encrypted vault. No smart-account deploys, no custom on-chain verifier programs.
+mera turns a WebAuthn passkey into stable, authenticator-bound entropy for wallet apps. The browser's WebAuthn PRF extension gives mera 32 bytes per ceremony; apps can feed those bytes into their chosen derivation scheme or wrap an app-held secret (a recovery phrase, a private key) into a passkey-encrypted vault. None of it needs a smart-account deploy or a custom on-chain verifier program.
 
-- One passkey, multiple chains (EVM + Solana today).
-- One biometric per session, not per transaction.
-- Wallet derivation stays app-owned — mera hands the app entropy, not a derivation path.
+- Signing sessions for secp256k1 and Ed25519, address helpers for EVM and Solana.
+- One biometric unlocks a whole session of signatures.
+- Key derivation stays app-owned; mera hands the app entropy.
 
 ## Modes
 
-**Derived.** mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable passkey and `rpId`; cross-device use requires that passkey to be available on the new device. The app derives wallet keys from that output using its chosen scheme — the demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519. Best for stateless wallet access across devices.
+**Derived.** mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable passkey and `rpId`; cross-device use requires that passkey to be available on the new device. The app derives account keys from that output using its chosen scheme; the demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519. Best for stateless account access across devices.
 
-**Wrapped.** An AES-256-GCM blob holds one secret — a recovery phrase, a private key, any bytes; only the passkey can unlock it. The blob can live in `localStorage`, a backend, or a sync service. Best for hot-wallet UX, returning users who sign many transactions per session, and importing an existing wallet.
+**Wrapped.** An AES-256-GCM blob holds one secret (a recovery phrase, a private key, any bytes); only the passkey can unlock it. The blob can live in `localStorage`, a backend, or a sync service. Suits returning users who sign many transactions per session, and imports of an existing account.
 
 Derived mode stores no app-owned secret to recover. If the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's `rpId` after a domain migration, the account may be unrecoverable unless the app offers export, import, or another backup path.
 
@@ -24,7 +24,7 @@ npm install @category-labs/mera
 
 ## Quick example
 
-A derived-mode skeleton: one passkey ceremony, then app-owned wallet derivation.
+A derived-mode skeleton: one passkey ceremony, then app-owned key derivation.
 
 ```ts
 import {
@@ -33,14 +33,14 @@ import {
   getEvmAddress,
   getPasskeyPrfOutput,
 } from "@category-labs/mera"
-import { deriveWalletPrivateKey } from "./wallet-derivation"
+import { deriveAccountPrivateKey } from "./account-derivation"
 
 const rpId = "account.example.com"
 
 const prfSalt = getDeterministicPrfSaltV1()
 const { prfOutput } = await getPasskeyPrfOutput({ rpId, prfSalt })
 
-const privateKey = deriveWalletPrivateKey({
+const privateKey = deriveAccountPrivateKey({
   entropy: prfOutput,
   path: "m/44'/60'/0'/0/0",
 })
@@ -49,9 +49,9 @@ const session = createSecp256k1SigningSession({ consumePrivateKey: privateKey })
 const address = getEvmAddress(session.publicKey)
 ```
 
-Reusing one PRF output unchanged for unrelated purposes — wallet derivation and app-data encryption, say — links those secrets. Use a different PRF salt per purpose, or split one output with a purpose-labeled KDF.
+Reusing one PRF output unchanged for unrelated purposes (key derivation and app-data encryption, say) links those secrets. Use a different PRF salt per purpose, or split one output with a purpose-labeled KDF.
 
-Derived/reproducible-wallet flows pass a stable PRF salt such as `getDeterministicPrfSaltV1()`. Wrapped flows pass 32 fresh random salt bytes.
+Derived, reproducible-account flows pass a stable PRF salt such as `getDeterministicPrfSaltV1()`. Wrapped flows pass 32 fresh random salt bytes.
 
 ## Supported authenticators
 
@@ -85,12 +85,12 @@ On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The
 
 Names only; editor hover shows the full JSDoc.
 
-- **Passkey ceremonies** — `createPasskey`, `createPasskeyWithPrfOutput`, `getPasskeyPrfOutput`
-- **Deterministic PRF salt** — `getDeterministicPrfSaltV1`
-- **Signing sessions** — `createSecp256k1SigningSession`, `createEd25519SigningSession`
-- **Secret vault** — `createSecretVault`, `unwrapSecretVault`, `parseSecretVault`, `getSecretVaultPrfOutput`
-- **Chain addresses** — `getEvmAddress`, `isEvmAddress`, `getSolanaAddress`, `isSolanaAddress`
-- **Errors** — `MeraError`, `isMeraError`, `MeraErrorCode`
+- **Passkey ceremonies**: `createPasskey`, `createPasskeyWithPrfOutput`, `getPasskeyPrfOutput`
+- **Deterministic PRF salt**: `getDeterministicPrfSaltV1`
+- **Signing sessions**: `createSecp256k1SigningSession`, `createEd25519SigningSession`
+- **Secret vault**: `createSecretVault`, `unwrapSecretVault`, `parseSecretVault`, `getSecretVaultPrfOutput`
+- **Chain addresses**: `getEvmAddress`, `isEvmAddress`, `getSolanaAddress`, `isSolanaAddress`
+- **Errors**: `MeraError`, `isMeraError`, `MeraErrorCode`
 
 ## Detailed docs
 

--- a/site/index.html
+++ b/site/index.html
@@ -461,12 +461,13 @@
 
         <p>
           Passkeys looked like the answer on both fronts. A passkey is a keypair
-          in the device's secure hardware, gated by OS authentication and synced
-          by the platform, and it ships with every phone, laptop, and browser.
-          For the user that means no phrase and no password; for the developer
-          it means generation, storage, locking, and cross-device sync are the
-          platform's job. Crypto adopted passkeys through smart accounts, where
-          the passkey signs and a contract on the chain verifies.
+          in the device's secure hardware, gated by the device's unlock gesture
+          and synced by the platform, and it ships with every phone, laptop, and
+          browser. For the user that means no phrase and no password; for the
+          developer it means generation, storage, locking, and cross-device sync
+          are the platform's job. Crypto adopted passkeys through smart
+          accounts, where the passkey signs and a contract on the chain
+          verifies.
         </p>
 
         <h2 id="why-a-passkey-cant-sign-a-transaction">
@@ -1016,37 +1017,59 @@ const address = getEvmAddress(session.publicKey)</code></pre>
           What users and developers get
         </h2>
 
-        <p>
-          For users, onboarding is one passkey prompt: create a passkey, see an
-          address, nothing to transcribe. Backup and new devices ride on passkey
-          sync, so signing in with the synced passkey on another device brings
-          up the same account, and the same entropy covers every chain the app
-          supports. There is also a way out: where the app offers export, the
-          recovery phrase imports into MetaMask, Phantom, or any other standard
-          wallet app.
-        </p>
+        <p>For users:</p>
 
-        <p>
-          For developers, the key-store layer mostly disappears. Derived mode
-          stores nothing, wrapped mode stores a blob that is useless without the
-          passkey, and locking is one call. There is nothing to deploy or
-          operate: no contracts, bundlers, paymasters, executor accounts, key
-          servers, or provider dependencies, and in derived mode no server-side
-          state at all.
-        </p>
+        <ul>
+          <li>
+            <strong>Onboarding is one passkey prompt.</strong>
+            Create a passkey, see an address. Nothing to transcribe.
+          </li>
+          <li>
+            <strong>One passkey, many chains.</strong>
+            The same entropy derives accounts for every chain the app supports.
+          </li>
+          <li>
+            <strong>Backup is passkey sync.</strong>
+            A synced password manager carries the passkey across devices, so a
+            new device is just a sign-in: the same account appears.
+          </li>
+          <li>
+            <strong>There is a way out.</strong>
+            Where the app offers export, the recovery phrase imports into
+            MetaMask, Phantom, or any other standard wallet app.
+          </li>
+        </ul>
 
-        <p>
-          The dependency itself is small and boring: under 2,000 lines including
-          its JSDoc, built from standard, well-studied primitives (WebAuthn,
-          HMAC-SHA-256,
-          <a href="https://www.rfc-editor.org/rfc/rfc5869">HKDF-SHA-256</a>, and
-          <a href="https://csrc.nist.gov/pubs/sp/800/38/d/final">AES-GCM</a>),
-          with ordinary HD derivation living in the demo rather than the
-          library. And the primitive is general: 32 deterministic,
-          authenticator-bound bytes feed any KDF for any curve, and they can key
-          things that are not chains at all, such as client-side encryption of
-          app data.
-        </p>
+        <p>For developers:</p>
+
+        <ul>
+          <li>
+            <strong>The key-store layer mostly disappears.</strong>
+            Derived mode stores nothing, wrapped mode stores a blob that is
+            useless without the passkey, and locking is one call.
+          </li>
+          <li>
+            <strong>Nothing to deploy or operate.</strong>
+            No contracts, bundlers, paymasters, executor accounts, key servers,
+            or provider dependencies, and in derived mode no server-side state
+            at all.
+          </li>
+          <li>
+            <strong>The dependency is small and boring.</strong>
+            Under 2,000 lines including its JSDoc, built from standard,
+            well-studied primitives: WebAuthn, HMAC-SHA-256,
+            <a href="https://www.rfc-editor.org/rfc/rfc5869">HKDF-SHA-256</a>,
+            and
+            <a href="https://csrc.nist.gov/pubs/sp/800/38/d/final">AES-GCM</a>.
+            Ordinary HD derivation lives in the demo rather than the library.
+          </li>
+          <li>
+            <strong>The primitive is general.</strong>
+            32 deterministic, authenticator-bound bytes feed any KDF for any
+            curve, and they can key things that are not chains at all, such as
+            client-side encryption of app data.
+          </li>
+        </ul>
 
         <h2 id="references">References</h2>
 

--- a/site/index.html
+++ b/site/index.html
@@ -461,10 +461,10 @@
 
         <p>
           Passkeys looked like the answer on both fronts. A passkey is a keypair
-          in the device's secure hardware, gated by a biometric and synced by
-          the platform, and it ships with every phone, laptop, and browser. For
-          the user that means no phrase and no password; for the developer it
-          means generation, storage, locking, and cross-device sync are the
+          in the device's secure hardware, gated by OS authentication and synced
+          by the platform, and it ships with every phone, laptop, and browser.
+          For the user that means no phrase and no password; for the developer
+          it means generation, storage, locking, and cross-device sync are the
           platform's job. Crypto adopted passkeys through smart accounts, where
           the passkey signs and a contract on the chain verifies.
         </p>
@@ -581,8 +581,8 @@ clientDataJSON
           and never leaves the authenticator. Each evaluation is one
           <a href="https://www.rfc-editor.org/rfc/rfc2104">HMAC-SHA-256</a>
           keyed by that secret, computed inside the authenticator behind the
-          same biometric check as the signature. The application passes a salt
-          (an input it chooses) and gets 32 bytes back; it never sees the
+          same user-verification check as the signature. The application passes
+          a salt (an input it chooses) and gets 32 bytes back; it never sees the
           secret. (This is FIDO2's
           <a
             href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension"
@@ -618,11 +618,11 @@ clientDataJSON
 
         <p>
           This moves where WebAuthn meets the chain. Instead of teaching each
-          chain to verify WebAuthn envelopes, an application takes
-          biometric-gated entropy out of the ceremony and derives ordinary keys
-          from it, using whatever key derivation function (KDF) and curve the
-          target chain needs. The chain sees a normal signature from a normal
-          account; everything WebAuthn-specific stays on the client.
+          chain to verify WebAuthn envelopes, an application takes user-verified
+          entropy out of the ceremony and derives ordinary keys from it, using
+          whatever key derivation function (KDF) and curve the target chain
+          needs. The chain sees a normal signature from a normal account;
+          everything WebAuthn-specific stays on the client.
         </p>
 
         <p>
@@ -644,7 +644,7 @@ clientDataJSON
           it; how entropy becomes keys (the KDF, the paths, the account model)
           belongs to the application. A session keeps key bytes in memory and
           zeroes them on <code>session.lock()</code>. One ceremony per session
-          is enough: one biometric check, then any number of signatures.
+          is enough: one user-verification check, then any number of signatures.
         </p>
 
         <p>

--- a/site/index.html
+++ b/site/index.html
@@ -394,8 +394,8 @@
           third-party trust assumptions. mera is powered by the
           <a href="https://www.w3.org/TR/webauthn-3/#prf-extension"
             >WebAuthn PRF extension</a
-          >, part of the standard behind passkeys. PRF ships today in the
-          authenticators bundled with major operating systems and browsers.
+          >, part of the standard behind passkeys and already shipping in
+          mainstream authenticators.
         </p>
 
         <h2 id="the-current-state-of-crypto-onboarding">
@@ -405,15 +405,15 @@
         <p>
           Self-custody onboarding (where no one but the user can move the funds)
           has not changed much in a decade. The app generates a recovery phrase
-          — a
+          (a
           <a
             href="https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki"
             >BIP-39</a
           >
-          mnemonic of twelve or twenty-four words — and asks the user to write
-          it down. The scheme works in every wallet app, but its costs land
-          before the app has done anything useful. The first is the flow itself:
-          no ordinary app asks a new user to transcribe those words and re-enter
+          mnemonic of twelve or twenty-four words) and asks the user to write it
+          down. The scheme works in every wallet app, but its costs land before
+          the app has done anything useful. The first is the flow itself: no
+          ordinary app asks a new user to transcribe those words and re-enter
           some of them before first use. The second outlasts onboarding. The
           user is now responsible for backing up a secret that controls all
           future funds.
@@ -436,11 +436,11 @@
 
         <p>
           Developers face a version of this too. Whatever a wallet app is
-          actually for — payments, trading, a game — it rests on a layer that
-          has nothing to do with the product: generate keys, store them, gate
-          their use, lock them when idle, recover them when a device is lost.
-          All of it has to work before the first feature ships. None of it sets
-          the app apart, and getting it wrong costs user funds.
+          actually for (payments, trading, a game), it rests on a layer that has
+          nothing to do with the product: generate keys, store them, gate their
+          use, lock them when idle, recover them when a device is lost. All of
+          it has to work before the first feature ships. None of it sets the app
+          apart, and getting it wrong costs user funds.
         </p>
 
         <p>
@@ -466,8 +466,7 @@
           the user that means no phrase and no password; for the developer it
           means generation, storage, locking, and cross-device sync are the
           platform's job. Crypto adopted passkeys through smart accounts, where
-          the passkey signs and a contract on the chain verifies. But the
-          approach has structural costs.
+          the passkey signs and a contract on the chain verifies.
         </p>
 
         <h2 id="why-a-passkey-cant-sign-a-transaction">
@@ -477,13 +476,13 @@
         <p>
           The problem is down in the details of
           <a href="https://www.w3.org/TR/webauthn-3/">WebAuthn</a>, so a short
-          primer. Each passkey lives on an authenticator — a phone, a laptop, or
-          a security key — and is scoped to one site. The private key is never
+          primer. Each passkey lives on an authenticator (a phone, a laptop, or
+          a security key) and is scoped to one site. The private key is never
           exposed to the site; the server sees only the public key. Every use
           runs a ceremony: the relying party (the site the passkey belongs to)
           sends a one-time challenge, the browser passes it to the
           authenticator, and the authenticator signs after a biometric or PIN
-          check — WebAuthn calls this user verification.
+          check; WebAuthn calls this user verification.
         </p>
 
         <p>
@@ -544,11 +543,11 @@ clientDataJSON
           start a transaction on its own, so something must submit it: a
           bundler, the relayer service defined by the smart-account standard
           <a href="https://eips.ethereum.org/EIPS/eip-4337">ERC-4337</a>
-          — with a paymaster if the app sponsors gas — or an executor account
-          the app runs itself. Solana repeats the whole thing separately — its
-          own P-256 precompile, a smart-account program such as LazorKit (or a
+          (with a paymaster if the app sponsors gas), or an executor account the
+          app runs itself. Solana repeats the whole thing separately: its own
+          P-256 precompile, a smart-account program such as LazorKit (or a
           third-party key service like Para or Privy), and a different address
-          scheme — with nothing reused from the EVM side.
+          scheme. Nothing is reused from the EVM side.
         </p>
 
         <p>
@@ -571,7 +570,7 @@ clientDataJSON
         <p>
           The PRF extension changes what an application can get out of a
           ceremony. Alongside the signature, the authenticator exposes a
-          per-credential pseudo-random function (PRF) — feed it an input, get
+          per-credential pseudo-random function (PRF). Feed it an input, get
           back fixed, unguessable bytes:
         </p>
 
@@ -607,8 +606,8 @@ clientDataJSON
             different credential. The browser also hashes a fixed prefix into
             the salt (<code>SHA-256("WebAuthn PRF" ‖ 0x00 ‖ salt)</code>), so a
             page can never evaluate the underlying hmac-secret PRF at arbitrary
-            points — WebAuthn's evaluations stay separate from the platform's
-            own uses of it.
+            points; WebAuthn's evaluations stay separate from the platform's own
+            uses of it.
           </li>
           <li>
             <strong>Full entropy.</strong>
@@ -621,9 +620,9 @@ clientDataJSON
           This moves where WebAuthn meets the chain. Instead of teaching each
           chain to verify WebAuthn envelopes, an application takes
           biometric-gated entropy out of the ceremony and derives ordinary keys
-          from it — whatever key derivation function (KDF) and curve the target
-          chain needs. The chain sees a normal signature from a normal account;
-          everything WebAuthn-specific stays on the client.
+          from it, using whatever key derivation function (KDF) and curve the
+          target chain needs. The chain sees a normal signature from a normal
+          account; everything WebAuthn-specific stays on the client.
         </p>
 
         <p>
@@ -781,7 +780,7 @@ clientDataJSON
           </svg>
         </figure>
 
-        <p>The skeleton — one ceremony, then app-owned derivation:</p>
+        <p>The skeleton: one ceremony, then app-owned derivation.</p>
 
         <pre><code class="language-typescript">import {
   getDeterministicPrfSaltV1,
@@ -789,14 +788,14 @@ clientDataJSON
   getEvmAddress,
   getPasskeyPrfOutput,
 } from "@category-labs/mera"
-import { deriveWalletPrivateKey } from "./wallet-derivation"
+import { deriveAccountPrivateKey } from "./account-derivation"
 
 const rpId = "account.example.com"
 
 const prfSalt = getDeterministicPrfSaltV1()
 const { prfOutput } = await getPasskeyPrfOutput({ rpId, prfSalt })
 
-const privateKey = deriveWalletPrivateKey({
+const privateKey = deriveAccountPrivateKey({
   entropy: prfOutput,
   path: "m/44'/60'/0'/0/0",
 })
@@ -929,7 +928,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
           <li>
             <strong>A passkey as a second factor.</strong>
             If the blob lives on the application's backend, having the blob is
-            not enough to spend — and neither is access to the user's login.
+            not enough to spend, and neither is access to the user's login.
             Spending requires the passkey ceremony on top.
           </li>
           <li>
@@ -1017,64 +1016,37 @@ const address = getEvmAddress(session.publicKey)</code></pre>
           What users and developers get
         </h2>
 
-        <p>For users:</p>
+        <p>
+          For users, onboarding is one passkey prompt: create a passkey, see an
+          address, nothing to transcribe. Backup and new devices ride on passkey
+          sync, so signing in with the synced passkey on another device brings
+          up the same account, and the same entropy covers every chain the app
+          supports. There is also a way out: where the app offers export, the
+          recovery phrase imports into MetaMask, Phantom, or any other standard
+          wallet app.
+        </p>
 
-        <ul>
-          <li>
-            <strong>Onboarding is one passkey prompt.</strong>
-            Create a passkey, see an address. Nothing to transcribe, nothing to
-            remember.
-          </li>
-          <li>
-            <strong>One passkey, many chains.</strong>
-            The same entropy derives accounts for every chain the app supports.
-          </li>
-          <li>
-            <strong>Backup is passkey sync.</strong>
-            A synced password manager makes the passkey available across
-            devices.
-          </li>
-          <li>
-            <strong>A new device is a sign-in.</strong>
-            Sign in with the synced passkey, and the same account appears.
-          </li>
-          <li>
-            <strong>There is a way out.</strong>
-            Where the app offers export, the recovery phrase imports into any
-            standard wallet app, like MetaMask or Phantom.
-          </li>
-        </ul>
+        <p>
+          For developers, the key-store layer mostly disappears. Derived mode
+          stores nothing, wrapped mode stores a blob that is useless without the
+          passkey, and locking is one call. There is nothing to deploy or
+          operate: no contracts, bundlers, paymasters, executor accounts, key
+          servers, or provider dependencies, and in derived mode no server-side
+          state at all.
+        </p>
 
-        <p>For developers:</p>
-
-        <ul>
-          <li>
-            <strong>The key-store layer mostly disappears.</strong>
-            Derived mode stores nothing; wrapped mode stores a blob that is
-            useless without the passkey; locking is one call.
-          </li>
-          <li>
-            <strong>Nothing to deploy or operate.</strong>
-            No contracts, bundlers, paymasters, executor accounts, key servers,
-            or provider dependencies — and in derived mode, no server-side state
-            at all.
-          </li>
-          <li>
-            <strong>The dependency is small and boring.</strong>
-            Under 2,000 lines including its JSDoc, built from standard,
-            well-studied primitives: WebAuthn, HMAC-SHA-256,
-            <a href="https://www.rfc-editor.org/rfc/rfc5869">HKDF-SHA-256</a>,
-            and
-            <a href="https://csrc.nist.gov/pubs/sp/800/38/d/final">AES-GCM</a>
-            — with ordinary HD derivation living in the demo, not the library.
-          </li>
-          <li>
-            <strong>The primitive is general.</strong>
-            32 deterministic, authenticator-bound bytes feed any KDF for any
-            curve — and they can key things that are not chains at all, such as
-            client-side encryption of app data.
-          </li>
-        </ul>
+        <p>
+          The dependency itself is small and boring: under 2,000 lines including
+          its JSDoc, built from standard, well-studied primitives (WebAuthn,
+          HMAC-SHA-256,
+          <a href="https://www.rfc-editor.org/rfc/rfc5869">HKDF-SHA-256</a>, and
+          <a href="https://csrc.nist.gov/pubs/sp/800/38/d/final">AES-GCM</a>),
+          with ordinary HD derivation living in the demo rather than the
+          library. And the primitive is general: 32 deterministic,
+          authenticator-bound bytes feed any KDF for any curve, and they can key
+          things that are not chains at all, such as client-side encryption of
+          app data.
+        </p>
 
         <h2 id="references">References</h2>
 
@@ -1085,7 +1057,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
                 >WebAuthn Level 3</a
               ></strong
             >
-            (W3C) — the passkey API. Specifically:
+            (W3C): the passkey API. Specifically
             <a href="https://www.w3.org/TR/webauthn-3/#sctn-authenticator-data"
               >authenticator data (§6.1)</a
             >,
@@ -1103,8 +1075,8 @@ const address = getEvmAddress(session.publicKey)</code></pre>
                 >CTAP 2.2</a
               ></strong
             >
-            (FIDO Alliance) — the authenticator protocol underneath WebAuthn.
-            Specifically:
+            (FIDO Alliance): the authenticator protocol underneath WebAuthn.
+            Specifically
             <a
               href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension"
               >the hmac-secret extension (§12.7)</a
@@ -1116,8 +1088,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
                 href="https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki"
                 >BIP-39</a
               ></strong
-            >
-            — mnemonic phrases from entropy.
+            >: mnemonic phrases from entropy.
           </li>
           <li>
             <strong
@@ -1125,8 +1096,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
                 href="https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki"
                 >BIP-32</a
               ></strong
-            >
-            — hierarchical deterministic derivation for secp256k1.
+            >: hierarchical deterministic derivation for secp256k1.
           </li>
           <li>
             <strong
@@ -1134,16 +1104,14 @@ const address = getEvmAddress(session.publicKey)</code></pre>
                 href="https://github.com/satoshilabs/slips/blob/master/slip-0010.md"
                 >SLIP-0010</a
               ></strong
-            >
-            — hierarchical deterministic derivation for Ed25519.
+            >: hierarchical deterministic derivation for Ed25519.
           </li>
           <li>
             <strong
               ><a href="https://eips.ethereum.org/EIPS/eip-4337"
                 >ERC-4337</a
               ></strong
-            >
-            — account abstraction.
+            >: account abstraction.
           </li>
           <li>
             <strong
@@ -1151,62 +1119,54 @@ const address = getEvmAddress(session.publicKey)</code></pre>
                 href="https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md"
                 >RIP-7212</a
               ></strong
-            >
-            — the P-256 signature-verification precompile.
+            >: the P-256 signature-verification precompile.
           </li>
           <li>
             <strong
               ><a href="https://eips.ethereum.org/EIPS/eip-1014"
                 >EIP-1014</a
               ></strong
-            >
-            — CREATE2, deterministic contract addresses.
+            >: CREATE2, deterministic contract addresses.
           </li>
           <li>
             <strong
               ><a href="https://www.rfc-editor.org/rfc/rfc2104"
                 >RFC 2104</a
               ></strong
-            >
-            — HMAC.
+            >: HMAC.
           </li>
           <li>
             <strong
               ><a href="https://www.rfc-editor.org/rfc/rfc5869"
                 >RFC 5869</a
               ></strong
-            >
-            — HKDF.
+            >: HKDF.
           </li>
           <li>
             <strong
               ><a href="https://csrc.nist.gov/pubs/sp/800/38/d/final"
                 >NIST SP 800-38D</a
               ></strong
-            >
-            — AES-GCM.
+            >: AES-GCM.
           </li>
           <li>
             <strong
               ><a href="https://www.rfc-editor.org/rfc/rfc8032"
                 >RFC 8032</a
               ></strong
-            >
-            — Ed25519 (EdDSA).
+            >: Ed25519 (EdDSA).
           </li>
           <li>
             <strong
               ><a href="https://www.secg.org/sec2-v2.pdf">SEC 2</a></strong
-            >
-            — the secp256k1 curve.
+            >: the secp256k1 curve.
           </li>
           <li>
             <strong
               ><a href="https://csrc.nist.gov/pubs/sp/800/186/final"
                 >NIST SP 800-186</a
               ></strong
-            >
-            — the P-256 curve.
+            >: the P-256 curve.
           </li>
         </ul>
       </article>

--- a/src/chains/evm.ts
+++ b/src/chains/evm.ts
@@ -19,7 +19,9 @@ function getEvmAddress(publicKey: Uint8Array): EvmAddress {
 /**
  * Returns true when a string is a 20-byte `0x`-prefixed EVM address.
  *
- * All-lowercase and all-uppercase hex bodies are accepted as-is (no checksum to verify). Mixed-case inputs are validated against EIP-55: an inconsistent mixed-case address — a typo or a tampered string — is rejected.
+ * All-lowercase and all-uppercase hex bodies are accepted as-is (no checksum
+ * to verify). Mixed-case inputs are validated against EIP-55: an inconsistent
+ * mixed-case address (a typo or a tampered string) is rejected.
  *
  * @param value - String to check.
  * @returns `true` when `value` is a 20-byte `0x`-prefixed EVM address with a valid (or absent) EIP-55 checksum.

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -107,10 +107,10 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  *
  * The credential is requested with fixed parameters: ES256 or RS256 key types,
  * attestation `"none"`, a required resident key, and required user
- * verification. User verification is the authenticator's local check, and the
- * platform chooses the gesture: a biometric, a device PIN, or a password all
- * satisfy it. The requirement is not configurable because the PRF extension
- * always evaluates the credential's user-verified PRF and overrides a weaker
+ * verification. User verification is the authenticator's local check; the
+ * gesture depends on the platform (a biometric, a device PIN, or a password).
+ * The requirement is not configurable because the PRF extension always
+ * evaluates the credential's user-verified PRF and overrides a weaker
  * `userVerification` setting, so exposing the setting could neither change
  * the PRF output nor remove the check.
  * @see {@link https://www.w3.org/TR/webauthn-3/#user-verification | WebAuthn: user verification}

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -344,8 +344,8 @@ async function getPasskeyPrfOutput({
  * @returns Credential metadata and the first PRF output.
  * @remarks
  * Invokes `navigator.credentials.create()`. On authenticators that do not
- * evaluate PRF during creation, also invokes `navigator.credentials.get()` — a
- * second browser prompt.
+ * evaluate PRF during creation, also invokes `navigator.credentials.get()`,
+ * which means a second browser prompt.
  *
  * WebAuthn challenges are generated internally. Raw attestation and assertion
  * responses are not returned.

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -107,7 +107,14 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  *
  * The credential is requested with fixed parameters: ES256 or RS256 key types,
  * attestation `"none"`, a required resident key, and required user
- * verification.
+ * verification. User verification is the authenticator's local check, and the
+ * platform chooses the gesture: a biometric, a device PIN, or a password all
+ * satisfy it. The requirement is not configurable because the PRF extension
+ * always evaluates the credential's user-verified PRF and overrides a weaker
+ * `userVerification` setting, so exposing the setting could neither change
+ * the PRF output nor remove the check.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#user-verification | WebAuthn: user verification}
+ * @see {@link https://www.w3.org/TR/webauthn-3/#prf-extension | WebAuthn: the PRF extension}
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or returns a malformed create-time PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -250,6 +257,16 @@ async function createPasskey({
  * The PRF output is a deterministic function of the credential, `rpId`, and
  * `prfSalt`: the same three inputs reproduce the same output, and a different
  * salt yields an unrelated output.
+ *
+ * The assertion requires user verification, and the requirement is not
+ * configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs
+ * per credential, one for user-verified requests and one for the rest;
+ * WebAuthn exposes only the user-verified PRF and overrides a weaker
+ * `userVerification` setting when evaluating it. A configurable setting could
+ * therefore neither change the PRF output nor skip the user-verification
+ * check.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#prf-extension | WebAuthn: the PRF extension}
+ * @see {@link https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement | WebAuthn: UserVerificationRequirement}
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -91,7 +91,7 @@ function createSecp256k1SigningSession({
       const recovery = signature[0];
 
       // A recovery ID of 2 or 3 requires the signature's r to be at least the
-      // curve order, which happens with probability about 2^-127 — never in
+      // curve order, which happens with probability about 2^-127, never in
       // practice. Such a signature cannot be address-recovered from `r` and a
       // parity bit alone, so fail loudly instead of returning an unusable
       // recovery ID. The check also narrows the byte to the declared `0 | 1`.

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -216,7 +216,7 @@ type CreateSecretVaultInput = {
  * post-call mutation does not change the vault being produced. Caller-owned
  * input buffers are not modified or zeroed.
  *
- * Security: a vault is bound to its `prfOutput` only — not to the credential
+ * Security: a vault is bound to its `prfOutput` only, not to the credential
  * ID or salt. Secrets wrapped under one reused PRF output share a wrapping key,
  * so their nonce/ciphertext pairs are interchangeable by anyone who can rewrite
  * stored vault JSON; a fresh `prfSalt` per secret avoids the shared key.


### PR DESCRIPTION
## Why

The public copy (README, site article, JSDoc) was largely AI-written with human feedback, and it showed: em dashes everywhere, four identical bold-lead bullet lists in one article, recycled "no X, no Y, no Z" triads, symmetric paragraph closers, and "X, not Y" contrast constructions. A few passages also broke the rules in `site/WRITING.md`: "wallet" where "account" is meant, and a network-support claim ("EVM + Solana today") in the README.

## What changed

- **Em dashes**: all removed (12 lines in the README, 31 in the site, 4 in JSDoc), replaced with parentheticals, colons, semicolons, or sentence breaks depending on the sentence.
- **README**: "(EVM + Solana today)" replaced with a bullet naming what actually ships; "wallet" reserved for wallet apps per WRITING.md ("account keys", "stateless account access", "imports of an existing account" instead of "hot-wallet UX"); the "X, not Y" bullets and the symmetric "Best for..." mode closers rewritten.
- **Site**: the verbatim-duplicated "PRF ships today..." sentence de-duplicated; the teaser closer "But the approach has structural costs." deleted; "What users and developers get" rewritten from two bold-lead bullet lists into prose so the article has two list shapes instead of four identical ones; second MetaMask/Phantom mention reworded.
- **Example rename**: `deriveWalletPrivateKey` / `./wallet-derivation` → `deriveAccountPrivateKey` / `./account-derivation` in the README and site code blocks. The identifier is illustrative only; nothing else in the repo references it.
- **JSDoc**: comment text only, no behavior changes (`passkey.ts`, `secret.ts`, `secp256k1.ts`, `evm.ts`; the last also rewrapped to 80 columns).

Kept deliberately: factual precision contrasts ("an assertion is not a signature over an arbitrary 32-byte hash"), good fragments ("The curve is wrong too."), and allowed mild opinion ("small and boring").

## Validation

- `npm run check` (Biome lint + format) passes.
- Grep confirms zero "—" characters remain in README, site, and src.
- Source edits are JSDoc/comment text only.