### PR TITLE
State the user-verification mechanism once, in getPasskeyPrfOutput

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -111,10 +111,10 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * attestation `"none"`, a required resident key, and required user
  * verification. User verification is the authenticator's local check; the
  * gesture depends on the platform (a biometric, a device PIN, or a password).
- * The requirement is not configurable because the PRF extension always
- * evaluates the credential's user-verified PRF and overrides a weaker
- * `userVerification` setting, so exposing the setting could neither change
- * the PRF output nor remove the check.
+ * The requirement is not configurable: the PRF extension evaluates only the
+ * credential's user-verified PRF, so a `userVerification` setting could
+ * neither change the PRF output nor remove the check ({@link
+ * getPasskeyPrfOutput} documents the authenticator mechanism).
  *
  * A `PRF_UNAVAILABLE` failure happens after the creation ceremony has
  * completed: the passkey exists on the authenticator, but the thrown error
@@ -231,9 +231,8 @@ async function createPasskey({
  * configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs
  * per credential, one for user-verified requests and one for the rest;
  * WebAuthn exposes only the user-verified PRF and overrides a weaker
- * `userVerification` setting when evaluating it. A configurable setting could
- * therefore neither change the PRF output nor skip the user-verification
- * check.
+ * `userVerification` setting when evaluating it, so a configurable setting
+ * could neither change the PRF output nor skip the check.
  * @see {@link https://www.w3.org/TR/webauthn-3/#prf-extension | WebAuthn: the PRF extension}
  * @see {@link https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement | WebAuthn: UserVerificationRequirement}
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.


### PR DESCRIPTION
## Problem

`createPasskey` and `getPasskeyPrfOutput` each carried a full derivation of the same argument — that exposing a `userVerification` setting would change nothing because the PRF extension always evaluates the user-verified PRF. The `getPasskeyPrfOutput` version additionally re-derived it from CTAP internals. The guidelines flag documentation that repeats itself; the argument only needs one home.

## Change

The authenticator mechanism (CTAP `hmac-secret`'s two PRFs per credential, WebAuthn exposing only the user-verified one) stays fully in `getPasskeyPrfOutput` — the function that performs the PRF evaluation — tightened by one sentence. `createPasskey` now states the conclusion in one sentence and links to `getPasskeyPrfOutput` for the mechanism. Both `@see` links to the WebAuthn spec sections are kept, so no technical reference is lost — the change removes only the duplicated derivation.

Doc-only; no runtime change. Stacked on #111 (edits the same `createPasskey` doc block).

## Validation

- `npm run check` and `tsc --noEmit` clean. Doc-only change.