### PR TITLE
docs: concepts pages

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,6 +47,7 @@ The bar is simple, concise, and detailed at the same time, and that combination 
 `site/WRITING.md` applies in full. The rules that carry the most weight here:
 
 - Say "account". "Wallet" is only for wallet apps: MetaMask, Phantom, the demo.
+- Word choice fits technical documentation. Plain nouns over narrative or dramatic ones: "trade-offs", never "stories"; "complication", never "trap". A word that belongs in a blog headline gets replaced.
 - Calm explanation, no marketing. If a sentence would fit in a product brochure, rewrite it.
 - Named wallet apps are examples, never an exhaustive list.
 - Prefer a concrete statement over an abstract one. "The salt is 32 bytes" beats "the salt has a fixed size".
@@ -63,6 +64,7 @@ The bar is simple, concise, and detailed at the same time, and that combination 
 ## Accuracy
 
 - Every claim must be checkable against the README or the JSDoc in `src/`.
+- Implementation details stay on the pages that own them. Error codes and library internals belong to the reference; the demo's internals (derivation schemes, storage, UI) appear only in the recipes that adapt its code. Every other page links to the owning page instead of restating the detail, so a demo or library change touches one page. The demo changes freely; never let a concepts or landing page depend on it.
 - Examples import only the public API plus explicitly declared app-side dependencies.
 - Security-sensitive behavior is stated plainly on the page where the risk is acted on: key material lifetimes, zeroing, nonce handling, prompt counts, and what the library cannot protect against.
 - Support claims are date-stamped. The authenticator matrix lives in the README; this site mirrors it, and updates land in both places.
@@ -90,3 +92,4 @@ The bar is simple, concise, and detailed at the same time, and that combination 
 9. Security caveats sit on the page where the risk is acted on.
 10. Links have descriptive text; no bare "here".
 11. Every sentence adds information; no setup, restatement, or editorial sentences survive.
+12. Implementation details sit only on their owning pages; demo internals appear only in recipes.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,6 @@
 # Writing the mera docs
 
-Guidance for authoring content in this site (`src/content/docs/`). It builds on [site/WRITING.md](../site/WRITING.md), which governs voice for everything published under the mera name. Read that first; this file adds the structure and mechanics specific to the docs site.
+Guidance for authoring content in this site (`src/content/docs/`). [site/WRITING.md](../site/WRITING.md) governs voice for everything published under the mera name; this file adds the structure and mechanics specific to the docs site.
 
 ## Information architecture
 
@@ -11,7 +11,7 @@ The site follows the Diátaxis split (<https://diataxis.fr/>): each page does on
 - **Recipes** solve one task each. A recipe assumes a competent reader with a goal, states its prerequisites, and gets to the point.
 - **Reference** states facts about the public API, one exported function per page. Keep instructions, opinions, and long explanations out of it; link to them instead.
 
-When content feels misplaced, move it and link to it. A reference page that starts teaching should hand that material to a recipe. A recipe that pauses to explain should link a concept page.
+When content feels misplaced, move it and link to it: a reference page that starts teaching hands that material to a recipe; a recipe that pauses to explain links a concept page.
 
 ## Reference pages
 
@@ -42,7 +42,7 @@ Source of truth is the JSDoc in `src/`. Write reference prose from it, and check
 
 ## Voice
 
-The bar is simple, concise, and detailed at the same time, and that combination is the hard part: detail survives the cut, filler does not. Every sentence must add information a reader can act on. Delete sentences that only set up, restate, or editorialize on what the surrounding text already shows ("that choice is what makes this repeatable", "what happens next is the app's decision").
+The bar is simple, concise, and detailed at once: detail survives the cut, filler does not. Every sentence must add information a reader can act on; delete sentences that only set up, restate, or editorialize ("that choice is what makes this repeatable", "what happens next is the app's decision").
 
 `site/WRITING.md` applies in full. The rules that carry the most weight here:
 
@@ -57,6 +57,9 @@ The bar is simple, concise, and detailed at the same time, and that combination 
 
 - No em dashes. Use a comma, a period, a colon, or parentheses.
 - No "not X, but Y" constructions, including "isn't just X" and "It's not about X". Rewrite the thought.
+- Complete sentences, plainly shaped. Fragments for punch ("Same three, same 32 bytes.") and aphorisms ("whoever holds it holds ciphertext") get rewritten as plain statements.
+- The library takes plain verbs: mera requires, returns, throws. "mera asks", "hands over", "stops there" are narration.
+- A sentence never defers its point to a link. State the consequence in place and link for depth; "the security model explains the consequence" tells the reader nothing.
 - Vary sentence length and openings. Three consecutive sentences with the same shape means one gets rewritten.
 - Short paragraphs, but not a wall of one-liners.
 - Banned vocabulary: seamless, robust, powerful, effortless, simply, leverage, unlock (as praise; unlocking a vault is fine), delve, game-changer.
@@ -64,7 +67,7 @@ The bar is simple, concise, and detailed at the same time, and that combination 
 ## Accuracy
 
 - Every claim must be checkable against the README or the JSDoc in `src/`.
-- Implementation details stay on the pages that own them. Error codes and library internals belong to the reference; the demo's internals (derivation schemes, storage, UI) appear only in the recipes that adapt its code. Every other page links to the owning page instead of restating the detail, so a demo or library change touches one page. The demo changes freely; never let a concepts or landing page depend on it.
+- Implementation details live only on the page that owns them: error codes and library internals on the reference, demo internals (derivation schemes, storage, UI) in the recipes that adapt its code. Every other page links to the owning page instead of restating the detail, so a demo or library change touches one page.
 - Examples import only the public API plus explicitly declared app-side dependencies.
 - Security-sensitive behavior is stated plainly on the page where the risk is acted on: key material lifetimes, zeroing, nonce handling, prompt counts, and what the library cannot protect against.
 - Support claims are date-stamped. The authenticator matrix lives in the README; this site mirrors it, and updates land in both places.
@@ -75,7 +78,7 @@ The bar is simple, concise, and detailed at the same time, and that combination 
 - Files are kebab-case; the file path is the slug.
 - The sidebar in `astro.config.mjs` is hand-maintained. A sidebar slug without a page fails the build.
 - Plain `.md` unless the page imports a component; then `.mdx`.
-- Internal links are root-relative with a trailing slash: `/reference/errors/`.
+- Internal links are root-relative with a trailing slash: `/reference/errors/`. Link text is descriptive; no bare "here".
 - Never reference sections by number; name the thing and link it.
 - `npm run build` must pass before a PR.
 
@@ -88,8 +91,3 @@ The bar is simple, concise, and detailed at the same time, and that combination 
 5. No em dash anywhere in the diff.
 6. No banned vocabulary, no "not X, but Y".
 7. "Wallet" appears only next to wallet apps.
-8. Claims trace to the README or JSDoc.
-9. Security caveats sit on the page where the risk is acted on.
-10. Links have descriptive text; no bare "here".
-11. Every sentence adds information; no setup, restatement, or editorial sentences survive.
-12. Implementation details sit only on their owning pages; demo internals appear only in recipes.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -45,7 +45,18 @@ export default defineConfig({
         ThemeProvider: "./src/components/ThemeProvider.astro",
         ThemeSelect: "./src/components/ThemeSelect.astro",
       },
-      sidebar: [{ label: "Getting started", slug: "getting-started" }],
+      sidebar: [
+        { label: "Getting started", slug: "getting-started" },
+        {
+          label: "Concepts",
+          items: [
+            "concepts/passkeys-and-prf",
+            "concepts/derived-and-wrapped",
+            "concepts/security-model",
+            "concepts/authenticator-support",
+          ],
+        },
+      ],
     }),
   ],
 });

