### PR TITLE
Replace the fictional derivation import with real @scure code in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install @category-labs/mera
 
 ## Quick example
 
-A derived-mode skeleton: one passkey ceremony, then app-owned key derivation.
+A derived-mode example: one passkey ceremony, then app-owned key derivation — here BIP-39/BIP-32 with `@scure/bip32` and `@scure/bip39`, as in the demo.
 
 ```ts
 import {
@@ -38,19 +38,26 @@ import {
   getEvmAddress,
   getPasskeyPrfOutput,
 } from "@category-labs/mera"
-import { deriveAccountPrivateKey } from "./account-derivation"
+import { HDKey } from "@scure/bip32"
+import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39"
+import { wordlist } from "@scure/bip39/wordlists/english.js"
 
 const rpId = "account.example.com"
 
 const prfSalt = getDeterministicPrfSaltV1()
 const { prfOutput } = await getPasskeyPrfOutput({ rpId, prfSalt })
 
-const privateKey = deriveAccountPrivateKey({
-  entropy: prfOutput,
-  path: "m/44'/60'/0'/0/0",
-})
+// App-owned derivation: the PRF output is BIP-39 entropy, so the same phrase
+// imported into a standard wallet reproduces the same account.
+const mnemonic = entropyToMnemonic(prfOutput, wordlist)
+const seed = mnemonicToSeedSync(mnemonic)
+const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0")
+if (node.privateKey === null) throw new Error("derivation produced no key")
 
-const session = createSecp256k1SigningSession({ consumePrivateKey: privateKey })
+const session = createSecp256k1SigningSession({
+  // Copy out of the HDKey so the signing session can own and later zero it.
+  consumePrivateKey: new Uint8Array(node.privateKey),
+})
 const address = getEvmAddress(session.publicKey)
 ```
 

--- a/site/index.html
+++ b/site/index.html
@@ -779,27 +779,37 @@ clientDataJSON
           </svg>
         </figure>
 
-        <p>The skeleton: one ceremony, then app-owned derivation.</p>
+        <p>
+          The example: one ceremony, then app-owned derivation — here
+          BIP-39/BIP-32, as in the demo.
+        </p>
 
         <pre><code class="language-typescript">import {
-  getDeterministicPrfSaltV1,
   createSecp256k1SigningSession,
+  getDeterministicPrfSaltV1,
   getEvmAddress,
   getPasskeyPrfOutput,
 } from "@category-labs/mera"
-import { deriveAccountPrivateKey } from "./account-derivation"
+import { HDKey } from "@scure/bip32"
+import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39"
+import { wordlist } from "@scure/bip39/wordlists/english.js"
 
 const rpId = "account.example.com"
 
 const prfSalt = getDeterministicPrfSaltV1()
 const { prfOutput } = await getPasskeyPrfOutput({ rpId, prfSalt })
 
-const privateKey = deriveAccountPrivateKey({
-  entropy: prfOutput,
-  path: "m/44'/60'/0'/0/0",
-})
+// App-owned derivation: the PRF output is BIP-39 entropy, so the same phrase
+// imported into a standard wallet reproduces the same account.
+const mnemonic = entropyToMnemonic(prfOutput, wordlist)
+const seed = mnemonicToSeedSync(mnemonic)
+const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0")
+if (node.privateKey === null) throw new Error("derivation produced no key")
 
-const session = createSecp256k1SigningSession({ consumePrivateKey: privateKey })
+const session = createSecp256k1SigningSession({
+  // Copy out of the HDKey so the signing session can own and later zero it.
+  consumePrivateKey: new Uint8Array(node.privateKey),
+})
 const address = getEvmAddress(session.publicKey)</code></pre>
 
         <p>

--- a/site/index.html
+++ b/site/index.html
@@ -807,7 +807,6 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0")
 if (node.privateKey === null) throw new Error("derivation produced no key")
 
 const session = createSecp256k1SigningSession({
-  // Copy out of the HDKey so the signing session can own and later zero it.
   consumePrivateKey: new Uint8Array(node.privateKey),
 })
 const address = getEvmAddress(session.publicKey)</code></pre>


### PR DESCRIPTION
## Problem

The quick example in the README and the site article imported `deriveAccountPrivateKey` from a nonexistent `./account-derivation` module. The fictional import kept derivation visibly app-owned, but it conflicts with "examples should be runnable" and "README examples should reflect actual tested behavior" — a reader copying the snippet hits a missing module immediately.

## Change

Both snippets now inline the demo's actual derivation (`demo/src/hd.ts`): PRF output as BIP-39 entropy via `@scure/bip39`, then the BIP-44 Ethereum path via `@scure/bip32`. Derivation stays app-owned — the code lives in the example, not the library — and the snippet now demonstrates the wallet-interoperability claim directly (the mnemonic it builds is the exportable recovery phrase). The intro sentence names the libraries and points at the demo; the null-key check and the copy-before-`consumePrivateKey` mirror the demo's tested handling.

## Validation

- The exact README snippet typechecks under `tsc --strict` (ESM, `nodenext`) against the built package plus `@scure/bip32@2.x` / `@scure/bip39@2.x`.
- Runtime cross-check with fixed all-zero entropy in place of the PRF output: the example's derivation + `getEvmAddress` produced `0xF278cF59F82eDcf871d630F28EcC8056f25C1cdb`, byte-identical to viem's independent `mnemonicToAccount` for the same mnemonic and path.
- `npm run check` clean.