### PR TITLE
Clarify cross-device account availability

### DIFF
--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -18,7 +18,7 @@ const features = [
   {
     title: "Cross-device, cross-platform",
     link: "/concepts/passkeys-and-prf/",
-    text: "The same accounts follow the passkey across devices and apps.",
+    text: "A web app and its native iOS or Android counterpart can use the same passkey to restore the same accounts.",
   },
   {
     title: "Works with existing accounts",


### PR DESCRIPTION
The landing-page copy said the same accounts follow a passkey across devices and apps. “Apps” could imply that unrelated applications share accounts, which mera does not guarantee.

This changes the sentence to name the supported relationship explicitly: a web app and its native iOS or Android counterpart can use the same passkey to restore the same accounts. The cross-platform benefit remains clear without implying that arbitrary apps share accounts.

Validation:

- `npm run build` in `docs`
- `npm run check`
- `git diff --check`