--- a/docs/src/content/docs/concepts/authenticator-support.md
+++ b/docs/src/content/docs/concepts/authenticator-support.md
@@ -5,7 +5,7 @@ description: Which browser and authenticator combinations deliver WebAuthn PRF.
 
 mera asks three things of the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification. When the browser, OS, and authenticator combination cannot deliver PRF, the library throws [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable).
 
-Support is uneven and worth checking before choosing a rollout path. In the table, `✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
+In the table, `✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
 
 | Authenticator            | Browser                           | OS                          | Status                     | Supported since                              |
 | ------------------------ | --------------------------------- | --------------------------- | -------------------------- | -------------------------------------------- |
@@ -33,11 +33,8 @@ On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The
 
 Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. The passkey exists either way; [createPasskey](/reference/create-passkey/) documents that ordering caveat.
 
-## Further reading
-
-For the broader PRF compatibility picture beyond the combinations tested here, see Corbado's [Passkeys & WebAuthn PRF for End-to-End Encryption](https://www.corbado.com/blog/passkeys-prf-webauthn).
-
 ## See also
 
 - [Passkeys and the PRF extension](/concepts/passkeys-and-prf/): what PRF is and why user verification is required.
 - [Handle errors](/recipes/handle-errors/): turning `PRF_UNAVAILABLE` into useful guidance for people.
+- Corbado's [Passkeys & WebAuthn PRF for End-to-End Encryption](https://www.corbado.com/blog/passkeys-prf-webauthn): the broader PRF compatibility picture beyond the combinations tested here.

--- a/docs/src/content/docs/concepts/authenticator-support.md
+++ b/docs/src/content/docs/concepts/authenticator-support.md
@@ -3,7 +3,7 @@ title: Authenticator support
 description: Which authenticators deliver WebAuthn PRF, and since when.
 ---
 
