### PR TITLE
docs: API reference, one page per exported function

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -15,7 +15,7 @@ When content feels misplaced, move it and link to it: a reference page that star
 
 ## Reference pages
 
-One exported function per page. A new public export means a new page and a new sidebar entry in `astro.config.mjs`.
+One exported function per page. A new public export means a new page and a new sidebar entry in `astro.config.mjs`. A small export inseparable from a contract shares the contract's page instead: `MeraError` and `isMeraError` live on the errors page.
 
 Fixed section order:
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -15,7 +15,7 @@ When content feels misplaced, move it and link to it: a reference page that star
 
 ## Reference pages
 
-One exported function per page. A new public export means a new page and a new sidebar entry in `astro.config.mjs`. A small export inseparable from a contract shares the contract's page instead: `MeraError` and `isMeraError` live on the errors page.
+One exported function per page. A new public export means a new page and a new sidebar entry in `astro.config.mjs`. A small export inseparable from a larger contract is documented on that contract's page instead.
 
 Fixed section order:
 
@@ -24,12 +24,12 @@ Fixed section order:
 3. `## Import`: a single import statement.
 4. `## Usage`: one focused, compilable example.
 5. `## Parameters`: an intro line naming the options type, then one `### options.field` subheading per field (dotted for nested fields). Under each: a `- Type:` line, a `- Required` or `- Optional` line (with the default or omission behavior), then prose.
-6. `## Returns`: the named result type and what it contains. Session constructors document the returned session's members here.
-7. `## Errors`: one bullet per `MeraError` code with its trigger condition, each code linked to its anchor on the errors page.
+6. `## Returns`: the named result type and what it contains. When the return value has members of its own, each member is documented here.
+7. `## Errors`: one bullet per error code with its trigger condition, each code linked to its anchor on the errors page.
 8. `## Notes`: copy and zeroing semantics, determinism statements, caveats. Omit the section when there is nothing to say.
 9. `## See also`: related functions, the owning concept page, the recipe that uses it.
 
-Parameters use subheadings and lists, never wide tables. The content column is 46rem; a five-column table does not survive it. Tables are reserved for the error-code list and the authenticator matrix.
+Parameters use subheadings and lists, never wide tables. The content column is narrow; a five-column table does not survive it. Tables are reserved for genuinely tabular data, like the authenticator matrix.
 
 Source of truth is the JSDoc in `src/`. Write reference prose from it, and check the README when the JSDoc is silent. When the two disagree, the code wins; flag the README in the PR.
 
@@ -38,7 +38,7 @@ Source of truth is the JSDoc in `src/`. Write reference prose from it, and check
 - Title with a verb: "Wrap a recovery phrase" rather than "Recovery phrase wrapping".
 - One goal per page. Prerequisites in the first paragraph.
 - Code blocks are complete and pasteable in order. A reader who pastes every block top to bottom ends with working code.
-- Code adapted from `demo/src/` is an app-side pattern. Say so. mera produces entropy and signing sessions; derivation, storage, and transport belong to the app, and the recipe's framing must keep that boundary visible.
+- Code adapted from `demo/src/` is an app-side pattern. Say so. Derivation schemes, storage, and transport belong to the app, and the recipe's framing must keep the library/app boundary visible.
 
 ## Voice
 
@@ -87,7 +87,7 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 1. `npm run build` passes.
 2. New pages appear in the sidebar; no sidebar entry points at a missing page.
 3. Examples compile against the current public API.
-4. Every `MeraError` code mentioned links to the errors page.
+4. Every error code mentioned links to the errors page.
 5. No em dash anywhere in the diff.
 6. No banned vocabulary, no "not X, but Y".
 7. "Wallet" appears only next to wallet apps.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -69,6 +69,7 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 - Every claim must be checkable against the README or the JSDoc in `src/`.
 - Implementation details live only on the page that owns them: error codes and library internals on the reference, demo internals (derivation schemes, storage, UI) in the recipes that adapt its code. Every other page links to the owning page instead of restating the detail, so a demo or library change touches one page.
 - Examples import only the public API plus explicitly declared app-side dependencies.
+- Examples define every identifier they use. Values the app supplies enter through a placeholder with realistic shape and provenance: `crypto.getRandomValues(new Uint8Array(32))` for key material, `new TextEncoder().encode(...)` for secret text, a literal for addresses and rpIds. Never use an all-zero buffer where the library validates the value; an all-zero secp256k1 key throws.
 - Security-sensitive behavior is stated plainly on the page where the risk is acted on: key material lifetimes, zeroing, nonce handling, prompt counts, and what the library cannot protect against.
 - Support claims are date-stamped. The authenticator matrix lives in the README; this site mirrors it, and updates land in both places.
 
@@ -86,7 +87,7 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 
 1. `npm run build` passes.
 2. New pages appear in the sidebar; no sidebar entry points at a missing page.
-3. Examples compile against the current public API.
+3. Examples compile against the current public API, with no undefined identifiers.
 4. Every error code mentioned links to the errors page.
 5. No em dash anywhere in the diff.
 6. No banned vocabulary, no "not X, but Y".

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -20,7 +20,7 @@ One exported function per page. A new public export means a new page and a new s
 Fixed section order:
 
 1. Frontmatter: `title` is the exact exported name, `description` is one sentence.
-2. A short lead with no heading: what the function does and the one fact a caller must know. Functions that run WebAuthn ceremonies say so here, because a browser prompt is a visible side effect.
+2. A short lead with no heading: what the function does, plus only facts no later section carries. Visible side effects belong here; functions that run WebAuthn ceremonies say so, because a browser prompt is one. Anything stated in or inferable from Parameters, Returns, or Errors is not repeated in the lead.
 3. `## Import`: a single import statement.
 4. `## Usage`: one focused, compilable example.
 5. `## Parameters`: an intro line naming the options type, then one `### options.field` subheading per field (dotted for nested fields). Under each: a `- Type:` line, a `- Required` or `- Optional` line (with the default or omission behavior), then prose.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -56,6 +56,48 @@ export default defineConfig({
             "concepts/authenticator-support",
           ],
         },
+        {
+          label: "Reference",
+          items: [
+            { label: "Overview", slug: "reference" },
+            {
+              label: "Passkeys",
+              items: [
+                "reference/create-passkey",
+                "reference/create-passkey-with-prf-output",
+                "reference/get-passkey-prf-output",
+                "reference/get-deterministic-prf-salt-v1",
+              ],
+            },
+            {
+              label: "Signing sessions",
+              items: [
+                "reference/create-secp256k1-signing-session",
+                "reference/create-ed25519-signing-session",
+              ],
+            },
+            {
+              label: "Secret vault",
+              items: [
+                "reference/create-secret-vault",
+                "reference/get-secret-vault-prf-output",
+                "reference/unwrap-secret-vault",
+                "reference/parse-secret-vault",
+                "reference/secret-vault-format",
+              ],
+            },
+            {
+              label: "Addresses",
+              items: [
+                "reference/get-evm-address",
+                "reference/is-evm-address",
+                "reference/get-solana-address",
+                "reference/is-solana-address",
+              ],
+            },
+            { label: "Errors", slug: "reference/errors" },
+          ],
+        },
       ],
     }),
   ],

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
     - text: Getting started
       link: /getting-started/
       icon: right-arrow
