### PR TITLE
scratch: verify docs-only CI gating (will be closed)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,4 @@ npm run preview  # serve the built site
 Pages live in `src/content/docs/` as Markdown/MDX. The visual style is `src/styles/mera.css`, which maps the demo app’s palette and the `site/` article’s typography onto Starlight's CSS variables. The landing page is `src/components/Hero.astro`; it embeds the hosted demo app through `src/components/DemoEmbed.astro` in a fixed-height panel that the demo scrolls inside.
 
 Authoring guidance (page structure, voice, review checklist) lives in [AGENTS.md](./AGENTS.md).
+


### PR DESCRIPTION
Temporary draft PR to verify that a docs-only change skips Test/Demo/Publish check under the new path gating. Will be closed without merging.