### PR TITLE
Collapse createPasskey overloads into a single signature

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -92,12 +92,14 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
 /**
  * Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
  *
- * When the authenticator evaluates PRF at create time, the result includes the
- * first PRF output for `prfSalt`, so no second ceremony is needed to obtain the
- * PRF output.
+ * When `prfSalt` is provided and the authenticator evaluates PRF at create
+ * time, the result includes the first PRF output, so no second ceremony is
+ * needed. Without `prfSalt`, no PRF evaluation happens during creation and
+ * the result carries credential metadata only; a later `getPasskeyPrfOutput`
+ * call with a salt produces PRF output for this passkey.
  *
  * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
- * @returns Credential metadata, plus the first PRF output when it was evaluated during creation.
+ * @returns Credential metadata, plus the first PRF output when `prfSalt` was provided and evaluated during creation.
  * @remarks
  * Invokes `navigator.credentials.create()`, which may show browser or
  * authenticator UI.
@@ -116,47 +118,10 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * @see {@link https://www.w3.org/TR/webauthn-3/#user-verification | WebAuthn: user verification}
  * @see {@link https://www.w3.org/TR/webauthn-3/#prf-extension | WebAuthn: the PRF extension}
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or returns a malformed create-time PRF output.
- * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
-function createPasskey(
-  options: CreatePasskeyInput & { prfSalt: Uint8Array },
-): Promise<CreatePasskeyResult>;
-/**
- * Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
- *
- * Without `prfSalt`, no PRF evaluation happens during creation, so the result
- * carries credential metadata only; a later `getPasskeyPrfOutput` call with a
- * salt produces PRF output for this passkey.
- *
- * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
- * @returns Credential metadata for the created passkey.
- * @remarks
- * The ceremony is the one documented on the `prfSalt` overload: the same
- * browser or authenticator UI, internally generated challenge, and fixed
- * WebAuthn parameters, minus the PRF salt evaluation.
- * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF.
- * @throws MeraError with code `INPUT_INVALID` when `user.id` is provided but not 1 to 64 bytes.
- * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
- * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
- */
-function createPasskey(
-  options: Omit<CreatePasskeyInput, "prfSalt"> & { prfSalt?: never },
-): Promise<PasskeyCredentialMetadata>;
-/**
- * Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
- *
- * Fallback overload for options where `prfSalt` presence is not statically
- * known. The ceremony and failure modes are the ones documented on the
- * `prfSalt` overload, with the salt evaluated only when present.
- *
- * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
- * @returns Credential metadata, plus the first PRF output when `prfSalt` was provided and evaluated during creation.
- */
-function createPasskey(
-  options: CreatePasskeyInput,
-): Promise<CreatePasskeyResult>;
 async function createPasskey({
   rp,
   user,
@@ -507,13 +472,8 @@ function copyPrfOutput(
   return output;
 }
 
-/**
- * Options accepted by `createPasskey`.
- *
- * Aliased directly rather than via `Parameters<typeof createPasskey>[0]`
- * because `Parameters` sees only the last overload.
- */
-type CreatePasskeyOptions = CreatePasskeyInput;
+/** Options accepted by `createPasskey`. */
+type CreatePasskeyOptions = Parameters<typeof createPasskey>[0];
 /** Options accepted by `createPasskeyWithPrfOutput`. */
 type CreatePasskeyWithPrfOutputOptions = Parameters<
   typeof createPasskeyWithPrfOutput


### PR DESCRIPTION
## Problem

`createPasskey` carried three overload signatures with three near-duplicate JSDoc blocks: the same summary line three times, the same four `@throws` lists twice, and a third block existing only to point at the first. The only narrowing the machinery delivered was the no-salt call returning `PasskeyCredentialMetadata` instead of `CreatePasskeyResult` — i.e. hiding one field (`prfOutput`) that is *already optional* in the with-salt case, so callers must handle its absence either way. The cleverness also leaked into the public option type: `CreatePasskeyOptions` needed a hand-written alias with an apology comment because `Parameters<typeof createPasskey>[0]` sees only the last overload, breaking the option-bag convention every other function in the library follows.

## Change

One signature, one JSDoc block. The merged doc states both behaviors plainly: with `prfSalt`, the result includes the first PRF output when the authenticator evaluated it at create time; without, the result carries credential metadata only and a later `getPasskeyPrfOutput` produces the output. `CreatePasskeyOptions` is now the standard `Parameters<typeof createPasskey>[0]` alias. Net −38 lines, all of them duplicate documentation or overload scaffolding.

No caller depended on the narrowed no-salt overload: the only no-salt call sites are e2e tests, and the widened return type only adds an optional field.

## Validation

- `npm run check` clean.
- `npm test`: 56 unit tests pass. The 3 `chromium-e2e` failures ("Failed to fetch dynamically imported module" from the local test server) reproduce identically on unmodified `main` in this environment — pre-existing/environmental, not introduced here.