-    - text: GitHub
-      link: https://github.com/category-labs/mera
+    - text: API reference
+      link: /reference/
       variant: minimal
 ---

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -1,0 +1,75 @@
+---
+title: createEd25519SigningSession
+description: Wraps an Ed25519 private key in an explicitly lockable signing session.
+---
+
+Wraps an Ed25519 private key in an explicitly lockable signing session. The key is consumed: the input buffer is zeroed before the call returns or throws, and from then on the session's copy is the only one the library knows about.
+
+## Import
+
+```ts
+import { createEd25519SigningSession } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  createEd25519SigningSession,
+  getSolanaAddress,
+} from "@category-labs/mera";
+
+const session = createEd25519SigningSession({
+  consumePrivateKey: seed, // zeroed by this call
+});
+
+const address = getSolanaAddress(session.publicKey);
+const signature = await session.signMessage(messageBytes);
+
+session.lock();
+```
+
+## Parameters
+
+`options` is a `CreateSigningSessionOptions`.
+
+### options.consumePrivateKey
+
+- Type: `Uint8Array`
+- Required
+
+Ed25519 private key (the 32-byte seed). Copied into one session-owned snapshot; the input buffer is zeroed before the call returns or throws. Callers holding the key elsewhere should pass a copy.
+
+## Returns
+
+An `Ed25519SigningSession`, unlocked.
+
+### publicKey
+
+`Uint8Array`, the 32-byte Ed25519 public key. Derived from the same owned snapshot used for signing, so the two cannot diverge.
+
+### signMessage(message)
+
+Signs an arbitrary-length message and resolves to the 64-byte Ed25519 signature (`R || s`). Hashing happens inside Ed25519 itself; the caller passes the raw message, never a digest. The message is copied before use because signing reads the buffer after an await; the original is not modified. Throws [`SESSION_LOCKED`](/reference/errors/#session_locked) after `lock`.
+
+### lock()
+
+Zeroes the session-owned private-key copy and permanently locks the session; later signing throws `SESSION_LOCKED`. If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
+
+### [Symbol.dispose]()
+
+Calls `lock`, so a `using` declaration locks the session when its scope exits. Sessions bound with `const` or `let` are unaffected; disposal runs only where a caller opts in with `using`.
+
+## Errors
+
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `consumePrivateKey` is not 32 bytes. The input buffer is zeroed even on this path.
+
+## Notes
+
+Signing needs no passkey ceremony and shows no prompt. One user-verification prompt produces the entropy; the session then signs as often as the app asks until it is locked.
+
+## See also
+
+- [getSolanaAddress](/reference/get-solana-address/): the address for `session.publicKey`.
+- [Sign Solana transactions](/recipes/sign-solana-transactions/): where `signMessage` plugs into a transaction flow.
+- [Security model](/concepts/security-model/): what an active session exposes.

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -66,7 +66,7 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits. S
 
 ## Notes
 
-Signing needs no passkey ceremony and shows no prompt. One user-verification prompt produces the entropy; the session then signs as often as the app asks until it is locked.
+Signing needs no passkey ceremony and shows no prompt; the session signs as often as the app asks until it is locked.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -19,12 +19,15 @@ import {
   getSolanaAddress,
 } from "@category-labs/mera";
 
+const seed = crypto.getRandomValues(new Uint8Array(32)); // stand-in for an app-derived key
+const message = new TextEncoder().encode("hello mera");
+
 const session = createEd25519SigningSession({
   consumePrivateKey: seed, // zeroed by this call
 });
 
 const address = getSolanaAddress(session.publicKey);
-const signature = await session.signMessage(messageBytes);
+const signature = await session.signMessage(message);
 
 session.lock();
 ```

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -72,4 +72,4 @@ Signing needs no passkey ceremony and shows no prompt; the session signs as ofte
 
 - [getSolanaAddress](/reference/get-solana-address/): the address for `session.publicKey`.
 - [Sign Solana transactions](/recipes/sign-solana-transactions/): where `signMessage` plugs into a transaction flow.
-- [Security model](/concepts/security-model/): what an active session exposes.
+- [Signing sessions](/concepts/signing-sessions/): the custody model, the lifecycle, and what an active session exposes.

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -3,7 +3,7 @@ title: createEd25519SigningSession
 description: Wraps an Ed25519 private key in an explicitly lockable signing session.
 ---
 
-Wraps an Ed25519 private key in an explicitly lockable signing session. The key is consumed: the input buffer is zeroed before the call returns or throws, and from then on the session's copy is the only one the library knows about.
+Wraps an Ed25519 private key in an explicitly lockable signing session.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -31,7 +31,7 @@ const result = await createPasskeyWithPrfOutput({
 
 ## Parameters
 
-`options` is a `CreatePasskeyWithPrfOutputOptions`. It tightens `CreatePasskeyOptions` in two places: `rp.id` is required so the fallback ceremony can target the same relying party, and `prfSalt` is required so the app chooses whether this flow is deterministic or random-key.
+`options` is a `CreatePasskeyWithPrfOutputOptions`. It tightens `CreatePasskeyOptions` in two places: `rp.id` is required so the fallback ceremony can target the same relying party, and `prfSalt` is required so the app explicitly chooses between the derived and wrapped patterns.
 
 ### options.rp
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -1,0 +1,86 @@
+---
+title: createPasskeyWithPrfOutput
+description: Creates a passkey and returns its first PRF output in one call.
+---
+
+Creates a passkey and returns the first WebAuthn PRF output, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time. Equivalent to [createPasskey](/reference/create-passkey/) followed, when `prfOutput` is absent, by [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt.
+
+Runs `navigator.credentials.create()`, and on authenticators without create-time PRF also `navigator.credentials.get()`. The fallback means a possible second browser prompt.
+
+## Import
+
+```ts
+import { createPasskeyWithPrfOutput } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  createPasskeyWithPrfOutput,
+  getDeterministicPrfSaltV1,
+} from "@category-labs/mera";
+
+const result = await createPasskeyWithPrfOutput({
+  rp: { id: "account.example.com", name: "Example" },
+  user: { name: "account@example.com", displayName: "Example account" },
+  prfSalt: getDeterministicPrfSaltV1(),
+});
+// result.credentialId, result.prfSalt, result.prfOutput
+```
+
+## Parameters
+
+`options` is a `CreatePasskeyWithPrfOutputOptions`. It tightens `CreatePasskeyOptions` in two places: `rp.id` is required so the fallback ceremony can target the same relying party, and `prfSalt` is required so the app chooses whether this flow is deterministic or random-key.
+
+### options.rp
+
+- Type: `PublicKeyCredentialRpEntity & { id: string }`
+- Required, including `rp.id`
+
+Relying party identity, passed to WebAuthn.
+
+### options.user
+
+- Type: `{ id?: Uint8Array; name: string; displayName: string }`
+- Required
+
+Same fields and constraints as on [createPasskey](/reference/create-passkey/#optionsusername): `name` and `displayName` are required, `id` is optional (1 to 64 bytes, fresh 32-byte random handle per call when omitted).
+
+### options.prfSalt
+
+- Type: `Uint8Array`
+- Required
+
+32-byte PRF salt, evaluated during creation or by the fallback assertion. Derived flows pass [getDeterministicPrfSaltV1()](/reference/get-deterministic-prf-salt-v1/); wrapped flows pass 32 fresh random bytes. Copied before async WebAuthn work starts, so post-call mutation of the input changes neither the fallback ceremony nor the returned salt.
+
+### options.timeout
+
+- Type: `number`
+- Optional; browser defaults apply when omitted
+
+WebAuthn timeout in milliseconds, applied to each ceremony.
+
+## Returns
+
+`Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`. The returned salt never aliases the caller's input.
+
+The shape is deliberate: the result can be passed straight through as the `credential` argument of [createSecretVault](/reference/create-secret-vault/).
+
+## Errors
+
+- [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF, or did not return PRF output on the fallback ceremony.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+
+## Notes
+
+WebAuthn challenges are generated internally. Raw attestation and assertion responses are not returned.
+
+If the fallback ceremony fails, the passkey from the completed creation ceremony still exists on the authenticator, but the thrown error does not carry its metadata.
+
+## See also
+
+- [createSecretVault](/reference/create-secret-vault/): wrap a secret with this function's result.
+- [Getting started](/getting-started/): the derived-mode flow built on this call.

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -3,9 +3,7 @@ title: createPasskeyWithPrfOutput
 description: Creates a passkey and returns its first PRF output in one call.
 ---
 
-Creates a passkey and returns the first WebAuthn PRF output, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time. Equivalent to [createPasskey](/reference/create-passkey/) followed, when `prfOutput` is absent, by [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt.
-
-Runs `navigator.credentials.create()`, and on authenticators without create-time PRF also `navigator.credentials.get()`. The fallback means a possible second browser prompt.
+Creates a passkey and returns the first WebAuthn PRF output, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time. Equivalent to [createPasskey](/reference/create-passkey/) followed, when `prfOutput` is absent, by [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt; the fallback means a possible second browser prompt.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -1,9 +1,9 @@
 ---
 title: createPasskeyWithPrfOutput
-description: Creates a passkey and returns its first PRF output in one call.
+description: Creates a passkey and returns the PRF output for the given salt in one call.
 ---
 
-Creates a passkey and returns the first WebAuthn PRF output, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time. Equivalent to [createPasskey](/reference/create-passkey/) followed, when `prfOutput` is absent, by [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt; the fallback means a possible second browser prompt.
+Creates a passkey and returns the WebAuthn PRF output for the given salt, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time. Equivalent to [createPasskey](/reference/create-passkey/) followed, when `prfOutput` is absent, by [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt; the fallback means a possible second browser prompt.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -65,7 +65,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 `Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`. The returned salt never aliases the caller's input.
 
-The shape is deliberate: the result can be passed straight through as the `credential` argument of [createSecretVault](/reference/create-secret-vault/).
+The result can be passed straight through as the `credential` argument of [createSecretVault](/reference/create-secret-vault/).
 
 ## Errors
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -1,9 +1,9 @@
 ---
 title: createPasskey
-description: Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
+description: Creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled.
 ---
 
-Creates a discoverable, user-verified passkey and requires WebAuthn PRF support. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
+Creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -5,8 +5,6 @@ description: Creates a discoverable, user-verified passkey and requires WebAuthn
 
 Creates a discoverable, user-verified passkey and requires WebAuthn PRF support. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
 
-When `prfSalt` is provided and the authenticator evaluates PRF at create time, the result includes the first PRF output and no second ceremony is needed. Without `prfSalt`, no PRF evaluation happens during creation and the result carries credential metadata only; a later [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) call with a salt produces PRF output for this passkey.
-
 ## Import
 
 ```ts

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -1,0 +1,96 @@
+---
+title: createPasskey
+description: Creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
+---
+
+Creates a discoverable, user-verified passkey and requires WebAuthn PRF support. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
+
+When `prfSalt` is provided and the authenticator evaluates PRF at create time, the result includes the first PRF output and no second ceremony is needed. Without `prfSalt`, no PRF evaluation happens during creation and the result carries credential metadata only; a later [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) call with a salt produces PRF output for this passkey.
+
+## Import
+
+```ts
+import { createPasskey } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+const credential = await createPasskey({
+  rp: { id: "account.example.com", name: "Example" },
+  user: { name: "account@example.com", displayName: "Example account" },
+});
+// credential.credentialId is base64url; credential.transports when reported.
+```
+
+## Parameters
+
+`options` is a `CreatePasskeyOptions`.
+
+### options.rp
+
+- Type: `PublicKeyCredentialRpEntity`
+- Required
+
+Relying party identity, passed directly to WebAuthn.
+
+### options.user.name
+
+- Type: `string`
+- Required
+
+User name displayed or stored by the authenticator.
+
+### options.user.displayName
+
+- Type: `string`
+- Required
+
+Human-readable display name for the authenticator UI.
+
+### options.user.id
+
+- Type: `Uint8Array`
+- Optional; a fresh 32-byte random handle is generated per call when omitted
+
+User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). The generated handle is not correlated with an app account, so repeated calls do not share a stable user handle. Copied before use.
+
+### options.timeout
+
+- Type: `number`
+- Optional; browser defaults apply when omitted
+
+WebAuthn timeout in milliseconds.
+
+### options.prfSalt
+
+- Type: `Uint8Array`
+- Optional; no PRF evaluation happens during creation when omitted
+
+32-byte PRF salt to evaluate during creation. Authenticators that do not support PRF evaluation at create time silently ignore it, and the result then omits `prfOutput`. Copied before use; the original buffer is not modified.
+
+## Returns
+
+`Promise<CreatePasskeyResult>`. The credential ID as canonical unpadded base64url, the authenticator transports when the browser reports them, and a 32-byte `prfOutput` when `prfSalt` was provided and evaluated during creation.
+
+## Errors
+
+- [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF, or returned a malformed create-time PRF output.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `prfSalt` is provided but not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+
+## Notes
+
+The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"`, a required resident key, and required user verification. The user-verification requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the PRF output nor remove the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
+
+The WebAuthn challenge is generated internally. The raw attestation response is not returned.
+
+A `PRF_UNAVAILABLE` failure happens after the creation ceremony has completed: the passkey exists on the authenticator, but the thrown error does not carry its metadata. Expect the orphan credential to appear in the authenticator's passkey list.
+
+WebAuthn availability is checked before Web Crypto, so an environment missing both throws `PASSKEY_OPERATION_FAILED`.
+
+## See also
+
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): create and obtain the PRF output in one call.
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): evaluate the PRF of an existing passkey.

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -86,7 +86,7 @@ The credential is requested with fixed parameters: ES256 or RS256 key types, att
 
 The WebAuthn challenge is generated internally. The raw attestation response is not returned.
 