-mera asks three things of the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification.
+mera requires three things from the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification.
 
 In the table, `✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
 
@@ -31,10 +31,10 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local Chrome profile authenticator does not implement the CTAP2 `hmac-secret` extension, so a passkey created there comes back without PRF.
 
-Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but cannot back an account; [createPasskey](/reference/create-passkey/) documents the ordering caveat.
+Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but returns no PRF output, so mera cannot use it; [createPasskey](/reference/create-passkey/) documents the ordering caveat.
 
 ## See also
 
 - [Passkeys and the PRF extension](/concepts/passkeys-and-prf/): what PRF is and why user verification is required.
-- [Handle errors](/recipes/handle-errors/): turning unsupported-authenticator failures into useful guidance for people.
+- [Handle errors](/recipes/handle-errors/): turning unsupported-authenticator failures into clear guidance.
 - Corbado's [Passkeys & WebAuthn PRF for End-to-End Encryption](https://www.corbado.com/blog/passkeys-prf-webauthn): the broader PRF compatibility picture beyond the combinations tested here.

--- a/docs/src/content/docs/concepts/authenticator-support.md
+++ b/docs/src/content/docs/concepts/authenticator-support.md
@@ -1,0 +1,43 @@
+---
+title: Authenticator support
+description: Which browser and authenticator combinations deliver WebAuthn PRF.
+---
+
+mera asks three things of the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification. When the browser, OS, and authenticator combination cannot deliver PRF, the library throws [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable).
+
+Support is uneven and worth checking before choosing a rollout path. In the table, `✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
+
+| Authenticator            | Browser                           | OS                          | Status                     | Supported since                              |
+| ------------------------ | --------------------------------- | --------------------------- | -------------------------- | -------------------------------------------- |
+| 1Password                | any browser with 1Password active | any                         | ✓                          | 2.26.1 beta / Android 8.10.38 beta (2024-07) |
+| iCloud Keychain          | Safari                            | iOS 18+                     | ✓                          | Safari 18 / iOS 18 (2024-09)                 |
+| iCloud Keychain          | Safari                            | macOS 15+                   | ✓                          | Safari 18 / macOS 15 (2024-09)               |
+| iCloud Keychain          | Chrome                            | macOS 15+                   | ✓                          | Chrome 132+ (2025-01)                        |
+| iCloud Keychain          | Chrome                            | iOS 18+                     | ✓                          | Safari 18 / iOS 18 (2024-09)                 |
+| iCloud Keychain          | Firefox                           | macOS 15+                   | ✓                          | Firefox 139+ (2025-05)                       |
+| Google Password Manager  | Chrome                            | Android                     | ✓                          | Known by 2026-06                             |
+| Google Password Manager  | Chrome                            | Desktop (signed-in)         | ✓                          | Chrome 132+ (2025-01)                        |
+| Chrome profile           | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
+| Google Password Manager  | Edge                              | Android                     | ✓                          | Known by 2026-06                             |
+| Windows Password Manager | Edge                              | Windows 11 25H2+            | ✓                          | Windows 11 25H2 + 2026-02 update             |
+| Windows Password Manager | Chrome                            | Windows 11 25H2+            | ✓                          | Chrome 147+ (2026-04)                        |
+| Windows Password Manager | Firefox 148+                      | Windows 11 25H2+            | ✓                          | Firefox 148+ (2026-02)                       |
+| YubiKey 5C Nano          | Chrome                            | Desktop                     | ✓                          | Chrome 116+; YubiKey 5.2+ hmac-secret        |
+| Bitwarden                | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
+| Dashlane                 | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
+| Proton Pass              | Chrome                            | Desktop                     | ✓                          | Latest public version (2026-06)              |
+
+## The desktop Chrome trap
+
+On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local Chrome profile authenticator does not implement the CTAP2 `hmac-secret` extension, so a passkey created there comes back with `prf.enabled: false` and mera throws.
+
+Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. The passkey exists either way; [createPasskey](/reference/create-passkey/) documents that ordering caveat.
+
+## Further reading
+
+For the broader PRF compatibility picture beyond the combinations tested here, see Corbado's [Passkeys & WebAuthn PRF for End-to-End Encryption](https://www.corbado.com/blog/passkeys-prf-webauthn).
+
+## See also
+
+- [Passkeys and the PRF extension](/concepts/passkeys-and-prf/): what PRF is and why user verification is required.
+- [Handle errors](/recipes/handle-errors/): turning `PRF_UNAVAILABLE` into useful guidance for people.

--- a/docs/src/content/docs/concepts/authenticator-support.md
+++ b/docs/src/content/docs/concepts/authenticator-support.md
@@ -1,9 +1,9 @@
 ---
 title: Authenticator support
-description: Which browser and authenticator combinations deliver WebAuthn PRF.
+description: Which authenticators deliver WebAuthn PRF, and since when.
 ---
 
