### PR TITLE
Explain the string-widening mechanism on PasskeyCredentialTransport

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,13 @@ type Brand<T, Name extends string> = T & { readonly [brand]: Name };
  */
 type SolanaAddress = Brand<string, "SolanaAddress">;
 
-/** WebAuthn authenticator transport metadata, including future browser transport values. */
+/**
+ * WebAuthn authenticator transport metadata, including future browser transport values.
+ *
+ * The `string & {}` arm accepts any string without collapsing the union to
+ * plain `string`, so editors keep offering the known `AuthenticatorTransport`
+ * literals in autocomplete.
+ */
 type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});
 
 /** Metadata needed to ask WebAuthn for a previously created passkey. */


### PR DESCRIPTION
## Problem

`PasskeyCredentialTransport = AuthenticatorTransport | (string & {})` is the right idiom, but `(string & {})` is a construct a reader has to decode, and the one-line doc stated only the intent ("including future browser transport values"), not the mechanism. The guidelines ask docs that give a rationale to explain the mechanism, not just the claim.

## Change

Two sentences added to the type's JSDoc: the `string & {}` arm accepts any string without collapsing the union to plain `string`, which is what keeps the known `AuthenticatorTransport` literals in editor autocomplete. Doc-only; the type is unchanged.

## Validation

- `npm run check` and `tsc --noEmit` clean. Doc-only change.