### PR TITLE
Deploy demo and docs to Railway on push to main

### DIFF
--- a/demo/railway.json
+++ b/demo/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "npm ci && npm run build && npm --prefix demo ci && npm --prefix demo run build",
+    "watchPatterns": [
+      "/demo/**",
+      "/src/**",
+      "/package.json",
+      "/package-lock.json",
+      "/tsconfig.json"
+    ]
+  }
+}

--- a/docs/railway.json
+++ b/docs/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "watchPatterns": ["/docs/**"]
+  }
+}


### PR DESCRIPTION
## Why

The demo and docs sites have no hosted deployment. This adds Railway config-as-code so both deploy automatically on every push to `main`, gated on CI passing. Railway's Railpack builder detects the static builds and serves the output with its built-in Caddy file server, so no server code, Dockerfile, or start command is needed.

The two services differ in one important way: `docs` is self-contained, but the demo compiles against the library's built output (`demo/vite.config.ts` and `demo/tsconfig.json` both resolve `@category-labs/mera` from `../dist`). The demo service therefore builds from the repo root with a build command that chains the library build before the demo build, while the docs service is isolated to `/docs`.

## What

- `docs/railway.json` — Railpack builder, watch paths limited to `/docs/**` so unrelated pushes don't redeploy the docs.
- `demo/railway.json` — Railpack builder, build command `npm ci && npm run build && npm --prefix demo ci && npm --prefix demo run build`, watch paths covering `demo/` plus the root library inputs (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`) so a library change redeploys the demo.

No env vars are required: the demo's `VITE_*` RPC URLs all have in-code defaults, and Node 24 is picked up from each package's `engines` field.

## Prerequisites — one-time Railway setup

These settings are dashboard-only (Railway's config-as-code cannot set root directory, branch, CI gating, variables, or domains).

1. **Project**: create a Railway account/project at railway.com (Hobby plan is sufficient — two idle static services fit within its included usage). Install the Railway GitHub App with access to `category-labs/mera`.
2. **`docs` service** — New Service → GitHub Repo → `category-labs/mera`, then in Service Settings:
   - Source: branch `main`, **Root Directory** `/docs`.
   - **Config-as-code file path**: `/docs/railway.json`. This must be set explicitly — the config path does not follow the root directory, and without it Railway would ignore the file.
   - Enable **Wait for CI** (deploys hold until the commit's GitHub checks pass and are skipped if they fail).
   - Networking: **Generate Domain**.
3. **`demo` service** — New Service → same repo, then in Service Settings:
   - Source: branch `main`, **Root Directory left unset** (repo root — the build needs the root library sources).
   - **Config-as-code file path**: `/demo/railway.json`.
   - Variables: add `RAILPACK_SPA_OUTPUT_DIR=demo/dist`. Required — the repo root package is the library, so Railpack cannot auto-detect the Vite app; this variable forces static serving and points Caddy at the demo's build output.
   - Enable **Wait for CI**.
   - Networking: **Generate Domain**.

Notes:
- **Wait for CI** waits on *all* check suites on the commit, not just `Mera - CI` — if another checks-reporting GitHub App is added later, it will also gate deploys.
- On push to `main` the CI's path filtering is bypassed (the `changes` job only runs on PRs), so every merge gets the full suite before deploying.
- To use custom domains later: Service Settings → Networking → Custom Domain (needs CNAME + TXT records).

## Validation

- Ran the demo service's exact build command locally from a clean install (`npm ci && npm run build && npm --prefix demo ci && npm --prefix demo run build`) — builds successfully, output in `demo/dist`.
- Ran the docs service's default build (`npm ci` + `npm run build` in `docs/`) — 28 pages built to `docs/dist`.
- First real verification of the Railway side happens on the initial dashboard setup above; the initial deploy of each service can be triggered manually (Command Palette → "Deploy Latest Commit") without waiting for a push.