-mera asks three things of the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification. When the browser, OS, and authenticator combination cannot deliver PRF, the library throws [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable).
+mera asks three things of the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification.
 
 In the table, `✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
 
@@ -27,14 +27,14 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 | Dashlane                 | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
 | Proton Pass              | Chrome                            | Desktop                     | ✓                          | Latest public version (2026-06)              |
 
-## The desktop Chrome trap
+## The desktop Chrome complication
 
-On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local Chrome profile authenticator does not implement the CTAP2 `hmac-secret` extension, so a passkey created there comes back with `prf.enabled: false` and mera throws.
+On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local Chrome profile authenticator does not implement the CTAP2 `hmac-secret` extension, so a passkey created there comes back without PRF.
 
-Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. The passkey exists either way; [createPasskey](/reference/create-passkey/) documents that ordering caveat.
+Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but cannot back an account; [createPasskey](/reference/create-passkey/) documents the ordering caveat.
 
 ## See also
 
 - [Passkeys and the PRF extension](/concepts/passkeys-and-prf/): what PRF is and why user verification is required.
-- [Handle errors](/recipes/handle-errors/): turning `PRF_UNAVAILABLE` into useful guidance for people.
+- [Handle errors](/recipes/handle-errors/): turning unsupported-authenticator failures into useful guidance for people.
 - Corbado's [Passkeys & WebAuthn PRF for End-to-End Encryption](https://www.corbado.com/blog/passkeys-prf-webauthn): the broader PRF compatibility picture beyond the combinations tested here.

--- a/docs/src/content/docs/concepts/derived-and-wrapped.md
+++ b/docs/src/content/docs/concepts/derived-and-wrapped.md
@@ -1,13 +1,13 @@
 ---
 title: Derived and wrapped modes
-description: Two ways to use PRF output, with different storage and recovery stories.
+description: Two ways to use PRF output, with different storage and recovery trade-offs.
 ---
 
 Both modes start from the same ceremony and its 32 bytes of PRF output. Derived mode turns the bytes into accounts; wrapped mode turns them into the key that guards one stored secret.
 
 ## Derived
 
-With mera's [fixed deterministic salt](/reference/get-deterministic-prf-salt-v1/), the same passkey and relying party produce the same PRF output on every ceremony. The app feeds that output into a derivation scheme of its choosing; the demo uses BIP-39/BIP-32 for secp256k1 keys and SLIP-0010 for Ed25519.
+With mera's [fixed deterministic salt](/reference/get-deterministic-prf-salt-v1/), the same passkey and relying party produce the same PRF output on every ceremony. The app feeds that output into a derivation scheme of its choosing; [Derive accounts from one passkey](/recipes/derive-accounts/) shows one built on common HD standards.
 
 There is no stored secret. Sign-in on a new device is the same ceremony as on the old one and produces the same accounts, provided the passkey is there: state lives in the passkey and nowhere else.
 

--- a/docs/src/content/docs/concepts/derived-and-wrapped.md
+++ b/docs/src/content/docs/concepts/derived-and-wrapped.md
@@ -1,0 +1,33 @@
+---
+title: Derived and wrapped modes
+description: Two ways to use PRF output, with different storage and recovery stories.
+---
+
+Both modes start the same way: a passkey ceremony returns 32 bytes of PRF output. They differ in what those bytes become. Derived mode turns them into accounts. Wrapped mode turns them into the key that guards one stored secret.
+
+## Derived
+
+With mera's [fixed deterministic salt](/reference/get-deterministic-prf-salt-v1/), the same passkey and relying party produce the same PRF output on every ceremony. The app feeds that output into a derivation scheme of its choosing; the demo uses BIP-39/BIP-32 for secp256k1 keys and SLIP-0010 for Ed25519.
+
+There is no stored secret. Sign-in on a new device is the same ceremony as on the old one, and it produces the same accounts, provided the passkey is there. That is the mode's defining trade: state lives in the passkey and nowhere else.
+
+The loss cases follow directly. The account may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's rpId after a domain migration. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works. [Reveal a recovery phrase](/recipes/reveal-a-recovery-phrase/) shows one such path.
+
+## Wrapped
+
+An AES-256-GCM vault holds one secret: a recovery phrase, a private key, any bytes. The ceremony's PRF output, evaluated against a fresh random salt stored alongside the vault, produces the key material that decrypts it. The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
+
+Here the secret exists independently of the passkey. An account that predates the passkey can be imported by wrapping its recovery phrase or private key, and the person who holds that secret may also keep it somewhere else entirely. Custody of the vault blob becomes an app design question: whoever holds it holds ciphertext, and the passkey ceremony is what turns it back into the secret.
+
+## Choosing
+
+- **Where state lives.** Derived keeps it in the passkey. Wrapped keeps it in a blob the app has to store somewhere.
+- **Existing accounts.** Wrapped can hold a secret that predates the passkey. Derived only produces accounts rooted in the passkey itself.
+- **Losing the passkey.** Both modes lose access through mera. A derived account recovers only through an export taken beforehand; a wrapped secret recovers wherever another copy of it survives.
+- **Salts.** Derived uses the one fixed deterministic salt. Wrapped stores a fresh random salt per vault, and reusing one across secrets is a real mistake; the [security model](/concepts/security-model/) explains why.
+
+## See also
+
+- [Derive accounts from one passkey](/recipes/derive-accounts/)
+- [Wrap a recovery phrase](/recipes/wrap-a-recovery-phrase/)
+- [Secret vault format](/reference/secret-vault-format/)

--- a/docs/src/content/docs/concepts/derived-and-wrapped.md
+++ b/docs/src/content/docs/concepts/derived-and-wrapped.md
@@ -3,28 +3,28 @@ title: Derived and wrapped modes
 description: Two ways to use PRF output, with different storage and recovery stories.
 ---
 
-Both modes start the same way: a passkey ceremony returns 32 bytes of PRF output. They differ in what those bytes become. Derived mode turns them into accounts. Wrapped mode turns them into the key that guards one stored secret.
+Both modes start from the same ceremony and its 32 bytes of PRF output. Derived mode turns the bytes into accounts; wrapped mode turns them into the key that guards one stored secret.
 
 ## Derived
 
 With mera's [fixed deterministic salt](/reference/get-deterministic-prf-salt-v1/), the same passkey and relying party produce the same PRF output on every ceremony. The app feeds that output into a derivation scheme of its choosing; the demo uses BIP-39/BIP-32 for secp256k1 keys and SLIP-0010 for Ed25519.
 
-There is no stored secret. Sign-in on a new device is the same ceremony as on the old one, and it produces the same accounts, provided the passkey is there. That is the mode's defining trade: state lives in the passkey and nowhere else.
+There is no stored secret. Sign-in on a new device is the same ceremony as on the old one and produces the same accounts, provided the passkey is there: state lives in the passkey and nowhere else.
 
-The loss cases follow directly. The account may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's rpId after a domain migration. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works. [Reveal a recovery phrase](/recipes/reveal-a-recovery-phrase/) shows one such path.
+The account may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's rpId after a domain migration. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works. [Reveal a recovery phrase](/recipes/reveal-a-recovery-phrase/) shows one such path.
 
 ## Wrapped
 
 An AES-256-GCM vault holds one secret: a recovery phrase, a private key, any bytes. The ceremony's PRF output, evaluated against a fresh random salt stored alongside the vault, produces the key material that decrypts it. The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 
-Here the secret exists independently of the passkey. An account that predates the passkey can be imported by wrapping its recovery phrase or private key, and the person who holds that secret may also keep it somewhere else entirely. Custody of the vault blob becomes an app design question: whoever holds it holds ciphertext, and the passkey ceremony is what turns it back into the secret.
+The secret exists independently of the passkey: an account that predates it can be imported by wrapping its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question; whoever holds it holds ciphertext, and only the passkey ceremony turns it back into the secret.
 
 ## Choosing
 
 - **Where state lives.** Derived keeps it in the passkey. Wrapped keeps it in a blob the app has to store somewhere.
 - **Existing accounts.** Wrapped can hold a secret that predates the passkey. Derived only produces accounts rooted in the passkey itself.
 - **Losing the passkey.** Both modes lose access through mera. A derived account recovers only through an export taken beforehand; a wrapped secret recovers wherever another copy of it survives.
-- **Salts.** Derived uses the one fixed deterministic salt. Wrapped stores a fresh random salt per vault, and reusing one across secrets is a real mistake; the [security model](/concepts/security-model/) explains why.
+- **Salts.** Derived uses the one fixed deterministic salt. Wrapped stores a fresh random salt per vault; reusing one across secrets shares the wrapping key, and the [security model](/concepts/security-model/#one-output-one-purpose) explains the consequence.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/derived-and-wrapped.md
+++ b/docs/src/content/docs/concepts/derived-and-wrapped.md
@@ -3,13 +3,13 @@ title: Derived and wrapped modes
 description: Two ways to use PRF output, with different storage and recovery trade-offs.
 ---
 
-Both modes start from the same ceremony and its 32 bytes of PRF output. Derived mode turns the bytes into accounts; wrapped mode turns them into the key that guards one stored secret.
+Both modes start from the same ceremony and its 32 bytes of PRF output. Derived mode turns the bytes into accounts; wrapped mode turns them into the key that decrypts one stored secret.
 
 ## Derived
 
 With mera's [fixed deterministic salt](/reference/get-deterministic-prf-salt-v1/), the same passkey and relying party produce the same PRF output on every ceremony. The app feeds that output into a derivation scheme of its choosing; [Derive accounts from one passkey](/recipes/derive-accounts/) shows one built on common HD standards.
 
-There is no stored secret. Sign-in on a new device is the same ceremony as on the old one and produces the same accounts, provided the passkey is there: state lives in the passkey and nowhere else.
+There is no stored secret; all state lives in the passkey. Once the passkey has synced to a new device, sign-in there is the same ceremony and produces the same accounts.
 
 The account may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's rpId after a domain migration. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works. [Reveal a recovery phrase](/recipes/reveal-a-recovery-phrase/) shows one such path.
 
@@ -17,14 +17,14 @@ The account may be unrecoverable if the passkey is deleted, not synced, tied to 
 
 An AES-256-GCM vault holds one secret: a recovery phrase, a private key, any bytes. The ceremony's PRF output, evaluated against a fresh random salt stored alongside the vault, produces the key material that decrypts it. The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 
-The secret exists independently of the passkey: an account that predates it can be imported by wrapping its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question; whoever holds it holds ciphertext, and only the passkey ceremony turns it back into the secret.
+The secret exists independently of the passkey: an account that predates it can be imported by wrapping its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext; decrypting it requires the passkey ceremony.
 
 ## Choosing
 
 - **Where state lives.** Derived keeps it in the passkey. Wrapped keeps it in a blob the app has to store somewhere.
 - **Existing accounts.** Wrapped can hold a secret that predates the passkey. Derived only produces accounts rooted in the passkey itself.
-- **Losing the passkey.** Both modes lose access through mera. A derived account recovers only through an export taken beforehand; a wrapped secret recovers wherever another copy of it survives.
-- **Salts.** Derived uses the one fixed deterministic salt. Wrapped stores a fresh random salt per vault; reusing one across secrets shares the wrapping key, and the [security model](/concepts/security-model/#one-output-one-purpose) explains the consequence.
+- **Losing the passkey.** Both modes lose access through mera. A derived account is recoverable only through an export taken beforehand; a wrapped secret is recoverable from any other copy of it.
+- **Salts.** Derived uses the one fixed deterministic salt. Wrapped stores a fresh random salt per vault; secrets wrapped under a reused salt share one wrapping key, so exposing that key exposes all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -1,6 +1,6 @@
 ---
 title: Passkeys and the PRF extension
-description: Where mera's 32 bytes come from and why they are stable.
+description: What a passkey is, what the PRF extension adds, and why its output is stable.
 ---
 
 A passkey is a WebAuthn credential: a key pair created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. "Discoverable" means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
@@ -19,13 +19,13 @@ The requirement is not configurable. Authenticators built on CTAP's `hmac-secret
 
 The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) gives each credential a pseudorandom function. The caller passes a 32-byte salt with the ceremony and the authenticator returns 32 bytes.
 
