### PR TITLE
Clarify demo copy and account flow language

### DIFF
--- a/demo/src/AccountCard.tsx
+++ b/demo/src/AccountCard.tsx
@@ -38,7 +38,7 @@ type AccountCardProps = {
  * Account view: an account selector (derived mode only), then a chain toggle,
  * then the chain-specific card for the active account.
  *
- * Switching accounts or chains never triggers a passkey ceremony — every
+ * Switching accounts or chains never triggers a passkey ceremony because every
  * account was derived from the one master seed the wallet already holds.
  */
 function AccountCard({
@@ -76,9 +76,9 @@ function AccountCard({
     }
   }
 
-  // On testnet, suggest sending to another of the user's own HD accounts — a
-  // self-owned recipient that needs no second address. Deriving it here is free
-  // (cached) and invisible: no pill or stored-account bump until the user reveals it.
+  // On testnet, suggest sending to another HD account controlled by the same
+  // passkey. Deriving it here is cached and invisible: no pill or stored-account
+  // bump appears until the account is revealed.
   const isTestnet = networkMode === "testnet";
   const suggestion = useMemo(() => {
     if (!isTestnet || wallet.mode !== "derived") return null;
@@ -131,7 +131,7 @@ function AccountCard({
   );
 
   // The recovery phrase takes over the card slot rather than stacking a second
-  // card below it — keeps the embedded demo compact.
+  // card below it, which keeps the embedded demo compact.
   if (phrase !== null) {
     return (
       <div className="account-shell">
@@ -199,9 +199,11 @@ function AccountCard({
             onLock={onLock}
           />
         ) : ethereumError ? (
-          <p className="status error">Ethereum unavailable — {ethereumError}</p>
+          <p className="status error">
+            Ethereum is unavailable: {ethereumError}
+          </p>
         ) : (
-          <p className="status">Connecting to Ethereum…</p>
+          <p className="status">The demo is connecting to Ethereum…</p>
         )
       ) : solanaAdapter ? (
         <ChainAccountCard
@@ -214,9 +216,9 @@ function AccountCard({
           onLock={onLock}
         />
       ) : solanaError ? (
-        <p className="status error">Solana unavailable — {solanaError}</p>
+        <p className="status error">Solana is unavailable: {solanaError}</p>
       ) : (
-        <p className="status">Connecting to Solana…</p>
+        <p className="status">The demo is connecting to Solana…</p>
       )}
 
       <div className="backup-trigger">
@@ -226,7 +228,7 @@ function AccountCard({
           onClick={() => void revealBackup()}
           disabled={revealing}
         >
-          {revealing ? "Waiting for passkey…" : "Reveal backup phrase"}
+          {revealing ? "Waiting for passkey…" : "Reveal recovery phrase"}
         </button>
         {backupError && <p className="status error">{backupError}</p>}
       </div>

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -67,9 +67,9 @@ function App(): ReactElement {
 
   function handleConnected(result: ConnectResult) {
     setWallet(result.wallet);
-    // Derived wallets start with two accounts so "send to your other account"
-    // works out of the box: the second pill is visible and the recipient chip
-    // points at a real account. Wrapped mode has a single account.
+    // Derived wallets start with two accounts so transfers between demo accounts
+    // work immediately: the second pill is visible and the recipient chip points
+    // at a real account. Wrapped mode has a single account.
     const count =
       result.wallet.mode === "derived"
         ? Math.max(result.accountCount, 2)
@@ -109,8 +109,7 @@ function App(): ReactElement {
             ◈
           </div>
           <div>
-            <h1>Mera</h1>
-            <p className="tagline">One passkey for all accounts</p>
+            <h1>Mera Demo</h1>
           </div>
         </div>
 

--- a/demo/src/ChainAccountCard.tsx
+++ b/demo/src/ChainAccountCard.tsx
@@ -101,7 +101,7 @@ function ChainAccountCard({
   const [broadcastId, setBroadcastId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // The suggestion chip stays up until the user switches to manual entry.
+  // The suggestion chip stays visible until manual entry is enabled.
   const shownSuggestion = manual ? undefined : suggestion;
   const sendAmount = adapter.parseAmount(amount);
   // Testnet gates Send on a *known* balance that covers amount + fee reserve,
@@ -117,13 +117,13 @@ function ChainAccountCard({
     !busy &&
     (!isTestnet || covered);
 
-  // Drop the pre-filled recipient and let the user type any address.
+  // Drop the pre-filled recipient and enable manual address entry.
   function switchToManual(): void {
     setManual(true);
     setTo("");
   }
 
-  // Re-apply the suggested self-recipient after the user switched to manual.
+  // Restore the suggested self-recipient after manual entry was enabled.
   function restoreSuggestion(): void {
     if (!suggestion) return;
     setManual(false);
@@ -143,8 +143,8 @@ function ChainAccountCard({
     const interval = window.setInterval(() => {
       void refreshBalance();
     }, BALANCE_REFRESH_MS);
-    // Refresh the moment the tab regains focus — e.g. returning from the
-    // faucet — so the new balance shows without a manual Refresh button.
+    // Refresh when the tab regains focus, such as after returning from the
+    // faucet, so the new balance appears without a manual Refresh button.
     const onVisible = () => {
       if (document.visibilityState === "visible") void refreshBalance();
     };
@@ -254,9 +254,7 @@ function ChainAccountCard({
           </span>
           {shownSuggestion ? (
             <div className="recipient-chip">
-              <span className="recipient-name">
-                Your {shownSuggestion.label}
-              </span>
+              <span className="recipient-name">{shownSuggestion.label}</span>
               <span className="recipient-addr mono">{shorten(to)}</span>
             </div>
           ) : (
@@ -304,7 +302,11 @@ function ChainAccountCard({
 
         {signed && (
           <details className="reveal" open>
-            <summary>Signed locally with your passkey-derived key</summary>
+            <summary>
+              {mode === "derived"
+                ? "The transaction was signed locally with a passkey-derived key."
+                : "The transaction was signed locally with a key derived from the recovery phrase."}
+            </summary>
             <code className="mono break">{signed}</code>
           </details>
         )}
@@ -328,7 +330,7 @@ function ChainAccountCard({
             className="link reveal-recipient"
             onClick={shownSuggestion.onReveal}
           >
-            View your {shownSuggestion.label} →
+            View {shownSuggestion.label} →
           </button>
         )}
 

--- a/demo/src/ConnectCard.tsx
+++ b/demo/src/ConnectCard.tsx
@@ -12,7 +12,7 @@ const MODES: { id: AccountMode; label: string; hint: string }[] = [
   {
     id: "derived",
     label: "Derived",
-    hint: "Accounts are derived from the passkey. The demo keeps non-secret metadata in local storage for quicker sign-in. A synced passkey can reproduce the same addresses on another device.",
+    hint: "Accounts are derived from the passkey. A synced passkey can reproduce the same addresses on another device.",
   },
   {
     id: "wrapped",

--- a/demo/src/ConnectCard.tsx
+++ b/demo/src/ConnectCard.tsx
@@ -12,12 +12,12 @@ const MODES: { id: AccountMode; label: string; hint: string }[] = [
   {
     id: "derived",
     label: "Derived",
-    hint: "Accounts derived from your passkey — nothing is stored, and a synced passkey can restore them on another device.",
+    hint: "Accounts are derived from the passkey. The demo keeps non-secret metadata in local storage for quicker sign-in. A synced passkey can reproduce the same addresses on another device.",
   },
   {
     id: "wrapped",
     label: "Wrapped",
-    hint: "A seed phrase you generate or import, encrypted into a vault only the passkey can open.",
+    hint: "The demo encrypts a generated or imported recovery phrase in a vault that opens with the passkey.",
   },
 ];
 
@@ -97,7 +97,7 @@ function ConnectCard({
             </span>
             <input
               value={secret}
-              placeholder="Generate one, or paste an existing wallet's phrase"
+              placeholder="Generate a recovery phrase, or paste one from a wallet app"
               autoComplete="off"
               autoCorrect="off"
               autoCapitalize="off"
@@ -108,18 +108,18 @@ function ConnectCard({
           </label>
 
           {trimmedSecret.length > 0 && !secretValid && (
-            <p className="status error">That's not a valid recovery phrase.</p>
+            <p className="status error">That is not a valid recovery phrase.</p>
           )}
 
           <p className="hint">
-            Generated on your device, or imported — whoever holds the phrase
+            The phrase is generated on the device or imported. Anyone with it
             controls the account.
           </p>
         </div>
       )}
 
       <label className="field">
-        <span>Account name</span>
+        <span>Passkey name</span>
         <input
           value={username}
           autoComplete="username"
@@ -128,6 +128,7 @@ function ConnectCard({
           disabled={busy !== null}
         />
       </label>
+      <p className="hint">This name is used only when creating a passkey.</p>
 
       <div className="actions">
         <button

--- a/demo/src/WalletBackup.tsx
+++ b/demo/src/WalletBackup.tsx
@@ -11,9 +11,10 @@ type WalletBackupProps = {
 /**
  * Recovery-phrase display, shown in place of the account card.
  *
- * The phrase is held only by the caller's state while shown — `Hide`, or
- * unmounting on lock, drops it. JS strings can't be zeroed, so this is the
- * tightest lifetime achievable; the biometric gate is the real protection.
+ * The phrase is held only by the caller's state while shown. `Hide`, or
+ * unmounting on lock, drops it. JS strings cannot be zeroed, so this is the
+ * tightest lifetime achievable. Fresh user verification gates access while the
+ * phrase is hidden.
  */
 function WalletBackup({ phrase, onHide }: WalletBackupProps): ReactElement {
   const { copied, copy } = useCopyButton();
@@ -34,9 +35,9 @@ function WalletBackup({ phrase, onHide }: WalletBackupProps): ReactElement {
         </button>
       </div>
       <p className="hint">
-        Anyone with these {words.length} words controls the funds. Import them
-        into MetaMask (Ethereum) or Phantom (Solana) to recover the same
-        addresses.
+        Anyone with these {words.length} words controls the funds. Compatible
+        wallet apps, such as MetaMask for Ethereum and Phantom for Solana, can
+        recover the same addresses.
       </p>
       <ol className="mnemonic-grid">
         {words.map(({ position, word }) => (

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -20,7 +20,7 @@ const SOLANA_MAINNET_RPC_URL = "https://solana-rpc.publicnode.com";
 // the chain-id table in `ethereum.ts`.
 //
 // The genesis hash identifies the cluster from the RPC itself rather than
-// guessing from the URL — many providers (Helius, publicnode, …) host every
+// guessing from the URL, because many providers (Helius, publicnode, …) host every
 // cluster under hostnames that don't contain the cluster name.
 const KNOWN_CLUSTERS: Record<string, { cluster: Cluster; mode: NetworkMode }> =
   {

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -27,7 +27,7 @@ import {
 /** The two account modes the demo offers (mera itself is mode-agnostic). */
 type AccountMode = "wrapped" | "derived";
 
-/** One numbered account: a passkey-derived signing session per chain. */
+/** One numbered account with a signing session per chain. */
 type AccountSlot = {
   index: number;
   ethereum: {
@@ -41,7 +41,7 @@ type AccountSlot = {
 };
 
 /**
- * A connected wallet — one passkey ceremony's worth of authority.
+ * A connected wallet with one passkey ceremony's worth of authority.
  *
  * Derived mode holds the BIP-39 master seed for the session and can mint more
  * numbered HD accounts with no further passkey prompt. Wrapped mode exposes the
@@ -96,9 +96,9 @@ function deriveSlotFromSeed(seed: Uint8Array, index: number): AccountSlot {
  * Builds a derived-mode wallet from a single PRF output.
  *
  * The PRF output becomes a BIP-39 master seed held in memory for the session,
- * exactly like the signing keys are — and zeroed alongside them on `lock()`.
- * Holding it is what lets "Add account" derive a new HD account instantly with
- * no extra biometric: one ceremony per session, not per account.
+ * exactly like the signing keys are, and is zeroed alongside them on `lock()`.
+ * Holding it lets "Add account" derive a new HD account without another
+ * ceremony. The demo runs one ceremony per session rather than per account.
  */
 function buildDerivedWallet(
   prfOutput: Uint8Array,
@@ -120,7 +120,7 @@ function buildDerivedWallet(
     deriveAccount(index): AccountSlot {
       const cached = cache.get(index);
       if (cached) return cached;
-      if (!seed) throw new Error("Wallet is locked — connect again.");
+      if (!seed) throw new Error("The wallet is locked. Connect again.");
       const slot = deriveSlotFromSeed(seed, index);
       cache.set(index, slot);
       return slot;
@@ -209,17 +209,17 @@ async function createWrapped(
     prfSalt: crypto.getRandomValues(new Uint8Array(32)),
   });
 
-  // The phrase itself is the secret the passkey encrypts. Storing the phrase —
-  // not the derived keys — is what lets wrapped mode reveal it again later;
-  // signing keys are re-derived from it on unlock, the standard HD way, so it
-  // stays portable to MetaMask / Phantom.
+  // The phrase itself is the secret the passkey encrypts. Storing it lets
+  // wrapped mode reveal it again later. Signing keys are re-derived from the
+  // phrase on unlock, the standard HD way, so it stays portable to wallet apps
+  // such as MetaMask and Phantom.
   const secret = new TextEncoder().encode(phrase);
   try {
     const vault = await createSecretVault({ credential, secret });
     localStorage.setItem(VAULT_KEY, JSON.stringify(vault));
   } finally {
-    // Zero the transient secret and PRF output whether or not wrapping
-    // succeeded; the wallet is rebuilt from `phrase`, not from these.
+    // Zero the transient secret and PRF output regardless of whether wrapping
+    // succeeded. The wallet is rebuilt from `phrase` rather than these buffers.
     secret.fill(0);
     credential.prfOutput.fill(0);
   }
@@ -240,14 +240,14 @@ async function unlockWrapped(): Promise<ConnectResult> {
 
 /**
  * Reads the stored wrapped vault and decrypts its seed phrase behind a fresh
- * passkey ceremony. Shared by unlock and reveal; the PRF output and decrypted
- * bytes are zeroed before returning, even when the decrypt itself throws.
+ * passkey ceremony. Unlock and reveal share this function. The PRF output and
+ * decrypted bytes are zeroed before returning, even when decryption throws.
  */
 async function decryptStoredWrappedPhrase(): Promise<string> {
   const raw = localStorage.getItem(VAULT_KEY);
   if (!raw) {
     throw new Error(
-      "No wrapped account on this device yet — create one first.",
+      "No wrapped account exists on this device. Create one first.",
     );
   }
 
@@ -319,8 +319,8 @@ function connect(
  * Reveals a wallet's BIP-39 recovery phrase behind a fresh passkey ceremony.
  *
  * Derived wallets re-derive the phrase from the passkey PRF output; wrapped
- * wallets decrypt the phrase the user generated or imported out of the secret
- * vault. Either way the mnemonic is fetched on demand behind a fresh biometric.
+ * wallets decrypt the generated or imported phrase from the secret vault.
+ * Either way, the mnemonic is fetched on demand after fresh user verification.
  * PRF output and decrypted secret bytes are zeroed where possible before the
  * function returns. The phrase is returned as a JavaScript string, which cannot
  * be zeroed in place.
@@ -362,7 +362,7 @@ function describeError(error: unknown): string {
       case "DECRYPT_FAILED":
         return "Couldn't unlock the account with that passkey.";
       case "SESSION_LOCKED":
-        return "Your session is locked — connect again.";
+        return "The session is locked. Connect again.";
       case "CRYPTO_UNAVAILABLE":
         return "This browser doesn't provide the Web Crypto APIs this demo needs.";
       case "PASSKEY_OPERATION_FAILED":

--- a/demo/src/derivedWallet.ts
+++ b/demo/src/derivedWallet.ts
@@ -3,11 +3,11 @@ import type { PasskeyCredentialTransport } from "@category-labs/mera";
 /**
  * Non-secret metadata for a derived wallet created on this device.
  *
- * It holds no key material — only what the app needs to (a) pin the right
- * passkey with `allowCredentials` on the next same-device sign-in, instead of
- * showing every discoverable credential, and (b) remember how many HD accounts
- * the current wallet had derived so sign-in can restore them. A fresh device
- * simply has no record and falls back to a discoverable sign-in.
+ * It holds no key material. The app uses it to pin the right passkey with
+ * `allowCredentials` on the next same-device sign-in instead of showing every
+ * discoverable credential, and to remember how many HD accounts the current
+ * wallet had derived so sign-in can restore them. A fresh device has no record
+ * and falls back to a discoverable sign-in.
  */
 type DerivedWalletRecord = {
   credentialId: string;

--- a/demo/src/embed.ts
+++ b/demo/src/embed.ts
@@ -1,11 +1,12 @@
 /**
  * When the demo runs inside the post's iframe, report its content height to the
- * embedding page so the frame can size to fit — no dead whitespace on the short
- * sign-in screen, no inner scrollbar on the tall signed-in screen.
+ * embedding page so the frame can fit the content without dead whitespace on
+ * the short sign-in screen or an inner scrollbar on the tall signed-in screen.
  *
- * Standalone (opened in its own tab) this is a no-op: the app keeps its centered,
- * viewport-filling layout. Setting `data-embedded` before render lets the CSS
- * drop `min-height: 100vh` so the measured height is the content, not the viewport.
+ * Standalone (opened in its own tab), this is a no-op: the app keeps its
+ * centered, viewport-filling layout. Setting `data-embedded` before render lets
+ * the CSS drop `min-height: 100vh` so the measured height is the content instead
+ * of the viewport.
  *
  * The height is non-sensitive, so it's posted to "*"; the embedding page is the
  * side that validates the message origin before resizing anything.

--- a/demo/src/ethereumAdapter.ts
+++ b/demo/src/ethereumAdapter.ts
@@ -33,7 +33,7 @@ function createEthereumAdapter(
     faucetUrl: MONAD_FAUCET_URL,
     faucetText: `Get testnet ${symbol} ↗`,
     recipientPlaceholder: "0x…",
-    balanceTooLowError: "Balance is too low to cover gas",
+    balanceTooLowError: "Balance is too low to cover gas.",
     isValidRecipient: isAddress,
     parseAmount: (text) => parseDecimalAmount(text, ETH_DECIMALS),
     formatAmount: (amount) => formatDecimalAmount(amount, ETH_DECIMALS),

--- a/demo/src/solanaAdapter.ts
+++ b/demo/src/solanaAdapter.ts
@@ -36,7 +36,7 @@ function createSolanaAdapter(
     faucetUrl: SOLANA_FAUCET_URL,
     faucetText: `Get devnet ${solana.symbol} ↗`,
     recipientPlaceholder: "Solana address…",
-    balanceTooLowError: "Balance is too low to cover the fee",
+    balanceTooLowError: "Balance is too low to cover the fee.",
     isValidRecipient: isSolanaAddress,
     parseAmount: (text) => parseDecimalAmount(text, SOL_DECIMALS),
     formatAmount: (amount) => formatDecimalAmount(amount, SOL_DECIMALS),

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -35,10 +35,10 @@ body {
 }
 
 .app {
-  /* `margin-inline: auto` (not body-level grid/flex centering) — React mounts
+  /* `margin-inline: auto` instead of body-level grid or flex centering. React mounts
      into a `<div id="root">` between body and `.app`, so any centering applied
      to body centers that wrapper, which already fills the width. Self-centering
-     `.app` is robust to whatever the wrapper does. */
+     `.app` remains centered regardless of the wrapper's layout. */
   margin: 48px auto;
   width: min(420px, 100%);
   display: grid;
@@ -80,15 +80,6 @@ h1 {
   font-size: 20px;
   font-weight: 650;
   letter-spacing: -0.01em;
-}
-
-.tagline {
-  margin: 2px 0 0;
-  overflow: hidden;
-  font-size: 13px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--muted);
 }
 
 input {
@@ -578,7 +569,7 @@ input:focus-visible {
 .break {
   display: block;
   margin-top: 8px;
-  /* `overflow-wrap: anywhere` (not `word-break: break-all`) — the former reduces
+  /* `overflow-wrap: anywhere` instead of `word-break: break-all`. This reduces
      min-content intrinsic size so a long base64 token can't widen the grid
      track and push the centered card off-screen. */
   overflow-wrap: anywhere;


### PR DESCRIPTION
## Summary
- Tighten and standardize demo wording across the connect, account, backup, and chain cards.
- Clarify derived-vs-wrapped account behavior, recovery-phrase handling, and testnet suggestions.
- Simplify the demo header and remove the subtitle that duplicated the page message.

## Testing
- Not run (not requested)