### PR TITLE
ci: cancel superseded PR runs

### DIFF
--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel superseded runs when a PR branch gets a new push. Runs on main are
+# queued instead of cancelled so post-merge validation always completes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Pushing a new commit to a PR branch currently leaves the previous CI run going, so rapid iteration stacks full runs of all five jobs — including the Playwright browser install — for commits nobody will look at.

This adds a `concurrency` group keyed on workflow + ref with `cancel-in-progress` enabled only for `pull_request` events. A new push to a PR branch cancels the superseded run; pushes to `main` queue instead of cancelling, so post-merge validation always completes.

Validation: workflow YAML parses cleanly; CI on this PR exercises the new block.

Stacked under it: a follow-up PR adds path-based job gating so docs-only changes stop running library jobs.