-The output is deterministic in exactly three inputs: the credential, the relying party ID, and the salt. Same three, same 32 bytes, on any device the passkey syncs to. Change the salt and the output is unrelated. Salts act as namespaces, which is why derived accounts share one [fixed salt](/reference/get-deterministic-prf-salt-v1/) while each wrapped secret gets a fresh random one.
+The output is deterministic in exactly three inputs: the credential, the relying party ID, and the salt. The same three inputs produce the same 32 bytes on any device the passkey syncs to; a different salt produces an unrelated output. Salts act as namespaces, which is why derived accounts share one [fixed salt](/reference/get-deterministic-prf-salt-v1/) while each wrapped secret gets a fresh random one.
 
-## Account-grade entropy
+## Using the output
 
-32 stable bytes that appear only after user verification, exist outside the authenticator only as this evaluated output, and follow the passkey wherever it syncs: enough to root an account on.
+The output is suitable as the root secret for accounts. It is stable wherever the passkey syncs, it appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony.
 
-Fed to a key-derivation scheme, the bytes root a hierarchy of accounts; used as key material, they open an encrypted vault. mera hands them over and stops there; [derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two patterns.
+Fed to a key-derivation scheme, the output produces a hierarchy of accounts; used as key material, it decrypts a vault. mera returns the output and does nothing else with it. [Derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two patterns.
 
 ## Ceremonies and prompts
 
@@ -35,7 +35,7 @@ A ceremony is one WebAuthn call and one user-verification prompt. mera runs thre
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) chains the two: one prompt when the authenticator evaluates PRF at create time, two when it needs the follow-up assertion.
 
-Signing itself never prompts: a ceremony's output backs key material in a [signing session](/reference/create-secp256k1-signing-session/), and the session signs until it is locked.
+Signing itself never prompts: a [signing session](/reference/create-secp256k1-signing-session/) holds key material derived from a ceremony's output and signs until it is locked.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -3,7 +3,7 @@ title: Passkeys and the PRF extension
 description: What a passkey is, what the PRF extension adds, and why its output is stable.
 ---
 
-A passkey is a WebAuthn credential: a key pair created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. "Discoverable" means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
+A passkey is a WebAuthn credential: a key pair created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. mera creates passkeys as discoverable credentials: the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -1,0 +1,45 @@
+---
+title: Passkeys and the PRF extension
+description: Where mera's 32 bytes come from and why they are stable.
+---
+
+A passkey is a WebAuthn credential: a key pair created by an authenticator at a website's request. The authenticator might be a phone, a password manager, or a hardware key. The private half never leaves it. "Discoverable" means the authenticator can find the credential for a domain on its own, so signing in needs no username and no stored identifier.
+
+Two properties matter for everything mera does.
+
+**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. This binding is load-bearing; the [security model](/concepts/security-model/) covers what it means for domain migrations.
+
+**Passkeys sync.** Platform authenticators replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. The credential, and everything derived from it, follows the passkey.
+
+## User verification
+
+Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
+
+The requirement is not configurable, and the reason sits in the authenticator protocol. Authenticators built on CTAP's `hmac-secret` keep two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
+
+## The PRF extension
+
+The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) gives each credential a pseudorandom function. The caller passes a 32-byte salt with the ceremony and the authenticator returns 32 bytes.
+
+The output is deterministic in exactly three inputs: the credential, the relying party ID, and the salt. Same three, same 32 bytes, on any device the passkey syncs to. Change the salt and the output is unrelated. Salts act as namespaces, which is why derived accounts share one [fixed salt](/reference/get-deterministic-prf-salt-v1/) while each wrapped secret gets a fresh random one.
+
+## Account-grade entropy
+
+Put those pieces together: 32 stable bytes that appear only after user verification, that exist outside the authenticator only as this evaluated output, and that follow the passkey wherever it syncs. That is enough to root an account on.
+
+What the bytes become is the app's decision. Fed to a key-derivation scheme, they root a hierarchy of accounts. Used as key material, they open an encrypted vault. mera hands them over and stops there; [derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two patterns.
+
+## Ceremonies and prompts
+
+A ceremony is one WebAuthn call and one user-verification prompt. mera runs three kinds:
+
+- [createPasskey](/reference/create-passkey/) makes the credential, and can evaluate the PRF in the same ceremony when the authenticator supports it.
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) chains the two: one prompt when the authenticator evaluates PRF at create time, two when it needs the follow-up assertion.
+
+Signing itself never prompts. A ceremony's output backs key material in a [signing session](/reference/create-secp256k1-signing-session/), and the session signs until it is locked. One prompt, then a session of signatures.
+
+## See also
+
+- [Authenticator support](/concepts/authenticator-support/): which stacks deliver PRF today.
+- [Getting started](/getting-started/): the ceremony-to-signature path in code.

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -3,7 +3,7 @@ title: Passkeys and the PRF extension
 description: What a passkey is, what the PRF extension adds, and why its output is stable.
 ---
 
