### PR TITLE
Document the tests-run-against-dist workflow in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ npm run check       # Biome lint + format
 npm run check:pack  # verify the publishable tarball
 ```
 
+Tests import the built `dist/` output, so they exercise the shipped artifact. Run them through `npm test`, which rebuilds first; a bare `playwright test` can run against stale `dist/`.
+
 ## License
 
 Licensed under either of [Apache License](./LICENSE-APACHE), Version


### PR DESCRIPTION
## Problem

AGENTS.md says project commands and the testing workflow live in the README's Development section. The commands are there and accurate, but the one real workflow gotcha — tests import the built `dist/` output, so a bare `playwright test` silently runs against stale code — lived only in a `playwright.config.ts` header comment where nobody setting up the repo would see it.

## Change

One sentence after the Development command block, matching the config comment's content: tests exercise the shipped artifact, run them through `npm test` (which rebuilds first), bare `playwright test` can hit stale `dist/`.

## Validation

README-only addition; wording cross-checked against the `playwright.config.ts` header comment it surfaces.