### PR TITLE
docs: signing sessions concept page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
           items: [
             "concepts/passkeys-and-prf",
             "concepts/derived-and-wrapped",
+            "concepts/signing-sessions",
             "concepts/security-model",
             "concepts/authenticator-support",
           ],

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -35,7 +35,7 @@ A ceremony is one WebAuthn call and one user-verification prompt. mera runs thre
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) chains the two: one prompt when the authenticator evaluates PRF at create time, two when it needs the follow-up assertion.
 
-Signing itself never prompts: a [signing session](/reference/create-secp256k1-signing-session/) holds key material derived from a ceremony's output and signs until it is locked.
+Signing itself never prompts: a [signing session](/concepts/signing-sessions/) holds key material derived from a ceremony's output and signs until it is locked.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/security-model.md
+++ b/docs/src/content/docs/concepts/security-model.md
@@ -3,7 +3,7 @@ title: Security model
 description: What mera protects, what it cannot, and the risks left to the app.
 ---
 
-mera has a narrow scope: it runs passkey ceremonies, returns entropy to the app, and holds signing keys in lockable sessions. This page states what the library handles inside that scope and what the app must handle itself; each fact also appears on the reference page of the function it concerns.
+mera has a narrow scope: it runs passkey ceremonies, returns entropy to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/). This page states what the library handles inside that scope and what the app must handle itself; each fact also appears on the reference page of the function it concerns.
 
 ## What the library handles
 