-A passkey is a WebAuthn credential: a key pair created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. mera creates passkeys as discoverable credentials: the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
+A passkey is a discoverable WebAuthn credential: a key pair created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -3,19 +3,17 @@ title: Passkeys and the PRF extension
 description: Where mera's 32 bytes come from and why they are stable.
 ---
 
-A passkey is a WebAuthn credential: a key pair created by an authenticator at a website's request. The authenticator might be a phone, a password manager, or a hardware key. The private half never leaves it. "Discoverable" means the authenticator can find the credential for a domain on its own, so signing in needs no username and no stored identifier.
+A passkey is a WebAuthn credential: a key pair created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. "Discoverable" means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
-Two properties matter for everything mera does.
+**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
 
-**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. This binding is load-bearing; the [security model](/concepts/security-model/) covers what it means for domain migrations.
-
-**Passkeys sync.** Platform authenticators replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. The credential, and everything derived from it, follows the passkey.
+**Passkeys sync.** Platform authenticators replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
 
 ## User verification
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
 
-The requirement is not configurable, and the reason sits in the authenticator protocol. Authenticators built on CTAP's `hmac-secret` keep two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
+The requirement is not configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
 
 ## The PRF extension
 
@@ -25,9 +23,9 @@ The output is deterministic in exactly three inputs: the credential, the relying
 
 ## Account-grade entropy
 