-A `PRF_UNAVAILABLE` failure happens after the creation ceremony has completed: the passkey exists on the authenticator, but the thrown error does not carry its metadata. Expect the orphan credential to appear in the authenticator's passkey list.
+A `PRF_UNAVAILABLE` failure happens after the creation ceremony has completed: the passkey exists on the authenticator, but the thrown error does not carry its metadata. The orphaned credential appears in the authenticator's passkey list.
 
 WebAuthn availability is checked before Web Crypto, so an environment missing both throws `PASSKEY_OPERATION_FAILED`.
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -38,7 +38,7 @@ session.lock();
 - Type: `Uint8Array`
 - Required
 
-secp256k1 private key. Must be exactly 32 bytes and a valid scalar. Copied into one session-owned snapshot; the input buffer is zeroed before the call returns or throws, which the `consume` prefix is there to signal. Callers holding the key inside another structure (an `HDKey`, for example) should pass a copy.
+secp256k1 private key. Must be exactly 32 bytes and a valid scalar. Copied into one session-owned snapshot; the input buffer is zeroed before the call returns or throws. Callers holding the key inside another structure (an `HDKey`, for example) should pass a copy.
 
 ## Returns
 
@@ -75,7 +75,7 @@ Sessions bound with `const` or `let` are unaffected; disposal runs only where a 
 
 ## Notes
 
-Signing needs no passkey ceremony and shows no prompt. One user-verification prompt produces the entropy; the session then signs as often as the app asks until it is locked.
+Signing needs no passkey ceremony and shows no prompt; the session signs as often as the app asks until it is locked.
 
 The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with `INPUT_INVALID` rather than return a signature that cannot be address-recovered.
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -3,7 +3,7 @@ title: createSecp256k1SigningSession
 description: Wraps a secp256k1 private key in an explicitly lockable signing session.
 ---
 
-Wraps a secp256k1 private key in an explicitly lockable signing session. The key is consumed: the input buffer is zeroed before the call returns or throws, and from then on the session's copy is the only one the library knows about.
+Wraps a secp256k1 private key in an explicitly lockable signing session.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -83,4 +83,4 @@ The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA but require t
 
 - [getEvmAddress](/reference/get-evm-address/): the address for `session.publicKey`.
 - [Sign with viem](/recipes/sign-with-viem/): adapting `signDigest` to a viem account.
-- [Security model](/concepts/security-model/): what an active session exposes.
+- [Signing sessions](/concepts/signing-sessions/): the custody model, the lifecycle, and what an active session exposes.

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -19,6 +19,9 @@ import {
   getEvmAddress,
 } from "@category-labs/mera";
 
+const privateKey = crypto.getRandomValues(new Uint8Array(32)); // stand-in for an app-derived key
+const digest32 = new Uint8Array(32); // stand-in for a 32-byte transaction digest
+
 const session = createSecp256k1SigningSession({
   consumePrivateKey: privateKey, // zeroed by this call
 });
@@ -62,7 +65,7 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits:
 
 ```ts
 {
-  using session = createSecp256k1SigningSession({ consumePrivateKey });
+  using session = createSecp256k1SigningSession({ consumePrivateKey: privateKey });
   await session.signDigest(digest32);
 } // locked here
 ```

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -1,0 +1,86 @@
+---
+title: createSecp256k1SigningSession
+description: Wraps a secp256k1 private key in an explicitly lockable signing session.
+---
+
+Wraps a secp256k1 private key in an explicitly lockable signing session. The key is consumed: the input buffer is zeroed before the call returns or throws, and from then on the session's copy is the only one the library knows about.
+
+## Import
+
+```ts
+import { createSecp256k1SigningSession } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  createSecp256k1SigningSession,
+  getEvmAddress,
+} from "@category-labs/mera";
+
+const session = createSecp256k1SigningSession({
+  consumePrivateKey: privateKey, // zeroed by this call
+});
+
+const address = getEvmAddress(session.publicKey);
+const { compact, recovery } = await session.signDigest(digest32);
+
+session.lock();
+```
+
+## Parameters
+
+`options` is a `CreateSigningSessionOptions`.
+
+### options.consumePrivateKey
+
+- Type: `Uint8Array`
+- Required
+
+secp256k1 private key. Must be exactly 32 bytes and a valid scalar. Copied into one session-owned snapshot; the input buffer is zeroed before the call returns or throws, which the `consume` prefix is there to signal. Callers holding the key inside another structure (an `HDKey`, for example) should pass a copy.
+
+## Returns
+
+A `Secp256k1SigningSession`, unlocked.
+
+### publicKey
+
+`Uint8Array`, 65 bytes, the uncompressed secp256k1 public key with the `0x04` prefix. Derived from the same owned snapshot used for signing, so the two cannot diverge.
+
+### signDigest(digest32)
+
+Signs a 32-byte digest without prehashing it and resolves to a `Secp256k1Signature`: `compact` (64 bytes, `r || s`, low-S) plus `recovery` (0 or 1). The digest is copied before use because signing reads the buffer after an await; the original is not modified. Throws [`INPUT_INVALID`](/reference/errors/#input_invalid) when the digest is not 32 bytes and [`SESSION_LOCKED`](/reference/errors/#session_locked) after `lock`.
+
+### lock()
+
+Zeroes the session-owned private-key copy and permanently locks the session; later signing throws `SESSION_LOCKED`. If `lock` is called while a sign on the same session is still in flight, the calls race and the in-flight signature's result is unspecified.
+
+### [Symbol.dispose]()
+
+Calls `lock`, so a `using` declaration locks the session when its scope exits:
+
+```ts
+{
+  using session = createSecp256k1SigningSession({ consumePrivateKey });
+  await session.signDigest(digest32);
+} // locked here
+```
+
+Sessions bound with `const` or `let` are unaffected; disposal runs only where a caller opts in with `using`.
+
+## Errors
+
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `consumePrivateKey` is not a valid secp256k1 scalar. The input buffer is zeroed even on this path.
+
+## Notes
+
+Signing needs no passkey ceremony and shows no prompt. One user-verification prompt produces the entropy; the session then signs as often as the app asks until it is locked.
+
+The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with `INPUT_INVALID` rather than return a signature that cannot be address-recovered.
+
+## See also
+
+- [getEvmAddress](/reference/get-evm-address/): the address for `session.publicKey`.
+- [Sign with viem](/recipes/sign-with-viem/): adapting `signDigest` to a viem account.
+- [Security model](/concepts/security-model/): what an active session exposes.

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -29,6 +29,8 @@ const credential = await createPasskeyWithPrfOutput({
   prfSalt,
 });
 
+const secret = new TextEncoder().encode("the secret to protect");
+
 const vault = await createSecretVault({ credential, secret });
 localStorage.setItem("vault", JSON.stringify(vault));
 ```

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -3,7 +3,7 @@ title: createSecretVault
 description: Encrypts an arbitrary secret into a passkey-protected vault.
 ---
 
-Encrypts an arbitrary secret into a passkey-protected vault. No ceremony runs here; the PRF output from an earlier ceremony does the cryptographic work.
+Encrypts an arbitrary secret into a passkey-protected vault.
 
 An AES-256-GCM wrapping key is derived from the PRF output with fixed HKDF-SHA-256 info (`mera.v1.wrap.secret`), which separates it from any other key derived from the same output. The secret is encrypted under fixed additional authenticated data.
 

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -70,6 +70,6 @@ Input byte buffers are copied before async cryptographic work starts; mutating t
 
 ## See also
 
-- [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) and [unwrapSecretVault](/reference/unwrap-secret-vault/): the way back in.
+- [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) and [unwrapSecretVault](/reference/unwrap-secret-vault/): the assertion and decryption that recover the secret.
 - [Wrap a recovery phrase](/recipes/wrap-a-recovery-phrase/): the full flow with zeroing.
-- [Security model](/concepts/security-model/#one-output-one-purpose): why salt reuse is the mistake to design out.
+- [Security model](/concepts/security-model/#one-output-one-purpose): why PRF outputs must not be reused across purposes.

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -1,0 +1,75 @@
+---
+title: createSecretVault
+description: Encrypts an arbitrary secret into a passkey-protected vault.
+---
+
+Encrypts an arbitrary secret into a passkey-protected vault. No ceremony runs here; the PRF output from an earlier ceremony does the cryptographic work.
+
+An AES-256-GCM wrapping key is derived from the PRF output with fixed HKDF-SHA-256 info (`mera.v1.wrap.secret`), which separates it from any other key derived from the same output. The secret is encrypted under fixed additional authenticated data.
+
+## Import
+
+```ts
+import { createSecretVault } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  createPasskeyWithPrfOutput,
+  createSecretVault,
+} from "@category-labs/mera";
+
+const prfSalt = crypto.getRandomValues(new Uint8Array(32)); // fresh per secret
+
+const credential = await createPasskeyWithPrfOutput({
+  rp: { id: "account.example.com", name: "Example" },
+  user: { name: "account@example.com", displayName: "Example account" },
+  prfSalt,
+});
+
+const vault = await createSecretVault({ credential, secret });
+localStorage.setItem("vault", JSON.stringify(vault));
+```
+
+## Parameters
+
+`options` is a `CreateSecretVaultOptions`.
+
+### options.credential
+
+- Type: `{ credentialId: string; transports?: readonly PasskeyCredentialTransport[]; prfSalt: Uint8Array; prfOutput: Uint8Array }`
+- Required
+
+The passkey credential plus the PRF salt and the PRF output it produced. The result of [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) can be passed straight through. `credentialId` must be canonical unpadded base64url and non-empty; `prfSalt` and `prfOutput` must each be exactly 32 bytes.
+
+### options.secret
+
+- Type: `Uint8Array`
+- Required
+
+Secret bytes to encrypt. Any non-empty length; the library does not interpret them.
+
+## Returns
+
+`Promise<PasskeySecretVault>`: a JSON-safe object holding the credential metadata, the base64url-encoded salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
+
+## Errors
+
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): the credential ID is empty or not canonical base64url, the PRF salt or output is not 32 bytes, or `secret` is empty.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+
+## Notes
+
+**Use a fresh random salt per secret.** A vault is bound to its `prfOutput` only, never to the credential ID or salt. Secrets wrapped under one reused PRF output share a wrapping key, so their nonce/ciphertext pairs are interchangeable by anyone who can rewrite stored vault JSON. A fresh 32-byte `prfSalt` per secret gives each vault an unrelated PRF output and its own key.
+
+The GCM nonce (12 bytes) is generated internally for each encryption, so a caller cannot accidentally reuse one.
+
+Input byte buffers are copied before async cryptographic work starts; mutating them after the call does not change the vault being produced. Caller-owned buffers are not modified or zeroed by this function; the internal copies of the PRF output and secret are zeroed before it returns. Callers that are done with their own `prfOutput` and `secret` buffers should zero them.
+
+## See also
+
+- [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) and [unwrapSecretVault](/reference/unwrap-secret-vault/): the way back in.
+- [Wrap a recovery phrase](/recipes/wrap-a-recovery-phrase/): the full flow with zeroing.
+- [Security model](/concepts/security-model/#one-output-one-purpose): why salt reuse is the mistake to design out.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -1,6 +1,6 @@
 ---
 title: Errors
-description: MeraError, isMeraError, and every stable error code.
+description: Every error the library throws and its stable code.
 ---
 
 Everything the library throws is a `MeraError`. It carries a stable, machine-readable `code` alongside the usual `message` and optional `cause`. The codes are the contract; the message text is free to change between versions.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -18,10 +18,17 @@ class MeraError extends Error {
 ## isMeraError
 
 ```ts
