### PR TITLE
Move the derived-mode recovery paragraph under Derived

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The result is ordinary signing material for the app to use. No smart-account dep
 
 Cross-device use requires the passkey to be available on the new device. This mode fits stateless account access across devices.
 
-**Wrapped.** An AES-256-GCM blob holds one secret: a recovery phrase, a private key, or any bytes. The passkey ceremony produces the key material needed to decrypt it. The blob can live in `localStorage`, a backend, or a sync service. This mode fits existing-account imports and sessions that sign many transactions.
-
 Derived mode stores no app-owned secret to recover. The account may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's `rpId` after a domain migration. Recovery then depends on an app-provided export, import, or backup path.
+
+**Wrapped.** An AES-256-GCM blob holds one secret: a recovery phrase, a private key, or any bytes. The passkey ceremony produces the key material needed to decrypt it. The blob can live in `localStorage`, a backend, or a sync service. This mode fits existing-account imports and sessions that sign many transactions.
 
 ## Install
 


### PR DESCRIPTION
## Problem

The Modes section's recovery paragraph ("Derived mode stores no app-owned secret to recover…") sat directly after the **Wrapped** description, so on first read it looks like a wrapped-mode caveat. It is entirely about derived mode, and the trailing placement also implicitly frames wrapped mode as the fix for a derived-mode constraint — something the site's own writing guide says to avoid (the two modes are parallel options).

## Change

The paragraph moves up to sit with the other derived-mode text, immediately after the cross-device paragraph and before **Wrapped**. No wording changes.

## Validation

README-only reordering; no code or examples touched.