### PR TITLE
Replace readBase64Url's union length parameter with plain named options

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -382,12 +382,9 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     "VAULT_FORMAT_INVALID",
     { byteLength: PRF_SALT_LENGTH },
   );
-  const nonce = readBase64Url(
-    vault.nonce,
-    "nonce",
-    "VAULT_FORMAT_INVALID",
-    { byteLength: NONCE_LENGTH },
-  );
+  const nonce = readBase64Url(vault.nonce, "nonce", "VAULT_FORMAT_INVALID", {
+    byteLength: NONCE_LENGTH,
+  });
   const ciphertext = readBase64Url(
     vault.ciphertext,
     "ciphertext",

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -152,7 +152,7 @@ function readBase64Url(
   value: unknown,
   name: string,
   errorCode: MeraErrorCode,
-  byteLength?: number | { min: number },
+  options: { byteLength?: number; minByteLength?: number } = {},
 ): string {
   if (typeof value !== "string") {
     throw new MeraError(errorCode, `${name} must be base64url`);
@@ -165,14 +165,20 @@ function readBase64Url(
     throw new MeraError(errorCode, `${name} must be base64url`, { cause });
   }
 
-  if (typeof byteLength === "number" && bytes.length !== byteLength) {
-    throw new MeraError(errorCode, `${name} must be ${byteLength} bytes`);
-  }
-
-  if (typeof byteLength === "object" && bytes.length < byteLength.min) {
+  if (options.byteLength !== undefined && bytes.length !== options.byteLength) {
     throw new MeraError(
       errorCode,
-      `${name} must be at least ${byteLength.min} bytes`,
+      `${name} must be ${options.byteLength} bytes`,
+    );
+  }
+
+  if (
+    options.minByteLength !== undefined &&
+    bytes.length < options.minByteLength
+  ) {
+    throw new MeraError(
+      errorCode,
+      `${name} must be at least ${options.minByteLength} bytes`,
     );
   }
 
@@ -235,7 +241,7 @@ async function createSecretVault({
     credential.credentialId,
     "credential.credentialId",
     "INPUT_INVALID",
-    { min: 1 },
+    { minByteLength: 1 },
   );
 
   if (prfSalt.length !== PRF_SALT_LENGTH) {
@@ -345,7 +351,7 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     vault.credential.credentialId,
     "credential.credentialId",
     "VAULT_FORMAT_INVALID",
-    { min: 1 },
+    { minByteLength: 1 },
   );
 
   let transports: PasskeyCredentialTransport[] | undefined;
@@ -374,19 +380,19 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
     vault.prfSalt,
     "prfSalt",
     "VAULT_FORMAT_INVALID",
-    PRF_SALT_LENGTH,
+    { byteLength: PRF_SALT_LENGTH },
   );
   const nonce = readBase64Url(
     vault.nonce,
     "nonce",
     "VAULT_FORMAT_INVALID",
-    NONCE_LENGTH,
+    { byteLength: NONCE_LENGTH },
   );
   const ciphertext = readBase64Url(
     vault.ciphertext,
     "ciphertext",
     "VAULT_FORMAT_INVALID",
-    { min: GCM_TAG_LENGTH },
+    { minByteLength: GCM_TAG_LENGTH },
   );
 
   // Allowlist: only v1 schema fields are copied, so unknown input keys are dropped.


### PR DESCRIPTION
## Problem

`readBase64Url` took a clever `byteLength?: number | { min: number }` union that a reader has to decode via `typeof` branches, and its `{ min }` branch expressed the same concept as the `minByteLength` option `base64UrlDecode` already has — two different option shapes for one idea (a length constraint on decoded base64url), in violation of "reach for a plainer construct over a clever one a reader has to decode."

Full delegation to `base64UrlDecode`'s option was considered and rejected: `readBase64Url` exists to produce field-named errors ("prfSalt must be 32 bytes") with a caller-chosen error code, and its catch block maps decode failures to "must be base64url" — routing length failures through that catch would mislabel them as format errors.

## Change

The union parameter becomes a plain options bag, `{ byteLength?: number; minByteLength?: number }`, matching `base64UrlDecode`'s naming. The `typeof`-branch decoding is gone; call sites now read literally (`{ byteLength: PRF_SALT_LENGTH }`, `{ minByteLength: 1 }`). Error codes, messages, and validation behavior are unchanged.

## Validation

- `npm run check` clean; `npm test`: 56 unit tests pass, including the `parseSecretVault` length/format validation tests. The 3 `chromium-e2e` failures reproduce identically on unmodified `main` in this environment (local test-server module fetch; pre-existing, unrelated).