### PR TITLE
ci: skip jobs a PR's changed paths cannot affect

### DIFF
--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -20,8 +20,10 @@ jobs:
   # Classifies a PR's changed files so later jobs can skip work the change
   # cannot affect: `library` covers everything the root package build/tests
   # depend on, `demo` adds demo/ on top of that (the demo compiles against the
-  # library's dist/), and `docs` is independent of library code. Runs only on
-  # pull_request; on push and manual dispatch the gated jobs run unconditionally.
+  # library's dist/), `package` adds the packaged root files that
+  # scripts/verify-tarball.mjs requires in the tarball, and `docs` is
+  # independent of library code. Runs only on pull_request; on push and manual
+  # dispatch the gated jobs run unconditionally.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -31,6 +33,7 @@ jobs:
     outputs:
       library: ${{ steps.filter.outputs.library }}
       demo: ${{ steps.filter.outputs.demo }}
+      package: ${{ steps.filter.outputs.package }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Filter changed paths
@@ -43,11 +46,13 @@ jobs:
 
           matches() { grep -qE "$1" changed-files.txt && echo true || echo false; }
           library='^(src/|test/|scripts/|package\.json$|package-lock\.json$|tsconfig\.json$|tsconfig\.test\.json$|playwright\.config\.ts$|\.nvmrc$|\.github/workflows/)'
+          packaged='^(README\.md|LICENSE-MIT|LICENSE-APACHE)$'
           shared='^(\.nvmrc$|\.github/workflows/)'
 
           {
             echo "library=$(matches "$library")"
             echo "demo=$(matches "$library|^demo/")"
+            echo "package=$(matches "$library|$packaged")"
             echo "docs=$(matches "$shared|^docs/")"
           } >> "$GITHUB_OUTPUT"
 
@@ -162,7 +167,7 @@ jobs:
     name: Publish check
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.library == 'true') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.package == 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -17,6 +17,40 @@ permissions:
   contents: read
 
 jobs:
+  # Classifies a PR's changed files so later jobs can skip work the change
+  # cannot affect: `library` covers everything the root package build/tests
+  # depend on, `demo` adds demo/ on top of that (the demo compiles against the
+  # library's dist/), and `docs` is independent of library code. Runs only on
+  # pull_request; on push and manual dispatch the gated jobs run unconditionally.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    outputs:
+      library: ${{ steps.filter.outputs.library }}
+      demo: ${{ steps.filter.outputs.demo }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Filter changed paths
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.url }}
+        run: |
+          gh api --paginate "$PR_URL/files" --jq '.[].filename' > changed-files.txt
+
+          matches() { grep -qE "$1" changed-files.txt && echo true || echo false; }
+          library='^(src/|test/|scripts/|package\.json$|package-lock\.json$|tsconfig\.json$|tsconfig\.test\.json$|playwright\.config\.ts$|\.nvmrc$|\.github/workflows/)'
+          shared='^(\.nvmrc$|\.github/workflows/)'
+
+          {
+            echo "library=$(matches "$library")"
+            echo "demo=$(matches "$library|^demo/")"
+            echo "docs=$(matches "$shared|^docs/")"
+          } >> "$GITHUB_OUTPUT"
+
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -41,6 +75,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # On non-PR events `changes` is skipped, which would skip dependents too;
+    # `!cancelled()` keeps them eligible so the event check can run everything.
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.library == 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -65,6 +103,8 @@ jobs:
   demo:
     name: Demo
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.demo == 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -96,6 +136,8 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -119,6 +161,8 @@ jobs:
   package:
     name: Publish check
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.library == 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel superseded runs when a PR branch gets a new push. Runs on main are
+# queued instead of cancelled so post-merge validation always completes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Stacked on #133.

The repo now holds three projects (library at the root, `demo/`, `docs/`), but every PR runs all five CI jobs. A docs-only change runs `Test` — the most expensive job, including a Playwright Chromium install — plus `Demo` and `Publish check`, none of which it can affect.

This adds a `changes` job that classifies a PR's changed files and gates `Test`, `Demo`, `Docs`, and `Publish check` on the result. The gating matches the actual dependency graph: `Test` and `Publish check` run on library changes; `Demo` runs on demo *or* library changes, because the demo compiles against the library's `dist/`; `Docs` runs on docs changes only, since docs reference the library purely in markdown prose. `Check` (Biome) still runs unconditionally — it lints the whole repo and is the cheapest job. Workflow and `.nvmrc` changes re-run everything.

Design choices, and why the behavior that runs is equivalent to today's:

- Gating is job-level `if:` rather than workflow-level `paths:` filters, and only for `pull_request` events. Pushes to `main` and manual dispatches run every job exactly as before, so post-merge validation is unchanged. Skipped PR jobs report "skipped", which satisfies required status checks — so this stays compatible if branch protection later requires these jobs (workflow-level `paths:` would leave required checks pending and block merges).
- Change detection is a short `gh api` script against the PR files endpoint (built-in `GITHUB_TOKEN`, `pull-requests: read`) rather than the de-facto `dorny/paths-filter` action, keeping third-party actions out of the supply chain. No checkout is needed.
- Gated jobs use `!cancelled() && (...)` because `changes` is skipped on non-PR events and a skipped dependency would otherwise skip its dependents. If `changes` fails on a PR, its outputs are empty, the gated jobs skip, and the run is red via the failed `changes` job.

Validation: the filter regexes were tested against 12 fixture changed-file lists (docs-only, demo-only, library paths, workflow/`.nvmrc`, README-only, and prefix-collision names like `mysrc/`) — all classify correctly; the workflow passes schema validation (`action-validator`). This PR touches `.github/workflows/`, so its own CI run exercises the "run everything" path; a scratch docs-only PR against this branch will demonstrate the skip path.

Follow-up outside the diff: if required status checks are added to branch protection, all five job names can be required as-is.