-import { isMeraError } from "@category-labs/mera";
+import {
+  getDeterministicPrfSaltV1,
+  getPasskeyPrfOutput,
+  isMeraError,
+} from "@category-labs/mera";
 
 try {
-  await getPasskeyPrfOutput({ rpId, prfSalt });
+  await getPasskeyPrfOutput({
+    rpId: "account.example.com",
+    prfSalt: getDeterministicPrfSaltV1(),
+  });
 } catch (error) {
   if (isMeraError(error) && error.code === "PRF_UNAVAILABLE") {
     // Point at a PRF-capable authenticator.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -1,0 +1,67 @@
+---
+title: Errors
+description: MeraError, isMeraError, and every stable error code.
+---
+
+Everything the library throws is a `MeraError`. It carries a stable, machine-readable `code` alongside the usual `message` and optional `cause`. The codes are the contract; the message text is free to change between versions.
+
+## MeraError
+
+```ts
+class MeraError extends Error {
+  readonly code: MeraErrorCode;
+}
+```
+
+`name` is always `"MeraError"`. When a lower-level failure triggered the error (a WebAuthn rejection, a Web Crypto failure), it rides along as `cause`.
+
+## isMeraError
+
+```ts
+import { isMeraError } from "@category-labs/mera";
+
+try {
+  await getPasskeyPrfOutput({ rpId, prfSalt });
+} catch (error) {
+  if (isMeraError(error) && error.code === "PRF_UNAVAILABLE") {
+    // Point at a PRF-capable authenticator.
+  }
+  throw error;
+}
+```
+
+A type guard: returns `true` when the value is a `MeraError` instance. Narrow with it first, then branch on `code`. [Handle errors](/recipes/handle-errors/) builds a complete code-to-message mapping.
+
+## Codes
+
+### PASSKEY_OPERATION_FAILED
+
+WebAuthn failed, was cancelled, returned an unexpected credential, or the credential API is unavailable. Cancellation is the everyday case: the person dismissed the prompt.
+
+### CRYPTO_UNAVAILABLE
+
+Web Crypto is unavailable. In practice this means the page is running outside a secure context, or in a runtime without `globalThis.crypto`.
+
+### PRF_UNAVAILABLE
+
+The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path this fires after the creation ceremony has completed, so the passkey exists on the authenticator even though the error carries no metadata; [createPasskey](/reference/create-passkey/) documents the caveat. [Authenticator support](/concepts/authenticator-support/) lists which stacks avoid this error entirely.
+
+### SESSION_LOCKED
+
+A signing call was made after the session's `lock()`. Locking is permanent; recover by building a new session from fresh key material.
+
+### DECRYPT_FAILED
+
+AES-GCM authentication failed while unwrapping a vault: wrong key material, or tampered ciphertext or additional authenticated data. The two cases are indistinguishable by design; GCM authenticates before it decrypts.
+
+### INPUT_INVALID
+
+A caller-supplied value at a public boundary did not satisfy a length, range, encoding, or curve (scalar or point) constraint. Each function's Errors section lists its specific conditions.
+
+### VAULT_FORMAT_INVALID
+
+Untrusted vault data (JSON text or an object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version. Thrown only by [parseSecretVault](/reference/parse-secret-vault/), the boundary for stored vault data.
+
+## See also
+
+- [Handle errors](/recipes/handle-errors/): per-code handling guidance and user-facing messages.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -13,7 +13,7 @@ class MeraError extends Error {
 }
 ```
 
-`name` is always `"MeraError"`. When a lower-level failure triggered the error (a WebAuthn rejection, a Web Crypto failure), it rides along as `cause`.
+`name` is always `"MeraError"`. When a lower-level failure triggered the error (a WebAuthn rejection, a Web Crypto failure), it is attached as `cause`.
 
 ## isMeraError
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -3,7 +3,7 @@ title: Errors
 description: Every error the library throws and its stable code.
 ---
 
-Everything the library throws is a `MeraError`. It carries a stable, machine-readable `code` alongside the usual `message` and optional `cause`. The codes are the contract; the message text is free to change between versions.
+The library uses `MeraError` for its documented failure modes. It carries a stable, machine-readable `code` alongside the usual `message` and optional `cause`. The codes are the contract; the message text is free to change between versions.
 
 ## MeraError
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -5,7 +5,7 @@ description: Returns mera's fixed v1 deterministic PRF salt.
 
 Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. No ceremony, no prompt; this is a pure function over a constant.
 
-The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party. That stability is the foundation of [derived mode](/concepts/derived-and-wrapped/).
+The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party: the foundation of [derived mode](/concepts/derived-and-wrapped/).
 
 ## Import
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -5,7 +5,7 @@ description: Returns mera's fixed v1 deterministic PRF salt.
 
 Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. No ceremony, no prompt; this is a pure function over a constant.
 
-The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party: the foundation of [derived mode](/concepts/derived-and-wrapped/).
+The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party. [Derived mode](/concepts/derived-and-wrapped/) is built on that stability.
 
 ## Import
 
@@ -36,7 +36,7 @@ None.
 
 The salt encodes no account selection. Selecting account 0 versus account 7 happens in the derivation scheme the app applies to the PRF output, never in the salt.
 
-Wrapped flows should not use this salt. Each secret vault stores 32 fresh random bytes instead; [createSecretVault](/reference/create-secret-vault/) explains what goes wrong when a PRF output is shared.
+Wrapped flows should not use this salt. Each secret vault stores 32 fresh random bytes instead: vaults sharing one PRF output would share a wrapping key ([createSecretVault](/reference/create-secret-vault/)).
 
 ## See also
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -3,7 +3,7 @@ title: getDeterministicPrfSaltV1
 description: Returns mera's fixed v1 deterministic PRF salt.
 ---
 
-Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. No ceremony, no prompt; this is a pure function over a constant.
+Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. It is a pure function over a constant.
 
 The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party. [Derived mode](/concepts/derived-and-wrapped/) is built on that stability.
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -1,0 +1,44 @@
+---
+title: getDeterministicPrfSaltV1
+description: Returns mera's fixed v1 deterministic PRF salt.
+---
+
+Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. No ceremony, no prompt; this is a pure function over a constant.
+
+The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party. That stability is the foundation of [derived mode](/concepts/derived-and-wrapped/).
+
+## Import
+
+```ts
+import { getDeterministicPrfSaltV1 } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+const prfSalt = getDeterministicPrfSaltV1();
+// 32 bytes, identical on every call and every mera version.
+```
+
+## Parameters
+
+None.
+
+## Returns
+
+`Uint8Array` of 32 bytes. Each call returns a fresh copy: a `Uint8Array` cannot be frozen, so a shared buffer mutated by one caller would silently change every later derivation.
+
+## Errors
+
+None.
+
+## Notes
+
+The salt encodes no account selection. Selecting account 0 versus account 7 happens in the derivation scheme the app applies to the PRF output, never in the salt.
+
+Wrapped flows should not use this salt. Each secret vault stores 32 fresh random bytes instead; [createSecretVault](/reference/create-secret-vault/) explains what goes wrong when a PRF output is shared.
+
+## See also
+
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): where this salt gets used.
+- [Passkeys and the PRF extension](/concepts/passkeys-and-prf/): salts as namespaces.

--- a/docs/src/content/docs/reference/get-evm-address.md
+++ b/docs/src/content/docs/reference/get-evm-address.md
@@ -1,0 +1,41 @@
+---
+title: getEvmAddress
+description: Derives the EIP-55 checksummed EVM address for a secp256k1 public key.
+---
+
+Derives the EIP-55 checksummed EVM address for a secp256k1 public key: keccak-256 over the uncompressed key's coordinates, last 20 bytes, mixed-case checksum.
+
+## Import
+
+```ts
+import { getEvmAddress } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+const address = getEvmAddress(session.publicKey);
+// "0x8ba1f109551bD432803012645Ac136ddd64DBA72"
+```
+
+## Parameters
+
+### publicKey
+
+- Type: `Uint8Array`
+- Required
+
+A secp256k1 public key, compressed (33 bytes) or uncompressed (65 bytes). Normalized internally, so both forms give the same address.
+
+## Returns
+
+An `EvmAddress`: the EIP-55 mixed-case checksummed address as a `0x`-prefixed string. `EvmAddress` is the structural type `` `0x${string}` ``; [isEvmAddress](/reference/is-evm-address/) is the authoritative runtime check for strings from elsewhere.
+
+## Errors
+
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `publicKey` is not valid secp256k1 (wrong length, wrong prefix, or not a point on the curve).
+
+## See also
+
+- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): the session whose `publicKey` this typically receives.
+- [isEvmAddress](/reference/is-evm-address/)

--- a/docs/src/content/docs/reference/get-evm-address.md
+++ b/docs/src/content/docs/reference/get-evm-address.md
@@ -14,8 +14,17 @@ import { getEvmAddress } from "@category-labs/mera";
 ## Usage
 
 ```ts
+import {
+  createSecp256k1SigningSession,
+  getEvmAddress,
+} from "@category-labs/mera";
+
+const session = createSecp256k1SigningSession({
+  consumePrivateKey: crypto.getRandomValues(new Uint8Array(32)),
+});
+
 const address = getEvmAddress(session.publicKey);
-// "0x8ba1f109551bD432803012645Ac136ddd64DBA72"
+// EIP-55 checksummed, like "0x8ba1f109551bD432803012645Ac136ddd64DBA72"
 ```
 
 ## Parameters

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -61,7 +61,7 @@ WebAuthn timeout in milliseconds.
 
 ## Returns
 
-`Promise<PasskeyPrfResult>`: the `credentialId` the browser actually selected (canonical unpadded base64url) and the 32-byte `prfOutput`. Checking the returned ID matters in the discoverable case, where the person may have picked a different passkey than the app expected.
+`Promise<PasskeyPrfResult>`: the `credentialId` the browser actually selected (canonical unpadded base64url) and the 32-byte `prfOutput`. When `credential` was omitted, the person picks the passkey in the browser UI, so the returned ID can name a different credential than the app expected.
 
 ## Errors
 
@@ -72,7 +72,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The assertion requires user verification, and the requirement is not configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a configurable setting could neither change the output nor skip the check.
+The assertion requires user verification, and the requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the output nor skip the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
 The WebAuthn challenge is generated internally. The raw assertion response is not returned.
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -5,8 +5,6 @@ description: Requests a passkey PRF evaluation and returns the first output.
 
 Requests a passkey PRF evaluation and returns the first output. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
 
-The PRF output is a deterministic function of the credential, `rpId`, and `prfSalt`: the same three inputs reproduce the same 32 bytes, and a different salt yields an unrelated output.
-
 ## Import
 
 ```ts
@@ -71,6 +69,8 @@ WebAuthn timeout in milliseconds.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes
+
+The PRF output is a deterministic function of the credential, `rpId`, and `prfSalt`: the same three inputs reproduce the same 32 bytes, and a different salt yields an unrelated output.
 
 The assertion requires user verification, and the requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the output nor skip the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -1,9 +1,9 @@
 ---
 title: getPasskeyPrfOutput
-description: Requests a passkey PRF evaluation and returns the first output.
+description: Requests a passkey PRF evaluation and returns the output.
 ---
 
-Requests a passkey PRF evaluation and returns the first output. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Requests a passkey PRF evaluation and returns the output. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
 
 ## Import
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -1,0 +1,85 @@
+---
+title: getPasskeyPrfOutput
+description: Requests a passkey PRF evaluation and returns the first output.
+---
+
+Requests a passkey PRF evaluation and returns the first output. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+
+The PRF output is a deterministic function of the credential, `rpId`, and `prfSalt`: the same three inputs reproduce the same 32 bytes, and a different salt yields an unrelated output.
+
+## Import
+
+```ts
+import { getPasskeyPrfOutput } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  getDeterministicPrfSaltV1,
+  getPasskeyPrfOutput,
+} from "@category-labs/mera";
+
+const { credentialId, prfOutput } = await getPasskeyPrfOutput({
+  rpId: "account.example.com",
+  prfSalt: getDeterministicPrfSaltV1(),
+});
+```
+
+## Parameters
+
+`options` is a `GetPasskeyPrfOutputOptions`.
+
+### options.rpId
+
+- Type: `string`
+- Required
+
+Relying party ID for the WebAuthn assertion.
+
+### options.credential
+
+- Type: `PasskeyCredentialMetadata`
+- Optional; when omitted, WebAuthn may choose any discoverable credential for the relying party
+
+Credential metadata that restricts the assertion to one passkey: a `credentialId` in canonical unpadded base64url, plus the `transports` reported when it was created. An empty `credentialId` is rejected rather than passed through, because WebAuthn would treat it as no restriction at all and silently widen the assertion to any discoverable passkey.
+
+### options.prfSalt
+
+- Type: `Uint8Array`
+- Required
+
+PRF salt as 32 raw bytes. Copied before use; the original buffer is not modified.
+
+### options.timeout
+
+- Type: `number`
+- Optional; browser defaults apply when omitted
+
+WebAuthn timeout in milliseconds.
+
+## Returns
+
+`Promise<PasskeyPrfResult>`: the `credentialId` the browser actually selected (canonical unpadded base64url) and the 32-byte `prfOutput`. Checking the returned ID matters in the discoverable case, where the person may have picked a different passkey than the app expected.
+
+## Errors
+
+- [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+
+## Notes
+
+The assertion requires user verification, and the requirement is not configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a configurable setting could neither change the output nor skip the check.
+
+The WebAuthn challenge is generated internally. The raw assertion response is not returned.
+
+WebAuthn availability is checked before Web Crypto, so an environment missing both throws `PASSKEY_OPERATION_FAILED`.
+
+## See also
+
+- [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): the fixed salt for derived flows.
+- [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/): the same assertion, driven by a stored vault.
+- [Derive accounts from one passkey](/recipes/derive-accounts/): credential pinning in practice.

--- a/docs/src/content/docs/reference/get-secret-vault-prf-output.md
+++ b/docs/src/content/docs/reference/get-secret-vault-prf-output.md
@@ -1,0 +1,76 @@
+---
+title: getSecretVaultPrfOutput
+description: Performs the WebAuthn assertion needed to unlock a secret vault.
+---
+
+Performs the WebAuthn assertion needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+
+Under the hood this reads the credential metadata and PRF salt out of a parsed vault and delegates to [getPasskeyPrfOutput](/reference/get-passkey-prf-output/), so the assertion is automatically pinned to the credential that wrapped the secret.
+
+## Import
+
+```ts
+import { getSecretVaultPrfOutput } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  getSecretVaultPrfOutput,
+  parseSecretVault,
+  unwrapSecretVault,
+} from "@category-labs/mera";
+
+const vault = parseSecretVault(localStorage.getItem("vault"));
+const { prfOutput } = await getSecretVaultPrfOutput({
+  rpId: "account.example.com",
+  vault,
+});
+const secret = await unwrapSecretVault({ vault, prfOutput });
+```
+
+## Parameters
+
+`options` is a `GetSecretVaultPrfOutputOptions`.
+
+### options.rpId
+
+- Type: `string`
+- Required
+
+Relying party ID for the WebAuthn assertion. Must match the rpId the passkey was created under.
+
+### options.vault
+
+- Type: `PasskeySecretVault`
+- Required
+
+A parsed secret vault. Run untrusted stored data through [parseSecretVault](/reference/parse-secret-vault/) first; this function trusts the vault's shape.
+
+### options.timeout
+
+- Type: `number`
+- Optional; browser defaults apply when omitted
+
+WebAuthn timeout in milliseconds.
+
+## Returns
+
+`Promise<PasskeyPrfResult>`: the selected `credentialId` and the 32-byte `prfOutput` for the vault's stored salt.
+
+## Errors
+
+- [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): the vault's `prfSalt` is not canonical base64url or does not decode to 32 bytes, or its `credentialId` is empty or not canonical base64url. Vaults from `parseSecretVault` have already passed these checks.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+
+## Notes
+
+The WebAuthn challenge is generated internally, and the raw assertion response is not returned.
+
+## See also
+
+- [unwrapSecretVault](/reference/unwrap-secret-vault/): the decryption step that follows.
+- [Wrap a recovery phrase](/recipes/wrap-a-recovery-phrase/): the full unlock flow.

--- a/docs/src/content/docs/reference/get-secret-vault-prf-output.md
+++ b/docs/src/content/docs/reference/get-secret-vault-prf-output.md
@@ -5,7 +5,7 @@ description: Performs the WebAuthn assertion needed to unlock a secret vault.
 
 Performs the WebAuthn assertion needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
 
-Under the hood this reads the credential metadata and PRF salt out of a parsed vault and delegates to [getPasskeyPrfOutput](/reference/get-passkey-prf-output/), so the assertion is automatically pinned to the credential that wrapped the secret.
+Reads the credential metadata and PRF salt out of a parsed vault and delegates to [getPasskeyPrfOutput](/reference/get-passkey-prf-output/), so the assertion is automatically pinned to the credential that wrapped the secret.
 
 ## Import
 

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -14,8 +14,17 @@ import { getSolanaAddress } from "@category-labs/mera";
 ## Usage
 
 ```ts
+import {
+  createEd25519SigningSession,
+  getSolanaAddress,
+} from "@category-labs/mera";
+
+const session = createEd25519SigningSession({
+  consumePrivateKey: crypto.getRandomValues(new Uint8Array(32)),
+});
+
 const address = getSolanaAddress(session.publicKey);
-// "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+// base58, like "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
 ```
 
 ## Parameters

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -1,0 +1,41 @@
+---
+title: getSolanaAddress
+description: Derives the base58-encoded Solana address for an Ed25519 public key.
+---
+
+Derives the base58-encoded Solana address for an Ed25519 public key. A Solana address is the public key itself, base58-encoded; there is no hashing step.
+
+## Import
+
+```ts
+import { getSolanaAddress } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+const address = getSolanaAddress(session.publicKey);
+// "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+```
+
+## Parameters
+
+### publicKey
+
+- Type: `Uint8Array`
+- Required
+
+A 32-byte Ed25519 public key.
+
+## Returns
+
+A `SolanaAddress`. The type is a nominal brand over `string`: base58 has no structural shape TypeScript could check the way `0x${string}` covers EVM addresses, so values of this type are minted only by this function and by [isSolanaAddress](/reference/is-solana-address/). At runtime the value is a plain string.
+
+## Errors
+
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `publicKey` is not 32 bytes.
+
+## See also
+
+- [createEd25519SigningSession](/reference/create-ed25519-signing-session/): the session whose `publicKey` this typically receives.
+- [isSolanaAddress](/reference/is-solana-address/)

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -34,4 +34,4 @@ Each exported function has its own page. Types are documented on the pages of th
 
 ## Errors
 
-- [Errors](/reference/errors/): `MeraError`, `isMeraError`, and every stable error code.
+- [Errors](/reference/errors/): every error the library throws and its stable code.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -3,16 +3,13 @@ title: API reference
 description: Every exported function, grouped the way the library is built.
 ---
 
-One page per exported function, each in the same shape: import, usage, parameters, return value, errors, notes. Types are documented on the pages of the functions that produce or accept them; the one exception is the [secret vault format](/reference/secret-vault-format/), a storage contract with its own page.
+One page per exported function, each in the same shape: import, usage, parameters, return value, errors, notes. Types are documented on the pages of the functions that produce or accept them. The exceptions are two contract pages: the [secret vault format](/reference/secret-vault-format/), a storage contract, and [errors](/reference/errors/), which documents `MeraError` and the `isMeraError` guard together.
 
-## Passkey ceremonies
+## Passkeys
 
 - [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns its first PRF output in one call.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the first output.
-
-## Deterministic PRF salt
-
 - [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): returns mera's fixed v1 deterministic PRF salt.
 
 ## Signing sessions
@@ -28,7 +25,7 @@ One page per exported function, each in the same shape: import, usage, parameter
 - [parseSecretVault](/reference/parse-secret-vault/): parses and validates untrusted vault JSON or objects.
 - [Secret vault format](/reference/secret-vault-format/): the v1 storage contract, field by field.
 
-## Chain addresses
+## Addresses
 
 - [getEvmAddress](/reference/get-evm-address/): derives the EIP-55 checksummed EVM address for a secp256k1 public key.
 - [isEvmAddress](/reference/is-evm-address/): returns true when a string is a 20-byte `0x`-prefixed EVM address.
@@ -37,4 +34,4 @@ One page per exported function, each in the same shape: import, usage, parameter
 
 ## Errors
 
-- [Errors](/reference/errors/): `MeraError`, `isMeraError`, and all seven stable error codes.
+- [Errors](/reference/errors/): `MeraError`, `isMeraError`, and every stable error code.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -1,0 +1,40 @@
+---
+title: API reference
+description: Every exported function, grouped the way the library is built.
+---
+
+One page per exported function. Every page follows the same shape: import, usage, parameters, return value, errors, and the notes that matter. Types are documented on the pages of the functions that produce or accept them; the one exception is the [secret vault format](/reference/secret-vault-format/), which is a storage contract and gets its own page.
+
+## Passkey ceremonies
+
+- [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns its first PRF output in one call.
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the first output.
+
+## Deterministic PRF salt
+
+- [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): returns mera's fixed v1 deterministic PRF salt.
+
+## Signing sessions
+
+- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): wraps a secp256k1 private key in an explicitly lockable signing session.
+- [createEd25519SigningSession](/reference/create-ed25519-signing-session/): wraps an Ed25519 private key in an explicitly lockable signing session.
+
+## Secret vault
+
+- [createSecretVault](/reference/create-secret-vault/): encrypts an arbitrary secret into a passkey-protected vault.
+- [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/): performs the WebAuthn assertion needed to unlock a vault.
+- [unwrapSecretVault](/reference/unwrap-secret-vault/): decrypts the secret from a vault.
+- [parseSecretVault](/reference/parse-secret-vault/): parses and validates untrusted vault JSON or objects.
+- [Secret vault format](/reference/secret-vault-format/): the v1 storage contract, field by field.
+
+## Chain addresses
+
+- [getEvmAddress](/reference/get-evm-address/): derives the EIP-55 checksummed EVM address for a secp256k1 public key.
+- [isEvmAddress](/reference/is-evm-address/): returns true when a string is a 20-byte `0x`-prefixed EVM address.
+- [getSolanaAddress](/reference/get-solana-address/): derives the base58-encoded Solana address for an Ed25519 public key.
+- [isSolanaAddress](/reference/is-solana-address/): returns true when a string is a valid base58-encoded Solana address.
+
+## Errors
+
+- [Errors](/reference/errors/): `MeraError`, `isMeraError`, and all seven stable error codes.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -7,7 +7,7 @@ Each exported function has its own page. Types are documented on the pages of th
 
 ## Passkeys
 
-- [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
+- [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns the PRF output for the given salt in one call.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the output.
 - [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): returns mera's fixed v1 deterministic PRF salt.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -8,8 +8,8 @@ One page per exported function, each in the same shape: import, usage, parameter
 ## Passkeys
 
 - [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey and requires WebAuthn PRF support.
-- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns its first PRF output in one call.
-- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the first output.
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns the PRF output for the given salt in one call.
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the output.
 - [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): returns mera's fixed v1 deterministic PRF salt.
 
 ## Signing sessions

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -1,9 +1,9 @@
 ---
 title: API reference
-description: Every exported function, grouped the way the library is built.
+description: Every exported function, one page each.
 ---
 
-One page per exported function, each in the same shape: import, usage, parameters, return value, errors, notes. Types are documented on the pages of the functions that produce or accept them. The exceptions are two contract pages: the [secret vault format](/reference/secret-vault-format/), a storage contract, and [errors](/reference/errors/), which documents `MeraError` and the `isMeraError` guard together.
+Each exported function has its own page. Types are documented on the pages of the functions that produce or accept them.
 
 ## Passkeys
 

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -3,7 +3,7 @@ title: API reference
 description: Every exported function, grouped the way the library is built.
 ---
 
-One page per exported function. Every page follows the same shape: import, usage, parameters, return value, errors, and the notes that matter. Types are documented on the pages of the functions that produce or accept them; the one exception is the [secret vault format](/reference/secret-vault-format/), which is a storage contract and gets its own page.
+One page per exported function, each in the same shape: import, usage, parameters, return value, errors, notes. Types are documented on the pages of the functions that produce or accept them; the one exception is the [secret vault format](/reference/secret-vault-format/), a storage contract with its own page.
 
 ## Passkey ceremonies
 

--- a/docs/src/content/docs/reference/is-evm-address.md
+++ b/docs/src/content/docs/reference/is-evm-address.md
@@ -3,7 +3,7 @@ title: isEvmAddress
 description: Returns true when a string is a 20-byte 0x-prefixed EVM address.
 ---
 
-Returns `true` when a string is a 20-byte `0x`-prefixed EVM address, narrowing it to `EvmAddress` for TypeScript. Never throws.
+Returns `true` when a string is a 20-byte `0x`-prefixed EVM address.
 
 ## Import
 

--- a/docs/src/content/docs/reference/is-evm-address.md
+++ b/docs/src/content/docs/reference/is-evm-address.md
@@ -1,0 +1,43 @@
+---
+title: isEvmAddress
+description: Returns true when a string is a 20-byte 0x-prefixed EVM address.
+---
+
+Returns `true` when a string is a 20-byte `0x`-prefixed EVM address, narrowing it to `EvmAddress` for TypeScript. Never throws.
+
+## Import
+
+```ts
+import { isEvmAddress } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+if (isEvmAddress(input)) {
+  // input: EvmAddress from here on
+}
+```
+
+## Parameters
+
+### value
+
+- Type: `string`
+- Required
+
+The string to check.
+
+## Returns
+
+`boolean`, and a type predicate for `EvmAddress`.
+
+The case rules match how addresses circulate in the wild. All-lowercase and all-uppercase hex bodies are accepted as-is, since they carry no checksum to verify. Mixed-case input is validated against EIP-55, so an inconsistently cased address (a typo, a tampered string) is rejected.
+
+## Errors
+
+None. Invalid input returns `false`.
+
+## See also
+
+- [getEvmAddress](/reference/get-evm-address/): produces checksummed addresses this guard always accepts.

--- a/docs/src/content/docs/reference/is-evm-address.md
+++ b/docs/src/content/docs/reference/is-evm-address.md
@@ -32,7 +32,7 @@ The string to check.
 
 `boolean`, and a type predicate for `EvmAddress`.
 
-The case rules match how addresses circulate in the wild. All-lowercase and all-uppercase hex bodies are accepted as-is, since they carry no checksum to verify. Mixed-case input is validated against EIP-55, so an inconsistently cased address (a typo, a tampered string) is rejected.
+All-lowercase and all-uppercase hex bodies are accepted as-is; they carry no checksum to verify. Mixed-case input is validated against EIP-55, so an inconsistently cased address (a typo, a tampered string) is rejected.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/is-evm-address.md
+++ b/docs/src/content/docs/reference/is-evm-address.md
@@ -14,7 +14,7 @@ import { isEvmAddress } from "@category-labs/mera";
 ## Usage
 
 ```ts
-const input = "0x8ba1f109551bD432803012645Ac136ddd64DBA72"; // a string from user input or storage
+const input = "0x8ba1f109551bD432803012645Ac136ddd64DBA72";
 
 if (isEvmAddress(input)) {
   // input: EvmAddress from here on

--- a/docs/src/content/docs/reference/is-evm-address.md
+++ b/docs/src/content/docs/reference/is-evm-address.md
@@ -14,6 +14,8 @@ import { isEvmAddress } from "@category-labs/mera";
 ## Usage
 
 ```ts
+const input = "0x8ba1f109551bD432803012645Ac136ddd64DBA72"; // a string from user input or storage
+
 if (isEvmAddress(input)) {
   // input: EvmAddress from here on
 }

--- a/docs/src/content/docs/reference/is-solana-address.md
+++ b/docs/src/content/docs/reference/is-solana-address.md
@@ -14,7 +14,7 @@ import { isSolanaAddress } from "@category-labs/mera";
 ## Usage
 
 ```ts
-const input = "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"; // a string from user input or storage
+const input = "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV";
 
 if (isSolanaAddress(input)) {
   // input: SolanaAddress from here on

--- a/docs/src/content/docs/reference/is-solana-address.md
+++ b/docs/src/content/docs/reference/is-solana-address.md
@@ -1,0 +1,41 @@
+---
+title: isSolanaAddress
+description: Returns true when a string is a valid base58-encoded Solana address.
+---
+
+Returns `true` when a string is valid base58 and decodes to exactly 32 bytes, narrowing it to `SolanaAddress` for TypeScript. Never throws.
+
+## Import
+
+```ts
+import { isSolanaAddress } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+if (isSolanaAddress(input)) {
+  // input: SolanaAddress from here on
+}
+```
+
+## Parameters
+
+### value
+
+- Type: `string`
+- Required
+
+The string to check.
+
+## Returns
+
+`boolean`, and a type predicate for `SolanaAddress`. Decode failures are caught internally and return `false`.
+
+## Errors
+
+None. Invalid input returns `false`.
+
+## See also
+
+- [getSolanaAddress](/reference/get-solana-address/): the other way to mint a `SolanaAddress`.

--- a/docs/src/content/docs/reference/is-solana-address.md
+++ b/docs/src/content/docs/reference/is-solana-address.md
@@ -14,6 +14,8 @@ import { isSolanaAddress } from "@category-labs/mera";
 ## Usage
 
 ```ts
+const input = "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"; // a string from user input or storage
+
 if (isSolanaAddress(input)) {
   // input: SolanaAddress from here on
 }

--- a/docs/src/content/docs/reference/is-solana-address.md
+++ b/docs/src/content/docs/reference/is-solana-address.md
@@ -3,7 +3,7 @@ title: isSolanaAddress
 description: Returns true when a string is a valid base58-encoded Solana address.
 ---
 
-Returns `true` when a string is valid base58 and decodes to exactly 32 bytes, narrowing it to `SolanaAddress` for TypeScript. Never throws.
+Returns `true` when a string is valid base58 and decodes to exactly 32 bytes.
 
 ## Import
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -1,0 +1,50 @@
+---
+title: parseSecretVault
+description: Parses and validates untrusted secret-vault JSON or objects.
+---
+
+Parses and validates untrusted secret-vault JSON or objects. This is the boundary for stored vault data: anything read from `localStorage`, a backend, or a sync service goes through here before other vault functions see it. Synchronous.
+
+## Import
+
+```ts
+import { parseSecretVault } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+const stored = localStorage.getItem("vault");
+if (stored !== null) {
+  const vault = parseSecretVault(stored);
+  // vault is a validated PasskeySecretVault
+}
+```
+
+## Parameters
+
+### value
+
+- Type: `unknown`
+- Required
+
+The secret vault as JSON text or an untrusted object. Strings are JSON-parsed first; objects are validated directly.
+
+## Returns
+
+A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The credential ID, PRF salt, nonce, and ciphertext are validated as canonical base64url and length-checked (salt 32 bytes, nonce 12 bytes, ciphertext at least the 16-byte GCM tag). Unknown fields are dropped: the returned object carries the v1 schema fields and nothing else.
+
+## Errors
+
+- [`VAULT_FORMAT_INVALID`](/reference/errors/#vault_format_invalid): the required structure, version, or encoded data is invalid. The underlying parse failure, when there is one, rides along as `cause`.
+
+## Notes
+
+Validation here means later steps fail cleanly. A vault that came through this function cannot trigger the `INPUT_INVALID` re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) or [unwrapSecretVault](/reference/unwrap-secret-vault/); what remains is honest cryptographic failure (`DECRYPT_FAILED`) or ceremony failure.
+
+Rejecting unknown versions is deliberate. A future vault format bumps the version number, and an old library refusing it beats an old library misreading it.
+
+## See also
+
+- [Secret vault format](/reference/secret-vault-format/): the v1 schema this function enforces.
+- [Wrap a recovery phrase](/recipes/wrap-a-recovery-phrase/): parse-then-unlock in context.

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -36,13 +36,13 @@ A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The creden
 
 ## Errors
 
-- [`VAULT_FORMAT_INVALID`](/reference/errors/#vault_format_invalid): the required structure, version, or encoded data is invalid. The underlying parse failure, when there is one, rides along as `cause`.
+- [`VAULT_FORMAT_INVALID`](/reference/errors/#vault_format_invalid): the required structure, version, or encoded data is invalid. The underlying parse failure, when there is one, is attached as `cause`.
 
 ## Notes
 
 A vault that came through this function cannot trigger the `INPUT_INVALID` re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) or [unwrapSecretVault](/reference/unwrap-secret-vault/); what remains is cryptographic failure (`DECRYPT_FAILED`) or ceremony failure.
 
-A future vault format bumps the version number; an old library refusing it beats an old library misreading it.
+A future vault format will use a higher version number. Rejecting an unknown version keeps an old library from misreading newer data.
 
 ## See also
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -14,11 +14,8 @@ import { parseSecretVault } from "@category-labs/mera";
 ## Usage
 
 ```ts
-const stored = localStorage.getItem("vault");
-if (stored !== null) {
-  const vault = parseSecretVault(stored);
-  // vault is a validated PasskeySecretVault
-}
+const vault = parseSecretVault(localStorage.getItem("vault"));
+// vault is a validated PasskeySecretVault
 ```
 
 ## Parameters
@@ -28,7 +25,7 @@ if (stored !== null) {
 - Type: `unknown`
 - Required
 
-The secret vault as JSON text or an untrusted object. Strings are JSON-parsed first; objects are validated directly.
+The secret vault as JSON text or an untrusted object. Strings are JSON-parsed first; objects are validated directly. Anything else fails validation, including the `null` a storage read returns when nothing is stored.
 
 ## Returns
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -3,7 +3,7 @@ title: parseSecretVault
 description: Parses and validates untrusted secret-vault JSON or objects.
 ---
 
-Parses and validates untrusted secret-vault JSON or objects. This is the boundary for stored vault data: anything read from `localStorage`, a backend, or a sync service goes through here before other vault functions see it. Synchronous.
+Parses and validates untrusted secret-vault JSON or objects.
 
 ## Import
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -40,9 +40,9 @@ A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The creden
 
 ## Notes
 
-Validation here means later steps fail cleanly. A vault that came through this function cannot trigger the `INPUT_INVALID` re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) or [unwrapSecretVault](/reference/unwrap-secret-vault/); what remains is honest cryptographic failure (`DECRYPT_FAILED`) or ceremony failure.
+A vault that came through this function cannot trigger the `INPUT_INVALID` re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) or [unwrapSecretVault](/reference/unwrap-secret-vault/); what remains is cryptographic failure (`DECRYPT_FAILED`) or ceremony failure.
 
-Rejecting unknown versions is deliberate. A future vault format bumps the version number, and an old library refusing it beats an old library misreading it.
+A future vault format bumps the version number; an old library refusing it beats an old library misreading it.
 
 ## See also
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -34,8 +34,7 @@ Authenticator transports reported by the browser when the passkey was created. O
 
 ### prfSalt
 
-The PRF salt for this secret, 32 bytes as canonical unpadded base64url. Generated fresh and randomly per vault; storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
-
+The PRF salt for this secret, 32 bytes as canonical unpadded base64url. Chosen by the app per vault, and typically generated fresh and randomly; storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
 ### nonce
 
 The 12-byte AES-GCM nonce, base64url. Generated internally by [createSecretVault](/reference/create-secret-vault/) for each encryption.

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -48,11 +48,11 @@ The AES-GCM ciphertext including its 16-byte authentication tag, base64url. The 
 
 The wrapping key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
 
-The credential ID and salt are stored but not authenticated: the AES-GCM additional authenticated data is a fixed constant (`mera.v1.secret.aad` plus the version), so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt; [createSecretVault](/reference/create-secret-vault/) spells out the consequence of sharing one.
+The credential ID and salt are stored but not authenticated: the AES-GCM additional authenticated data is a fixed constant (`mera.v1.secret.aad` plus the version), so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share a wrapping key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored JSON. [createSecretVault](/reference/create-secret-vault/) carries the same warning.
 
 ## Portability
 
-The vault is plain JSON. `localStorage`, a database row, a file, a sync service: anywhere JSON survives, a vault survives. Whoever holds it holds ciphertext; turning it back into the secret requires the passkey ceremony and its user verification.
+The vault is plain JSON and can be stored anywhere JSON can: `localStorage`, a database row, a file, a sync service. The holder has only ciphertext; turning it back into the secret requires the passkey ceremony and its user verification.
 
 ## See also
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -1,0 +1,60 @@
+---
+title: Secret vault format
+description: The v1 PasskeySecretVault JSON contract, field by field.
+---
+
+A secret vault is a versioned, JSON-safe object holding one secret encrypted behind a passkey. It is a storage contract: apps persist it as-is, ship it between devices, and hand it back to the library later. This page documents version 1, the only version that exists.
+
+```json
+{
+  "version": 1,
+  "credential": {
+    "credentialId": "pQEuLYuJ9BF-Kd8ijY5oQw",
+    "transports": ["internal", "hybrid"]
+  },
+  "prfSalt": "5iBEbmCBIF1MDVIGmirBg-XA0dcvNsSVUqiSCTuS_UM",
+  "nonce": "9k8bYQxlIm-A9nQi",
+  "ciphertext": "Zm9vYmFyYmF6cXV4…"
+}
+```
+
+## Fields
+
+### version
+
+Always `1`. [parseSecretVault](/reference/parse-secret-vault/) rejects anything else, including future versions it does not understand.
+
+### credential.credentialId
+
+The passkey credential that unlocks this vault, as canonical unpadded base64url. Stored so the unlock assertion can pin itself to the right passkey instead of letting the browser offer every discoverable credential.
+
+### credential.transports
+
+Authenticator transports reported by the browser when the passkey was created. Optional; when present, they help the browser route the unlock assertion (to a security key, to a phone) without guessing.
+
+### prfSalt
+
+The PRF salt for this secret, 32 bytes as canonical unpadded base64url. Generated fresh and randomly per vault; storing it is what lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret. Knowing it without the passkey yields nothing, because the PRF lives in the authenticator.
+
+### nonce
+
+The 12-byte AES-GCM nonce, base64url. Generated internally by [createSecretVault](/reference/create-secret-vault/) for each encryption.
+
+### ciphertext
+
+The AES-GCM ciphertext including its 16-byte authentication tag, base64url. The plaintext is the secret exactly as it was passed in; the library never interprets it.
+
+## What is deliberately absent
+
+The wrapping key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
+
+The credential ID and salt are stored but not authenticated: the AES-GCM additional authenticated data is a fixed constant (`mera.v1.secret.aad` plus the version), so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt; [createSecretVault](/reference/create-secret-vault/) spells out the consequence of sharing one.
+
+## Portability
+
+The vault is plain JSON. `localStorage`, a database row, a file, a sync service: anywhere JSON survives, a vault survives. Whoever holds it holds ciphertext; turning it back into the secret requires the passkey ceremony and its user verification.
+
+## See also
+
+- [createSecretVault](/reference/create-secret-vault/), [parseSecretVault](/reference/parse-secret-vault/), [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), [unwrapSecretVault](/reference/unwrap-secret-vault/): the four functions that produce and consume this format.
+- [Derived and wrapped modes](/concepts/derived-and-wrapped/): where the vault fits.

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -34,7 +34,7 @@ Authenticator transports reported by the browser when the passkey was created. O
 
 ### prfSalt
 
-The PRF salt for this secret, 32 bytes as canonical unpadded base64url. Generated fresh and randomly per vault; storing it is what lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret. Knowing it without the passkey yields nothing, because the PRF lives in the authenticator.
+The PRF salt for this secret, 32 bytes as canonical unpadded base64url. Generated fresh and randomly per vault; storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
 
 ### nonce
 

--- a/docs/src/content/docs/reference/unwrap-secret-vault.md
+++ b/docs/src/content/docs/reference/unwrap-secret-vault.md
@@ -1,0 +1,56 @@
+---
+title: unwrapSecretVault
+description: Decrypts the secret from a secret vault.
+---
+
+Decrypts the secret from a secret vault. No ceremony runs here; the caller brings the PRF output from [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/).
+
+## Import
+
+```ts
+import { unwrapSecretVault } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+const secret = await unwrapSecretVault({ vault, prfOutput });
+try {
+  // use the secret bytes
+} finally {
+  secret.fill(0);
+}
+```
+
+## Parameters
+
+`options` is an `UnwrapSecretVaultOptions`.
+
+### options.vault
+
+- Type: `PasskeySecretVault`
+- Required
+
+A parsed secret vault. Run untrusted stored data through [parseSecretVault](/reference/parse-secret-vault/) first.
+
+### options.prfOutput
+
+- Type: `Uint8Array`
+- Required
+
+The 32-byte WebAuthn PRF output for the vault's stored salt. Copied before async cryptographic work starts; the caller-owned buffer is not modified or zeroed.
+
+## Returns
+
+`Promise<Uint8Array>`: the decrypted secret bytes, exactly as they were passed to [createSecretVault](/reference/create-secret-vault/). The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it. Zeroing it after use is the caller's job, as in the example above.
+
+## Errors
+
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
+- [`DECRYPT_FAILED`](/reference/errors/#decrypt_failed): AES-GCM authentication failed, meaning wrong key material or a tampered vault. The two are indistinguishable.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+
+## See also
+
+- [Wrap a recovery phrase](/recipes/wrap-a-recovery-phrase/): create, store, and unwrap with the zeroing pattern.
+- [Secret vault format](/reference/secret-vault-format/): what the ciphertext actually contains.

--- a/docs/src/content/docs/reference/unwrap-secret-vault.md
+++ b/docs/src/content/docs/reference/unwrap-secret-vault.md
@@ -3,7 +3,7 @@ title: unwrapSecretVault
 description: Decrypts the secret from a secret vault.
 ---
 
-Decrypts the secret from a secret vault. No ceremony runs here; the caller brings the PRF output from [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/).
+Decrypts the secret from a secret vault.
 
 ## Import
 

--- a/docs/src/content/docs/reference/unwrap-secret-vault.md
+++ b/docs/src/content/docs/reference/unwrap-secret-vault.md
@@ -42,7 +42,7 @@ The 32-byte WebAuthn PRF output for the vault's stored salt. Copied before async
 
 ## Returns
 
-`Promise<Uint8Array>`: the decrypted secret bytes, exactly as they were passed to [createSecretVault](/reference/create-secret-vault/). The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it. Zeroing it after use is the caller's job, as in the example above.
+`Promise<Uint8Array>`: the decrypted secret bytes, exactly as they were passed to [createSecretVault](/reference/create-secret-vault/). The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it. Zeroing it after use is the caller's job.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/unwrap-secret-vault.md
+++ b/docs/src/content/docs/reference/unwrap-secret-vault.md
@@ -14,6 +14,18 @@ import { unwrapSecretVault } from "@category-labs/mera";
 ## Usage
 
 ```ts
+import {
+  getSecretVaultPrfOutput,
+  parseSecretVault,
+  unwrapSecretVault,
+} from "@category-labs/mera";
+
+const vault = parseSecretVault(localStorage.getItem("vault"));
+const { prfOutput } = await getSecretVaultPrfOutput({
+  rpId: "account.example.com",
+  vault,
+});
+
 const secret = await unwrapSecretVault({ vault, prfOutput });
 try {
   // use the secret bytes


### PR DESCRIPTION
Third PR in the docs-content stack (on top of #124). The README's API section is names-only and defers everything to "the developer documentation"; this PR writes that reference.

Structure follows docs/AGENTS.md: one page per exported function (the viem-style pattern), every page in the same fixed shape (lead, Import, Usage, Parameters as `### options.field` subheadings with Type/Required lines, Returns, Errors linked to the shared errors page, Notes, See also). Parameters use subheadings and lists rather than tables so they survive the 46rem serif column.

Contents:

- **Errors page first**: `MeraError`, `isMeraError`, one anchored section per code; every other page links its error bullets here.
- **Passkeys**: createPasskey (with the orphan-credential caveat), createPasskeyWithPrfOutput (fallback second prompt, result feeds createSecretVault), getPasskeyPrfOutput (determinism triple, discoverable vs pinned), getDeterministicPrfSaltV1.
- **Signing sessions**: both constructors document the consume-and-zero contract, the session members (publicKey, sign, lock, Symbol.dispose with a `using` example), the lock-during-sign race, and the secp256k1 recovery-ID bound.
- **Secret vault**: create (salt-reuse footgun stated prominently), getSecretVaultPrfOutput, unwrap (caller zeroes the returned buffer), parse (the untrusted-data boundary), plus the **secret vault format** page documenting the v1 JSON contract field by field, including what is deliberately absent and unauthenticated.
- **Addresses**: getEvmAddress / isEvmAddress (EIP-55 case rules), getSolanaAddress / isSolanaAddress (branded type rationale).
- **Overview** at /reference/, now the hero's secondary action.

All prose is written from the JSDoc in src/; every claim traces there or to the README. Links to recipe pages resolve when the final PR of the stack lands.

Validation: `npm run build` in docs/ passes (24 pages); a script check confirms every internal link target and every heading anchor referenced site-wide exists in the built HTML (the six recipe links are the known forward references); style sweep for em dashes, banned vocabulary, and possessives is clean; previewed the vault and session pages against the editorial skin.