-Put those pieces together: 32 stable bytes that appear only after user verification, that exist outside the authenticator only as this evaluated output, and that follow the passkey wherever it syncs. That is enough to root an account on.
+32 stable bytes that appear only after user verification, exist outside the authenticator only as this evaluated output, and follow the passkey wherever it syncs: enough to root an account on.
 
-What the bytes become is the app's decision. Fed to a key-derivation scheme, they root a hierarchy of accounts. Used as key material, they open an encrypted vault. mera hands them over and stops there; [derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two patterns.
+Fed to a key-derivation scheme, the bytes root a hierarchy of accounts; used as key material, they open an encrypted vault. mera hands them over and stops there; [derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two patterns.
 
 ## Ceremonies and prompts
 
@@ -37,7 +35,7 @@ A ceremony is one WebAuthn call and one user-verification prompt. mera runs thre
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) chains the two: one prompt when the authenticator evaluates PRF at create time, two when it needs the follow-up assertion.
 
-Signing itself never prompts. A ceremony's output backs key material in a [signing session](/reference/create-secp256k1-signing-session/), and the session signs until it is locked. One prompt, then a session of signatures.
+Signing itself never prompts: a ceremony's output backs key material in a [signing session](/reference/create-secp256k1-signing-session/), and the session signs until it is locked.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/security-model.md
+++ b/docs/src/content/docs/concepts/security-model.md
@@ -1,0 +1,45 @@
+---
+title: Security model
+description: What mera protects, what it cannot, and the sharp edges to design around.
+---
+
+mera's job is narrow: run passkey ceremonies, hand the app entropy, hold signing keys behind a lock. This page states what the library takes care of inside that job and what remains the app's problem. The same facts appear on the reference pages of the functions they concern; this is the connected version.
+
+## What the library handles
+
+Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, wrapped, or derived.
+
+Owned copies are zeroed where possible. A signing session zeroes the caller's private-key buffer when it consumes it, even when construction throws, and zeroes its own copy on `lock()`. [createSecretVault](/reference/create-secret-vault/) zeroes its internal copies of the PRF output and the secret before returning.
+
+WebAuthn challenges are generated internally. So are AES-GCM nonces, 12 fresh bytes per encryption, which means a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
+
+## What a compromised runtime sees
+
+A compromised JavaScript runtime, whether an injected script, a malicious dependency, or an extension with page access, can observe key material during app-owned derivation or import. It can also sign with an active session until `session.lock()` is called.
+
+No library choice changes that. The mitigations are app-level: lock sessions when idle, keep derivation windows short, and treat everything that can run script on the page as inside the trust boundary.
+
+## rpId binding
+
+PRF output is a function of the credential, the relying party ID, and the salt. A passkey answers only the rpId it was created under, so after a domain migration the app cannot run assertions under the old one. That breaks derived-mode reproduction and blocks the ceremony that opens wrapped vaults alike.
+
+Treat the rpId as a long-lived choice. If a migration is ever on the table, accounts need an export path before it happens; [Reveal a recovery phrase](/recipes/reveal-a-recovery-phrase/) is one.
+
+## One output, one purpose
+
+Reusing one PRF output for unrelated purposes (key derivation and app-data encryption, say) links those secrets: anyone who learns the output learns them all. Use a different salt per purpose, or split one output with a purpose-labeled KDF.
+
+The vault has a specific corollary. A vault is bound to its PRF output only, never to the credential ID or salt. Secrets wrapped under one reused output share a wrapping key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. Give each secret a fresh random 32-byte salt; the [createSecretVault](/reference/create-secret-vault/) page carries the same warning.
+
+## Strings cannot be zeroed
+
+A revealed recovery phrase is a JavaScript string, and strings cannot be zeroed in place. The app can only drop references and keep the lifetime short. Treat a revealed phrase as high-risk UI state: render it late, discard it early, never log it.
+
+## Dependency scope
+
+Runtime dependencies are `@noble/*` and `@scure/*` only. Build and test tooling, and the unpublished demo app, never ship to library consumers.
+
+## See also
+
+- [Passkeys and the PRF extension](/concepts/passkeys-and-prf/)
+- [Errors](/reference/errors/): every failure the library signals, by code.

--- a/docs/src/content/docs/concepts/security-model.md
+++ b/docs/src/content/docs/concepts/security-model.md
@@ -3,7 +3,7 @@ title: Security model
 description: What mera protects, what it cannot, and the sharp edges to design around.
 ---
 
-mera's job is narrow: run passkey ceremonies, hand the app entropy, hold signing keys behind a lock. This page states what the library takes care of inside that job and what remains the app's problem. The same facts appear on the reference pages of the functions they concern; this is the connected version.
+mera's job is narrow: run passkey ceremonies, hand the app entropy, hold signing keys behind a lock. This page states what the library handles inside that job and what remains the app's problem; each fact also appears on the reference page of the function it concerns.
 
 ## What the library handles
 
@@ -17,7 +17,7 @@ WebAuthn challenges are generated internally. So are AES-GCM nonces, 12 fresh by
 
 A compromised JavaScript runtime, whether an injected script, a malicious dependency, or an extension with page access, can observe key material during app-owned derivation or import. It can also sign with an active session until `session.lock()` is called.
 
