### PR TITLE
Build the fallback credential metadata once in createPasskeyWithPrfOutput

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -393,27 +393,26 @@ async function createPasskeyWithPrfOutput({
     prfSalt: prfSaltCopy,
   });
 
+  const credentialMetadata: PasskeyCredentialMetadata = {
+    credentialId: credential.credentialId,
+    ...(credential.transports !== undefined
+      ? { transports: credential.transports }
+      : {}),
+  };
+
   const prfOutput =
     credential.prfOutput ??
     (
       await getPasskeyPrfOutput({
         rpId: rp.id,
-        credential: {
-          credentialId: credential.credentialId,
-          ...(credential.transports !== undefined
-            ? { transports: credential.transports }
-            : {}),
-        },
+        credential: credentialMetadata,
         prfSalt: prfSaltCopy,
         ...(timeout !== undefined ? { timeout } : {}),
       })
     ).prfOutput;
 
   return {
-    credentialId: credential.credentialId,
-    ...(credential.transports !== undefined
-      ? { transports: credential.transports }
-      : {}),
+    ...credentialMetadata,
     prfSalt: prfSaltCopy,
     prfOutput,
   };


### PR DESCRIPTION
## Problem

`createPasskeyWithPrfOutput` constructed the same `{ credentialId, ...(transports ? { transports } : {}) }` object twice from the same source in one function body — once for the fallback `getPasskeyPrfOutput` call and once for the return value. Duplicated construction is a chance for the two to drift apart, and the conditional-spread idiom is noisy enough that repeating it hurts readability.

## Change

The credential metadata is built once into a `PasskeyCredentialMetadata`-typed local and used for both the fallback assertion and the returned result. Behavior is unchanged; the returned object has the same shape (the `transports` key is still omitted, not set to `undefined`, when the browser reported none).

## Validation

- `npm run check` clean; `npm test`: 56 unit tests pass, including the `createPasskeyWithPrfOutput` fallback-snapshot test. The 3 `chromium-e2e` failures reproduce identically on unmodified `main` in this environment (local test-server module fetch; pre-existing, unrelated).