--- a/docs/src/content/docs/concepts/signing-sessions.md
+++ b/docs/src/content/docs/concepts/signing-sessions.md
@@ -9,21 +9,27 @@ Two constructors exist, one per curve: [createSecp256k1SigningSession](/referenc
 
 ## Independent of passkeys
 
-A session's input is a raw private key, derived from PRF output, unwrapped from a vault, or imported from elsewhere; the session does not record where the key came from and never contacts an authenticator. The step in between, turning 32 bytes of entropy into a chain-specific private key, is app-owned by design. [Derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two common patterns.
+A session's input is a raw private key, derived from PRF output, unwrapped from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of entropy into a chain-specific private key, is app-owned by design; [derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two common patterns.
 
-This is why signing never prompts. The user-verification prompt belongs to the ceremony that produced the entropy; once a session exists, it signs as often as the app asks with no further WebAuthn involvement, so one prompt is enough for any number of signatures.
+Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the ceremony that produced the entropy, and it covers any number of signatures.
 
 ## The lifecycle
 
-A session begins unlocked and ends locked, and each transition zeroes a copy of the key.
-
-Construction consumes the key: the session keeps the only library-side copy and zeroes the caller's input buffer, even when construction throws. Locking zeroes the session's copy and is permanent: a locked session throws on signing, and there is no unlock. New signatures require a new session built from fresh key material. An unlock path would mean the key still existed somewhere after `lock()`; permanence is what makes the lock meaningful.
+Construction consumes the key: the session keeps the only library-side copy and zeroes the caller's input buffer, even when construction throws. Locking zeroes the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`; permanence is what makes the lock meaningful.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
 ## The open window
 
-Between construction and lock, anything that can run script on the page can request signatures. The session exposes no way to read the key back, but a compromised runtime does not need the key if it can sign. Locking is the only thing that closes the window, so sessions are best created late and locked as soon as the signing work is done. The [security model](/concepts/security-model/#what-a-compromised-runtime-sees) covers the runtime trust boundary in full.
+Between construction and lock, anything that can run script on the page can request signatures. The session exposes no way to read the key back, but a compromised runtime does not need the key if it can sign. The [security model](/concepts/security-model/#what-a-compromised-runtime-sees) covers the runtime trust boundary in full.
+
+## How long to keep a session
+
+Locking is not free. Unless the app kept the key somewhere else, fresh key material means another passkey ceremony: reproducing a derived key and unwrapping a vault both start with one, so after `lock()` the next signature costs one more user-verification prompt. Session lifetime is a trade-off between that prompt and the open window.
+
+Frequent signing justifies a held session. A high-frequency trading app that ran a fresh ceremony per order would prompt constantly, so it keeps one session for the active burst of work and locks it when the burst ends.
+
+Apps that sign occasionally are better served by holding no session at all: derive the public key, identify the account by its address, and zero the private key right away; the next signature starts with a fresh ceremony. Key material then exists only in the moments that use it.
 
 ## Why sessions exist
 

--- a/docs/src/content/docs/concepts/signing-sessions.md
+++ b/docs/src/content/docs/concepts/signing-sessions.md
@@ -1,0 +1,36 @@
+---
+title: Signing sessions
+description: How a session owns its private key, why signing never prompts, and what locking destroys.
+---
+
+A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing.
+
+Two constructors exist, one per curve: [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests and [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
+
+## Independent of passkeys
+
+A session's input is a raw private key, derived from PRF output, unwrapped from a vault, or imported from elsewhere; the session does not record where the key came from and never contacts an authenticator. The step in between, turning 32 bytes of entropy into a chain-specific private key, is app-owned by design. [Derived and wrapped modes](/concepts/derived-and-wrapped/) compares the two common patterns.
+
+This is why signing never prompts. The user-verification prompt belongs to the ceremony that produced the entropy; once a session exists, it signs as often as the app asks with no further WebAuthn involvement, so one prompt is enough for any number of signatures.
+
+## The lifecycle
+
+A session begins unlocked and ends locked, and each transition zeroes a copy of the key.
+
+Construction consumes the key: the session keeps the only library-side copy and zeroes the caller's input buffer, even when construction throws. Locking zeroes the session's copy and is permanent: a locked session throws on signing, and there is no unlock. New signatures require a new session built from fresh key material. An unlock path would mean the key still existed somewhere after `lock()`; permanence is what makes the lock meaningful.
+
+Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
+
+## The open window
+
+Between construction and lock, anything that can run script on the page can request signatures. The session exposes no way to read the key back, but a compromised runtime does not need the key if it can sign. Locking is the only thing that closes the window, so sessions are best created late and locked as soon as the signing work is done. The [security model](/concepts/security-model/#what-a-compromised-runtime-sees) covers the runtime trust boundary in full.
+
+## Why sessions exist
+
+A signing function that took the key as an argument on every call would spread copies across every caller and make zeroing each one the app's job. The session shape keeps the key in one place with one owner, and it makes key lifetime visible in the code: the lifetime spans the line that creates the session and the line that locks it.
+
+## See also
+
+- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) and [createEd25519SigningSession](/reference/create-ed25519-signing-session/): the exact copy, zeroing, and locking semantics.
+- [Sign with viem](/recipes/sign-with-viem/) and [Sign Solana transactions](/recipes/sign-solana-transactions/): sessions in transaction flows.
+- [Getting started](/getting-started/): the ceremony-to-signature path in code.


### PR DESCRIPTION
The concepts section explains two of the library's three jobs: ceremonies (passkeys and the PRF extension) and entropy (derived and wrapped modes). The third, holding signing keys in lockable sessions, had no owning page. The model was scattered across one sentence on the PRF page, two paragraphs in the security model, and member-level facts on the reference pages, and nothing stated why the API is session-shaped at all.

This PR adds `concepts/signing-sessions` covering the custody model:

- Sessions are passkey-independent by design; the derivation step between ceremony and session is app-owned.
- One user-verification prompt is enough for any number of signatures; signing never prompts.
- The lifecycle: construction consumes and zeroes the input key, lock zeroes the session's copy and is permanent, `using` disposal locks on scope exit.
- The open window: what an active session means for a compromised runtime, with the security model kept as the owner of the trust-boundary elaboration.
- Why a session rather than a bare signing function: one owned copy, key lifetime visible between the create line and the lock line.

Existing mentions now link to the new page as its owner: the PRF page's signing sentence and the security model's lead. Independent of the open stack (branched from main); the sidebar entry slots between derived-and-wrapped and security-model. Links to reference and recipe pages resolve when #125 and #126 land, same as the rest of the stack.

Validation: `npm run build` in docs/ passes (8 pages); style sweep for em dashes, banned vocabulary, and "your"/"wallet" is clean.