### PR TITLE
Document the synchronous input snapshot in hkdfSha256AesGcmKey

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -300,6 +300,8 @@ async function unwrapSecretVault({
   vault,
   prfOutput,
 }: UnwrapSecretVaultInput): Promise<Uint8Array<ArrayBuffer>> {
+  // The copy guarantee documented above is provided by hkdfSha256AesGcmKey,
+  // which snapshots prfOutput synchronously before its first await.
   const wrappingKey = await deriveWrappingKey(prfOutput);
 
   return aesGcmDecrypt({

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -34,6 +34,12 @@ function getCrypto(): Crypto {
  * @param ikm - Input keying material.
  * @param info - HKDF info/context bytes; domain-separates keys derived from the same `ikm`.
  * @returns A non-extractable AES-GCM `CryptoKey` usable for encryption and decryption.
+ * @remarks
+ * `ikm` and `info` are copied into standalone buffers synchronously, before
+ * the first `await`, so mutating either input after the call starts does not
+ * affect the derived key. Public copy guarantees (`unwrapSecretVault`'s
+ * `prfOutput` remark) rest on this ordering; the copies must stay ahead of
+ * every `await`.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  */
 async function hkdfSha256AesGcmKey(


### PR DESCRIPTION
## Problem

`unwrapSecretVault` publicly documents that `prfOutput` is "copied before async cryptographic work starts" — but unlike `createSecretVault`, it never copies explicitly. The guarantee holds only because `hkdfSha256AesGcmKey` happens to call `asArrayBuffer()` on its inputs synchronously, before its first `await`, and nothing in that helper's docs said so. A well-meaning refactor of the webcrypto helper could move the copy past an `await` and silently break a documented public guarantee.

An explicit copy in `unwrapSecretVault` was the alternative, but it would allocate a second buffer of key material that then needs its own zeroing; stating the real mechanism where it lives is simpler and leaves one copy of the PRF output instead of two.

## Change

- `hkdfSha256AesGcmKey` now documents the invariant: `ikm` and `info` are snapshotted synchronously before the first `await`, public copy guarantees rest on that ordering, and the copies must stay ahead of every `await`.
- `unwrapSecretVault` gets a two-line comment pointing its documented guarantee at that mechanism.

Doc/comment-only; no runtime change.

## Validation

- `npm run check` and `tsc --noEmit` clean.