### PR TITLE
Extract a shared withStubbedGlobal test helper

### DIFF
--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-export function expectError(fn: () => unknown, code: string): void {
+function expectError(fn: () => unknown, code: string): void {
   try {
     fn();
   } catch (error) {
@@ -10,3 +10,26 @@ export function expectError(fn: () => unknown, code: string): void {
 
   throw new Error(`expected fn to throw with code ${code}`);
 }
+
+// Replaces a globalThis property for the duration of fn, then restores the
+// original property descriptor (or deletes the property if it did not exist).
+async function withStubbedGlobal<T>(
+  name: string,
+  value: unknown,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, { configurable: true, value });
+
+  try {
+    return await fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, name, original);
+    } else {
+      Reflect.deleteProperty(globalThis, name);
+    }
+  }
+}
+
+export { expectError, withStubbedGlobal };

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -5,21 +5,7 @@ import {
   createPasskeyWithPrfOutput,
   getPasskeyPrfOutput,
 } from "../dist/passkey.js";
-import { expectError } from "./helpers.js";
-
-const ORIGINAL_NAVIGATOR = Object.getOwnPropertyDescriptor(
-  globalThis,
-  "navigator",
-);
-const ORIGINAL_CRYPTO = Object.getOwnPropertyDescriptor(globalThis, "crypto");
-
-function restoreGlobalCrypto(): void {
-  if (ORIGINAL_CRYPTO) {
-    Object.defineProperty(globalThis, "crypto", ORIGINAL_CRYPTO);
-  } else {
-    Reflect.deleteProperty(globalThis, "crypto");
-  }
-}
+import { expectError, withStubbedGlobal } from "./helpers.js";
 
 test("copyPrfOutput copies a plain ArrayBuffer without aliasing", () => {
   const source = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
@@ -85,12 +71,7 @@ test("copyPrfOutput rejects PRF output that is not 32 bytes", () => {
 });
 
 test("passkey helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable", async () => {
-  Object.defineProperty(globalThis, "crypto", {
-    configurable: true,
-    value: undefined,
-  });
-
-  try {
+  await withStubbedGlobal("crypto", undefined, async () => {
     const user = { name: "nad", displayName: "nad" };
     const prfSalt = new Uint8Array(32);
 
@@ -116,50 +97,45 @@ test("passkey helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable",
         prfSalt,
       }),
     ).rejects.toMatchObject({ code: "CRYPTO_UNAVAILABLE" });
-  } finally {
-    restoreGlobalCrypto();
-  }
+  });
 });
 
 test("passkey helpers generate internal challenges and request no attestation", async () => {
   let createOptions: PublicKeyCredentialCreationOptions | undefined;
   let getOptions: PublicKeyCredentialRequestOptions | undefined;
 
-  Object.defineProperty(globalThis, "navigator", {
-    configurable: true,
-    value: {
-      credentials: {
-        async create({ publicKey }: CredentialCreationOptions) {
-          createOptions = publicKey;
-          return {
-            type: "public-key",
-            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
-            response: {
-              getTransports: () => ["internal"],
+  const navigator = {
+    credentials: {
+      async create({ publicKey }: CredentialCreationOptions) {
+        createOptions = publicKey;
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          response: {
+            getTransports: () => ["internal"],
+          },
+          getClientExtensionResults: () => ({
+            prf: {
+              enabled: true,
+              results: { first: new Uint8Array(32).buffer },
             },
-            getClientExtensionResults: () => ({
-              prf: {
-                enabled: true,
-                results: { first: new Uint8Array(32).buffer },
-              },
-            }),
-          };
-        },
-        async get({ publicKey }: CredentialRequestOptions) {
-          getOptions = publicKey;
-          return {
-            type: "public-key",
-            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
-            getClientExtensionResults: () => ({
-              prf: { results: { first: new Uint8Array(32).buffer } },
-            }),
-          };
-        },
+          }),
+        };
+      },
+      async get({ publicKey }: CredentialRequestOptions) {
+        getOptions = publicKey;
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          getClientExtensionResults: () => ({
+            prf: { results: { first: new Uint8Array(32).buffer } },
+          }),
+        };
       },
     },
-  });
+  };
 
-  try {
+  await withStubbedGlobal("navigator", navigator, async () => {
     await createPasskey({
       rp: { id: "example.com", name: "Mera Test" },
       user: {
@@ -173,27 +149,19 @@ test("passkey helpers generate internal challenges and request no attestation", 
       rpId: "example.com",
       prfSalt: new Uint8Array(32),
     });
+  });
 
-    if (createOptions === undefined || getOptions === undefined) {
-      throw new Error("expected WebAuthn options to be captured");
-    }
-
-    expect(createOptions.challenge).toBeInstanceOf(ArrayBuffer);
-    expect(new Uint8Array(createOptions.challenge as ArrayBuffer)).toHaveLength(
-      32,
-    );
-    expect(createOptions.attestation).toBe("none");
-    expect(getOptions.challenge).toBeInstanceOf(ArrayBuffer);
-    expect(new Uint8Array(getOptions.challenge as ArrayBuffer)).toHaveLength(
-      32,
-    );
-  } finally {
-    if (ORIGINAL_NAVIGATOR) {
-      Object.defineProperty(globalThis, "navigator", ORIGINAL_NAVIGATOR);
-    } else {
-      Reflect.deleteProperty(globalThis, "navigator");
-    }
+  if (createOptions === undefined || getOptions === undefined) {
+    throw new Error("expected WebAuthn options to be captured");
   }
+
+  expect(createOptions.challenge).toBeInstanceOf(ArrayBuffer);
+  expect(new Uint8Array(createOptions.challenge as ArrayBuffer)).toHaveLength(
+    32,
+  );
+  expect(createOptions.attestation).toBe("none");
+  expect(getOptions.challenge).toBeInstanceOf(ArrayBuffer);
+  expect(new Uint8Array(getOptions.challenge as ArrayBuffer)).toHaveLength(32);
 });
 
 test("getPasskeyPrfOutput rejects an empty credentialId without prompting", async () => {
@@ -201,19 +169,16 @@ test("getPasskeyPrfOutput rejects an empty credentialId without prompting", asyn
   // assertion to any discoverable credential for the relying party.
   let asserted = false;
 
-  Object.defineProperty(globalThis, "navigator", {
-    configurable: true,
-    value: {
-      credentials: {
-        async get() {
-          asserted = true;
-          throw new Error("assertion must not start");
-        },
+  const navigator = {
+    credentials: {
+      async get() {
+        asserted = true;
+        throw new Error("assertion must not start");
       },
     },
-  });
+  };
 
-  try {
+  await withStubbedGlobal("navigator", navigator, async () => {
     await expect(
       getPasskeyPrfOutput({
         rpId: "example.com",
@@ -222,13 +187,7 @@ test("getPasskeyPrfOutput rejects an empty credentialId without prompting", asyn
       }),
     ).rejects.toMatchObject({ code: "INPUT_INVALID" });
     expect(asserted).toBe(false);
-  } finally {
-    if (ORIGINAL_NAVIGATOR) {
-      Object.defineProperty(globalThis, "navigator", ORIGINAL_NAVIGATOR);
-    } else {
-      Reflect.deleteProperty(globalThis, "navigator");
-    }
-  }
+  });
 });
 
 test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", async () => {
@@ -236,41 +195,38 @@ test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", asy
   const prfSalt = new Uint8Array(originalSalt);
   let fallbackSalt: Uint8Array | undefined;
 
-  Object.defineProperty(globalThis, "navigator", {
-    configurable: true,
-    value: {
-      credentials: {
-        async create() {
-          await Promise.resolve();
-          return {
-            type: "public-key",
-            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
-            response: {
-              getTransports: () => ["internal"],
-            },
-            getClientExtensionResults: () => ({ prf: { enabled: true } }),
-          };
-        },
-        async get({ publicKey }: CredentialRequestOptions) {
-          const first = publicKey?.extensions?.prf?.eval?.first;
-          if (!(first instanceof ArrayBuffer)) {
-            throw new Error("expected fallback PRF salt");
-          }
+  const navigator = {
+    credentials: {
+      async create() {
+        await Promise.resolve();
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          response: {
+            getTransports: () => ["internal"],
+          },
+          getClientExtensionResults: () => ({ prf: { enabled: true } }),
+        };
+      },
+      async get({ publicKey }: CredentialRequestOptions) {
+        const first = publicKey?.extensions?.prf?.eval?.first;
+        if (!(first instanceof ArrayBuffer)) {
+          throw new Error("expected fallback PRF salt");
+        }
 
-          fallbackSalt = new Uint8Array(first);
-          return {
-            type: "public-key",
-            rawId: new Uint8Array([1, 2, 3, 4]).buffer,
-            getClientExtensionResults: () => ({
-              prf: { results: { first } },
-            }),
-          };
-        },
+        fallbackSalt = new Uint8Array(first);
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          getClientExtensionResults: () => ({
+            prf: { results: { first } },
+          }),
+        };
       },
     },
-  });
+  };
 
-  try {
+  await withStubbedGlobal("navigator", navigator, async () => {
     const pending = createPasskeyWithPrfOutput({
       rp: { id: "example.com", name: "Mera Test" },
       user: {
@@ -288,11 +244,5 @@ test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", asy
     expect(result.prfSalt).toEqual(originalSalt);
     expect(result.prfOutput).toEqual(originalSalt);
     expect(fallbackSalt).toEqual(originalSalt);
-  } finally {
-    if (ORIGINAL_NAVIGATOR) {
-      Object.defineProperty(globalThis, "navigator", ORIGINAL_NAVIGATOR);
-    } else {
-      Reflect.deleteProperty(globalThis, "navigator");
-    }
-  }
+  });
 });

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -6,11 +6,10 @@ import {
   parseSecretVault,
   unwrapSecretVault,
 } from "../dist/index.js";
-import { expectError } from "./helpers.js";
+import { expectError, withStubbedGlobal } from "./helpers.js";
 
 const PRF_OUTPUT = new Uint8Array(32).fill(7);
 const PRF_SALT = new Uint8Array(32).fill(9);
-const ORIGINAL_CRYPTO = Object.getOwnPropertyDescriptor(globalThis, "crypto");
 // A real 12-word BIP-39 phrase stands in for an opaque secret; the library
 // neither knows nor cares that these bytes are a mnemonic.
 const SECRET = utf8ToBytes(
@@ -29,14 +28,6 @@ async function createTestVault(
     },
     secret,
   });
-}
-
-function restoreGlobalCrypto(): void {
-  if (ORIGINAL_CRYPTO) {
-    Object.defineProperty(globalThis, "crypto", ORIGINAL_CRYPTO);
-  } else {
-    Reflect.deleteProperty(globalThis, "crypto");
-  }
 }
 
 test("creates a secret vault and unwraps the exact bytes", async () => {
@@ -91,21 +82,14 @@ test("unwrapSecretVault fails with the wrong PRF output", async () => {
 test("secret vault helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable", async () => {
   const vault = await createTestVault();
 
-  Object.defineProperty(globalThis, "crypto", {
-    configurable: true,
-    value: undefined,
-  });
-
-  try {
+  await withStubbedGlobal("crypto", undefined, async () => {
     await expect(createTestVault()).rejects.toMatchObject({
       code: "CRYPTO_UNAVAILABLE",
     });
     await expect(
       unwrapSecretVault({ vault, prfOutput: PRF_OUTPUT }),
     ).rejects.toMatchObject({ code: "CRYPTO_UNAVAILABLE" });
-  } finally {
-    restoreGlobalCrypto();
-  }
+  });
 });
 
 test("secret vault AAD is independent of credential metadata and PRF salt", async () => {


### PR DESCRIPTION
## Problem

The capture-descriptor / `Object.defineProperty` stub / `finally`-restore pattern for `globalThis` was copy-pasted three times in `test/passkey.test.ts` (for `navigator`), and `restoreGlobalCrypto()` was duplicated verbatim between `passkey.test.ts` and `secret.test.ts`. Five hand-rolled restore paths are five chances to leave a global stubbed for the rest of the suite.

## Change

One helper in `test/helpers.ts`, `withStubbedGlobal(name, value, fn)`, captures the original property descriptor, installs the stub, runs `fn`, and restores (or deletes, if the property did not exist) in a single `finally`. All five stub sites now use it; the module-level `ORIGINAL_NAVIGATOR` / `ORIGINAL_CRYPTO` captures and both `restoreGlobalCrypto` copies are gone. Test assertions are unchanged — in the challenge-capture test the assertions moved after the stub scope, which they never needed to be inside. Net −33 lines. `helpers.ts` exports also moved to a grouped export at end of file, per the repo convention.

## Validation

- `npm run check` clean; `npm test`: all 56 unit tests pass, including every rewritten stub test. The 3 `chromium-e2e` failures reproduce identically on unmodified `main` in this environment (local test-server module fetch; pre-existing, unrelated).