-No library choice changes that. The mitigations are app-level: lock sessions when idle, keep derivation windows short, and treat everything that can run script on the page as inside the trust boundary.
+The mitigations are app-level: lock sessions when idle, keep derivation windows short, and treat everything that can run script on the page as inside the trust boundary.
 
 ## rpId binding
 
@@ -29,7 +29,7 @@ Treat the rpId as a long-lived choice. If a migration is ever on the table, acco
 
 Reusing one PRF output for unrelated purposes (key derivation and app-data encryption, say) links those secrets: anyone who learns the output learns them all. Use a different salt per purpose, or split one output with a purpose-labeled KDF.
 
-The vault has a specific corollary. A vault is bound to its PRF output only, never to the credential ID or salt. Secrets wrapped under one reused output share a wrapping key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. Give each secret a fresh random 32-byte salt; the [createSecretVault](/reference/create-secret-vault/) page carries the same warning.
+A vault is bound to its PRF output only, never to the credential ID or salt. Secrets wrapped under one reused output share a wrapping key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. Give each secret a fresh random 32-byte salt; the [createSecretVault](/reference/create-secret-vault/) page carries the same warning.
 
 ## Strings cannot be zeroed
 

--- a/docs/src/content/docs/concepts/security-model.md
+++ b/docs/src/content/docs/concepts/security-model.md
@@ -1,9 +1,9 @@
 ---
 title: Security model
-description: What mera protects, what it cannot, and the sharp edges to design around.
+description: What mera protects, what it cannot, and the risks left to the app.
 ---
 
-mera's job is narrow: run passkey ceremonies, hand the app entropy, hold signing keys behind a lock. This page states what the library handles inside that job and what remains the app's problem; each fact also appears on the reference page of the function it concerns.
+mera has a narrow scope: it runs passkey ceremonies, returns entropy to the app, and holds signing keys in lockable sessions. This page states what the library handles inside that scope and what the app must handle itself; each fact also appears on the reference page of the function it concerns.
 
 ## What the library handles
 
@@ -21,13 +21,13 @@ The mitigations are app-level: lock sessions when idle, keep derivation windows 
 
 ## rpId binding
 
-PRF output is a function of the credential, the relying party ID, and the salt. A passkey answers only the rpId it was created under, so after a domain migration the app cannot run assertions under the old one. That breaks derived-mode reproduction and blocks the ceremony that opens wrapped vaults alike.
+PRF output is a function of the credential, the relying party ID, and the salt. A passkey can be used only under the rpId it was created for, so after a domain migration the app cannot run assertions under the old one. That breaks both modes: derived accounts can no longer be reproduced, and wrapped vaults can no longer be decrypted.
 
-Treat the rpId as a long-lived choice. If a migration is ever on the table, accounts need an export path before it happens; [Reveal a recovery phrase](/recipes/reveal-a-recovery-phrase/) is one.
+Treat the rpId as a long-lived choice. Before any planned migration, accounts need an export path; [Reveal a recovery phrase](/recipes/reveal-a-recovery-phrase/) is one.
 
 ## One output, one purpose
 
-Reusing one PRF output for unrelated purposes (key derivation and app-data encryption, say) links those secrets: anyone who learns the output learns them all. Use a different salt per purpose, or split one output with a purpose-labeled KDF.
+Reusing one PRF output for unrelated purposes (for example, key derivation and app-data encryption) links those secrets: exposure of the output exposes all of them. Use a different salt per purpose, or split one output with a purpose-labeled KDF.
 
 A vault is bound to its PRF output only, never to the credential ID or salt. Secrets wrapped under one reused output share a wrapping key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. Give each secret a fresh random 32-byte salt; the [createSecretVault](/reference/create-secret-vault/) page carries the same warning.
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -45,7 +45,7 @@ The salt is mera's fixed deterministic one: the same passkey, relying party, and
 
 ## Derive an account
 
-The PRF output is entropy. This walkthrough maps it through BIP-39 and BIP-32, the demo's scheme, so the account can be imported into wallet apps that speak those standards.
+The PRF output is entropy. This walkthrough maps it through BIP-39 and BIP-32 so the account can be imported into wallet apps that speak those standards.
 
 ```ts
 import { HDKey } from "@scure/bip32";


### PR DESCRIPTION
Second PR in the docs-content stack (on top of #123). The entry funnel links to concept pages for everything it deliberately does not explain inline; this PR writes them.

- **Passkeys and the PRF extension**: WebAuthn for wallet developers. What a passkey is, why user verification is required and not configurable (the CTAP hmac-secret two-PRF mechanism), the determinism triple (credential, rpId, salt), salts as namespaces, and ceremony/prompt economics.
- **Derived and wrapped modes**: the two patterns as parallel options, with honest loss cases for each and a trade-off list that names where state lives, what happens when the passkey is gone, and the salt discipline.
- **Security model**: the connected version of the security facts that also sit on individual reference pages. Buffer copying, zeroing, internal challenges and nonces; the compromised-runtime boundary; rpId binding and domain migrations; one output, one purpose (with the vault corollary); strings cannot be zeroed; dependency scope.
- **Authenticator support**: requirements, the matrix mirrored from the README (README remains the source of truth; updates land in both places per docs/AGENTS.md), the desktop Chrome local-profile trap, and the Corbado article for the broader picture.

Every claim traces to the README or the JSDoc in src/. Links to recipe and reference pages resolve later in the stack.

Validation: `npm run build` in docs/ passes (7 pages); style sweep for em dashes, banned vocabulary, "your", and "wallet" outside wallet-app contexts is clean.