### PR TITLE
Make PRF salt optional in secret vault workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ The `@category-labs/mera/viem` entry point requires `viem` (^2.28.0) as an optio
 
 ## Quick example
 
-A derived-mode example: one passkey ceremony, then app-owned key derivation — here BIP-39/BIP-32 with `@scure/bip32` and `@scure/bip39`, as in the demo.
+A derived-mode example: one passkey ceremony, then app-owned BIP-39/BIP-32 key derivation with `@scure/bip32` and `@scure/bip39`, as in the demo.
 
 ```ts
 import {
   createSecp256k1SigningSession,
-  getDeterministicPrfSaltV1,
   getEvmAddress,
   getPasskeyPrfOutput,
 } from "@category-labs/mera"
@@ -46,8 +45,7 @@ import { wordlist } from "@scure/bip39/wordlists/english.js"
 
 const rpId = "account.example.com"
 
-const prfSalt = getDeterministicPrfSaltV1()
-const { prfOutput } = await getPasskeyPrfOutput({ rpId, prfSalt })
+const { prfOutput } = await getPasskeyPrfOutput({ rpId })
 
 // App-owned derivation: the PRF output is BIP-39 entropy, so the same phrase
 // imported into a standard wallet reproduces the same account.
@@ -65,7 +63,7 @@ const address = getEvmAddress(session.publicKey)
 
 Reusing one PRF output unchanged for unrelated purposes (key derivation and app-data encryption, say) links those secrets. Use a different PRF salt per purpose, or split one output with a purpose-labeled KDF.
 
-Derived, reproducible-account flows pass a stable PRF salt such as `getDeterministicPrfSaltV1()`. Wrapped flows pass 32 fresh random salt bytes.
+Derived flows use mera's fixed v1 salt internally. Wrapped-mode vault functions generate and store a fresh random salt for each secret.
 
 ## Supported authenticators
 
@@ -106,7 +104,8 @@ Names only; editor hover shows the full JSDoc.
 - **Passkey ceremonies**: `createPasskey`, `createPasskeyWithPrfOutput`, `getPasskeyPrfOutput`
 - **Deterministic PRF salt**: `getDeterministicPrfSaltV1`
 - **Signing sessions**: `createSecp256k1SigningSession`, `createEd25519SigningSession`
-- **Secret vault**: `createSecretVault`, `unwrapSecretVault`, `parseSecretVault`, `getSecretVaultPrfOutput`
+- **Secret vault workflows**: `createSecretVaultWithNewPasskey`, `createSecretVaultWithExistingPasskey`, `unwrapSecretVaultWithPasskey`
+- **Secret vault primitives**: `createSecretVault`, `unwrapSecretVault`, `parseSecretVault`, `getSecretVaultPrfOutput`
 - **Chain addresses**: `getEvmAddress`, `isEvmAddress`, `getSolanaAddress`, `isSolanaAddress`
 - **viem adapter** (`@category-labs/mera/viem`): `toViemAccount`
 - **Errors**: `MeraError`, `isMeraError`, `MeraErrorCode`

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -2,18 +2,16 @@ import {
   createEd25519SigningSession,
   createPasskeyWithPrfOutput,
   createSecp256k1SigningSession,
-  createSecretVault,
+  createSecretVaultWithNewPasskey,
   type Ed25519SigningSession,
   type EvmAddress,
-  getDeterministicPrfSaltV1,
   getEvmAddress,
   getPasskeyPrfOutput,
-  getSecretVaultPrfOutput,
   getSolanaAddress,
   isMeraError,
   parseSecretVault,
   type Secp256k1SigningSession,
-  unwrapSecretVault,
+  unwrapSecretVaultWithPasskey,
 } from "@category-labs/mera";
 import { currentDerivedWallet, rememberDerivedWallet } from "./derivedWallet";
 import {
@@ -24,7 +22,7 @@ import {
   prfOutputToMnemonic,
 } from "./hd";
 
-/** The two account modes the demo offers (mera itself is mode-agnostic). */
+/** The two account modes the demo offers. */
 type AccountMode = "wrapped" | "derived";
 
 /** One numbered account with a signing session per chain. */
@@ -142,11 +140,9 @@ function buildDerivedWallet(
 async function createDerived(label: string): Promise<ConnectResult> {
   // `user.id` is left to default (32 random bytes), so every "Create" is a
   // distinct, parallel passkey rather than silently overwriting an existing one.
-  const prfSalt = getDeterministicPrfSaltV1();
   const credential = await createPasskeyWithPrfOutput({
     rp: { id: rpId, name: RP_NAME },
     user: { name: label, displayName: label },
-    prfSalt,
   });
 
   rememberDerivedWallet({
@@ -167,13 +163,11 @@ async function openDerived(): Promise<ConnectResult> {
   // Pin to the passkey created on this device when we know it; otherwise fall
   // back to a discoverable credential so a freshly synced device still works.
   const known = currentDerivedWallet();
-  const prfSalt = getDeterministicPrfSaltV1();
   const { prfOutput, credentialId } = await getPasskeyPrfOutput({
     rpId,
     credential: known?.credentialId
       ? { credentialId: known.credentialId, transports: known.transports }
       : undefined,
-    prfSalt,
   });
 
   // The ceremony reports which credential was actually used; if it matches the
@@ -203,25 +197,22 @@ async function createWrapped(
     throw new Error("Enter a valid recovery phrase, or generate a fresh one.");
   }
 
-  const credential = await createPasskeyWithPrfOutput({
-    rp: { id: rpId, name: RP_NAME },
-    user: { name: label, displayName: label },
-    prfSalt: crypto.getRandomValues(new Uint8Array(32)),
-  });
-
   // The phrase itself is the secret the passkey encrypts. Storing it lets
   // wrapped mode reveal it again later. Signing keys are re-derived from the
   // phrase on unlock, the standard HD way, so it stays portable to wallet apps
   // such as MetaMask and Phantom.
   const secret = new TextEncoder().encode(phrase);
   try {
-    const vault = await createSecretVault({ credential, secret });
+    const vault = await createSecretVaultWithNewPasskey({
+      rp: { id: rpId, name: RP_NAME },
+      user: { name: label, displayName: label },
+      secret,
+    });
     localStorage.setItem(VAULT_KEY, JSON.stringify(vault));
   } finally {
-    // Zero the transient secret and PRF output regardless of whether wrapping
-    // succeeded. The wallet is rebuilt from `phrase` rather than these buffers.
+    // The library owns and zeroes transient PRF output. This caller-owned copy
+    // of the phrase remains the demo's responsibility.
     secret.fill(0);
-    credential.prfOutput.fill(0);
   }
 
   return {
@@ -252,16 +243,11 @@ async function decryptStoredWrappedPhrase(): Promise<string> {
   }
 
   const vault = parseSecretVault(raw);
-  const { prfOutput } = await getSecretVaultPrfOutput({ rpId, vault });
+  const secret = await unwrapSecretVaultWithPasskey({ rpId, vault });
   try {
-    const secret = await unwrapSecretVault({ vault, prfOutput });
-    try {
-      return new TextDecoder().decode(secret);
-    } finally {
-      secret.fill(0);
-    }
+    return new TextDecoder().decode(secret);
   } finally {
-    prfOutput.fill(0);
+    secret.fill(0);
   }
 }
 
@@ -331,7 +317,6 @@ async function revealMnemonic(wallet: ConnectedWallet): Promise<string> {
   }
 
   const record = currentDerivedWallet();
-  const prfSalt = getDeterministicPrfSaltV1();
   const { prfOutput } = await getPasskeyPrfOutput({
     rpId,
     credential: wallet.credentialId
@@ -343,7 +328,6 @@ async function revealMnemonic(wallet: ConnectedWallet): Promise<string> {
               : undefined,
         }
       : undefined,
-    prfSalt,
   });
 
   try {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -85,6 +85,9 @@ export default defineConfig({
             {
               label: "Secret vault",
               items: [
+                "reference/create-secret-vault-with-new-passkey",
+                "reference/create-secret-vault-with-existing-passkey",
+                "reference/unwrap-secret-vault-with-passkey",
                 "reference/create-secret-vault",
                 "reference/get-secret-vault-prf-output",
                 "reference/unwrap-secret-vault",

--- a/docs/src/content/docs/concepts/derived-and-wrapped.md
+++ b/docs/src/content/docs/concepts/derived-and-wrapped.md
@@ -7,7 +7,7 @@ Both modes start from the same ceremony and its 32 bytes of PRF output. Derived 
 
 ## Derived
 
-With mera's [fixed deterministic salt](/reference/get-deterministic-prf-salt-v1/), the same passkey and relying party produce the same PRF output on every ceremony. The app feeds that output into a derivation scheme of its choosing; [Derive accounts from one passkey](/recipes/derive-accounts/) shows one built on common HD standards.
+When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party produce the same PRF output on every ceremony. The app feeds that output into a derivation scheme of its choosing; [Derive accounts from one passkey](/recipes/derive-accounts/) shows one built on common HD standards.
 
 There is no stored secret; all state lives in the passkey. Once the passkey has synced to a new device, sign-in there is the same ceremony and produces the same accounts.
 
@@ -15,7 +15,7 @@ The account may be unrecoverable if the passkey is deleted, not synced, tied to 
 
 ## Wrapped
 
-An AES-256-GCM vault holds one secret: a recovery phrase, a private key, any bytes. The ceremony's PRF output, evaluated against a fresh random salt stored alongside the vault, produces the key material that decrypts it. The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
+An AES-256-GCM vault holds one secret: a recovery phrase, a private key, any bytes. Wrapped-mode functions evaluate the passkey against a fresh random salt for each secret and store that salt in the vault. The resulting PRF output produces the key material that decrypts it. The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 
 The secret exists independently of the passkey: an account that predates it can be imported by wrapping its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext; decrypting it requires the passkey ceremony.
 
@@ -24,7 +24,7 @@ The secret exists independently of the passkey: an account that predates it can 
 - **Where state lives.** Derived keeps it in the passkey. Wrapped keeps it in a blob the app has to store somewhere.
 - **Existing accounts.** Wrapped can hold a secret that predates the passkey. Derived only produces accounts rooted in the passkey itself.
 - **Losing the passkey.** Both modes lose access through mera. A derived account is recoverable only through an export taken beforehand; a wrapped secret is recoverable from any other copy of it.
-- **Salts.** Derived uses the one fixed deterministic salt. Wrapped stores a fresh random salt per vault; secrets wrapped under a reused salt share one wrapping key, so exposing that key exposes all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
+- **Salts.** Derived calls omit the salt and use mera's fixed v1 value. Wrapped-mode functions generate and store a fresh random salt per vault; secrets wrapped under a reused salt share one wrapping key, so exposing that key exposes all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
 
 ## See also
 

--- a/docs/src/content/docs/concepts/security-model.md
+++ b/docs/src/content/docs/concepts/security-model.md
@@ -9,7 +9,7 @@ mera has a narrow scope: it runs passkey ceremonies, returns entropy to the app,
 
 Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, wrapped, or derived.
 
-Owned copies are zeroed where possible. A signing session zeroes the caller's private-key buffer when it consumes it, even when construction throws, and zeroes its own copy on `lock()`. [createSecretVault](/reference/create-secret-vault/) zeroes its internal copies of the PRF output and the secret before returning.
+Owned copies are zeroed where possible. A signing session zeroes the caller's private-key buffer when it consumes it, even when construction throws, and zeroes its own copy on `lock()`. [createSecretVault](/reference/create-secret-vault/) zeroes its internal secret and PRF-output copies. Wrapped-mode workflow functions also zero the transient secret and PRF-output copies they own before settling.
 
 WebAuthn challenges are generated internally. So are AES-GCM nonces, 12 fresh bytes per encryption, which means a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
 
@@ -29,7 +29,7 @@ Treat the rpId as a long-lived choice. Before any planned migration, accounts ne
 
 Reusing one PRF output for unrelated purposes (for example, key derivation and app-data encryption) links those secrets: exposure of the output exposes all of them. Use a different salt per purpose, or split one output with a purpose-labeled KDF.
 
-A vault is bound to its PRF output only, never to the credential ID or salt. Secrets wrapped under one reused output share a wrapping key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. Give each secret a fresh random 32-byte salt; the [createSecretVault](/reference/create-secret-vault/) page carries the same warning.
+A vault is bound to its PRF output only, never to the credential ID or salt. Secrets wrapped under one reused output share a wrapping key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. The wrapped-mode creation functions generate a fresh random 32-byte salt for each secret; the [createSecretVault](/reference/create-secret-vault/) page documents the low-level requirement.
 
 ## Strings cannot be zeroed
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -25,23 +25,19 @@ npm install @scure/bip32 @scure/bip39
 `createPasskeyWithPrfOutput` creates a discoverable passkey and evaluates its PRF in one call.
 
 ```ts
-import {
-  createPasskeyWithPrfOutput,
-  getDeterministicPrfSaltV1,
-} from "@category-labs/mera";
+import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 
 const rpId = "account.example.com";
 
 const { prfOutput } = await createPasskeyWithPrfOutput({
   rp: { id: rpId, name: "Example" },
   user: { name: "account@example.com", displayName: "Example account" },
-  prfSalt: getDeterministicPrfSaltV1(),
 });
 ```
 
 Expect one authenticator prompt, sometimes two: authenticators that do not evaluate PRF at create time get a follow-up assertion with the same salt.
 
-The salt is mera's fixed deterministic one: the same passkey, relying party, and salt always produce the same 32 bytes, on any device the passkey syncs to. The result also carries the credential ID; [Derive accounts from one passkey](/recipes/derive-accounts/) stores it to pin later sign-ins.
+mera uses its fixed v1 salt for this call. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID; [Derive accounts from one passkey](/recipes/derive-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 
@@ -88,14 +84,10 @@ The session copies the key, zeroes the buffer it was given, and signs without fu
 A later visit needs no stored secret: the same assertion with the same salt returns the same 32 bytes, and with them the same account.
 
 ```ts
-import {
-  getDeterministicPrfSaltV1,
-  getPasskeyPrfOutput,
-} from "@category-labs/mera";
+import { getPasskeyPrfOutput } from "@category-labs/mera";
 
 const { prfOutput } = await getPasskeyPrfOutput({
   rpId,
-  prfSalt: getDeterministicPrfSaltV1(),
 });
 ```
 

--- a/docs/src/content/docs/recipes/derive-accounts.md
+++ b/docs/src/content/docs/recipes/derive-accounts.md
@@ -8,17 +8,13 @@ This recipe extends [Getting started](/getting-started/) to a real multi-account
 ## Create the passkey
 
 ```ts
-import {
-  createPasskeyWithPrfOutput,
-  getDeterministicPrfSaltV1,
-} from "@category-labs/mera";
+import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 
 const rpId = location.hostname;
 
 const created = await createPasskeyWithPrfOutput({
   rp: { id: rpId, name: "Example" },
   user: { name: "account@example.com", displayName: "Example account" },
-  prfSalt: getDeterministicPrfSaltV1(),
 });
 
 // The seed comes from the sign-in assertion below, so this flow never uses
@@ -49,10 +45,7 @@ A fresh device has no record; sign-in falls back to a discoverable ceremony, and
 ## Sign in
 
 ```ts
-import {
-  getDeterministicPrfSaltV1,
-  getPasskeyPrfOutput,
-} from "@category-labs/mera";
+import { getPasskeyPrfOutput } from "@category-labs/mera";
 
 const stored = localStorage.getItem("app.derivedCredential");
 const known = stored ? JSON.parse(stored) : undefined;
@@ -60,7 +53,6 @@ const known = stored ? JSON.parse(stored) : undefined;
 const { prfOutput, credentialId } = await getPasskeyPrfOutput({
   rpId,
   credential: known,
-  prfSalt: getDeterministicPrfSaltV1(),
 });
 
 // The ceremony reports which credential was actually used; the person may

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -21,38 +21,29 @@ if (!validateMnemonic(phrase, wordlist)) {
 }
 ```
 
-## Create the passkey with a fresh random salt
+## Create and persist the vault
 
-Wrapped flows never use the deterministic salt. Each secret gets 32 fresh random bytes, because a vault is bound to its PRF output only: secrets wrapped under one reused output would share a wrapping key, and their nonce/ciphertext pairs would become interchangeable to anyone who can rewrite the stored JSON. [createSecretVault](/reference/create-secret-vault/) documents the details.
+`createSecretVaultWithNewPasskey` generates a fresh random salt, creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault.
 
 ```ts
-import { createPasskeyWithPrfOutput } from "@category-labs/mera";
+import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
 
 const rpId = location.hostname;
 
-const credential = await createPasskeyWithPrfOutput({
-  rp: { id: rpId, name: "Example" },
-  user: { name: "account@example.com", displayName: "Example account" },
-  prfSalt: crypto.getRandomValues(new Uint8Array(32)),
-});
-```
-
-## Wrap and persist
-
-```ts
-import { createSecretVault } from "@category-labs/mera";
-
 const secret = new TextEncoder().encode(phrase);
 try {
-  const vault = await createSecretVault({ credential, secret });
+  const vault = await createSecretVaultWithNewPasskey({
+    rp: { id: rpId, name: "Example" },
+    user: { name: "account@example.com", displayName: "Example account" },
+    secret,
+  });
   localStorage.setItem("app.vault", JSON.stringify(vault));
 } finally {
   secret.fill(0);
-  credential.prfOutput.fill(0);
 }
 ```
 
-The `finally` zeroes the encoded phrase and the PRF output whether or not wrapping succeeded. A private key wraps the same way: pass its raw bytes as `secret` instead of encoded text. The vault stores the salt and credential metadata itself ([format](/reference/secret-vault-format/)), so nothing else needs saving.
+The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before settling. The `finally` zeroes the caller-owned encoded phrase. A private key wraps the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
 
 ## Unlock
 
@@ -60,9 +51,8 @@ One ceremony, pinned automatically to the credential stored in the vault:
 
 ```ts
 import {
-  getSecretVaultPrfOutput,
   parseSecretVault,
-  unwrapSecretVault,
+  unwrapSecretVaultWithPasskey,
 } from "@category-labs/mera";
 
 async function unlockPhrase(): Promise<string> {
@@ -70,21 +60,16 @@ async function unlockPhrase(): Promise<string> {
   if (raw === null) throw new Error("No vault on this device yet.");
 
   const vault = parseSecretVault(raw);
-  const { prfOutput } = await getSecretVaultPrfOutput({ rpId, vault });
+  const secret = await unwrapSecretVaultWithPasskey({ rpId, vault });
   try {
-    const secret = await unwrapSecretVault({ vault, prfOutput });
-    try {
-      return new TextDecoder().decode(secret);
-    } finally {
-      secret.fill(0);
-    }
+    return new TextDecoder().decode(secret);
   } finally {
-    prfOutput.fill(0);
+    secret.fill(0);
   }
 }
 ```
 
-`parseSecretVault` is the boundary for the untrusted stored JSON; everything after it works with validated data. The decrypted buffer is a fresh allocation the library never zeroes; the inner `finally` does.
+`parseSecretVault` is the boundary for the untrusted stored JSON. The unwrap function owns and zeroes the transient PRF output. The decrypted buffer is a fresh allocation, so the `finally` zeroes it after decoding.
 
 ## Derive signing sessions
 
@@ -92,6 +77,6 @@ The phrase is a standard BIP-39 mnemonic, so key derivation from here is exactly
 
 ## Pitfalls
 
-- **A second secret needs its own salt, ceremony, and vault.** Generate 32 fresh random bytes, run [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) against them, and wrap the new secret into a separate vault.
+- **A second secret needs its own ceremony and vault.** [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/) generates the fresh salt and stores it in the new vault.
 - **The phrase is a string** while it transits the wrap and unlock code, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)). Keep the lifetime short and never log it.
 - **The vault JSON is the only ciphertext copy.** Losing the storage loses the account unless the person still holds the phrase elsewhere.

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -1,9 +1,9 @@
 ---
 title: createPasskeyWithPrfOutput
-description: Creates a passkey and returns the PRF output for the given salt in one call.
+description: Creates a passkey and returns its deterministic PRF output in one call.
 ---
 
-Creates a passkey and returns the WebAuthn PRF output for the given salt, falling back to a second ceremony only when the authenticator does not evaluate PRF at create time. Equivalent to [createPasskey](/reference/create-passkey/) followed, when `prfOutput` is absent, by [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt; the fallback means a possible second browser prompt.
+Creates a passkey and returns a WebAuthn PRF output, falling back to a second ceremony when the authenticator does not evaluate PRF during creation. The fallback means a possible second browser prompt.
 
 ## Import
 
@@ -14,22 +14,18 @@ import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 ## Usage
 
 ```ts
-import {
-  createPasskeyWithPrfOutput,
-  getDeterministicPrfSaltV1,
-} from "@category-labs/mera";
+import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 
 const result = await createPasskeyWithPrfOutput({
   rp: { id: "account.example.com", name: "Example" },
   user: { name: "account@example.com", displayName: "Example account" },
-  prfSalt: getDeterministicPrfSaltV1(),
 });
 // result.credentialId, result.prfSalt, result.prfOutput
 ```
 
 ## Parameters
 
-`options` is a `CreatePasskeyWithPrfOutputOptions`. It tightens `CreatePasskeyOptions` in two places: `rp.id` is required so the fallback ceremony can target the same relying party, and `prfSalt` is required so the app explicitly chooses between the derived and wrapped patterns.
+`options` is a `CreatePasskeyWithPrfOutputOptions`. It requires `rp.id` so the fallback ceremony can target the same relying party.
 
 ### options.rp
 
@@ -48,9 +44,9 @@ Same fields and constraints as on [createPasskey](/reference/create-passkey/#opt
 ### options.prfSalt
 
 - Type: `Uint8Array`
-- Required
+- Optional; defaults to mera's fixed v1 deterministic salt
 
-32-byte PRF salt, evaluated during creation or by the fallback assertion. Derived flows pass [getDeterministicPrfSaltV1()](/reference/get-deterministic-prf-salt-v1/); wrapped flows pass 32 fresh random bytes. Copied before async WebAuthn work starts, so post-call mutation of the input changes neither the fallback ceremony nor the returned salt.
+32-byte PRF salt evaluated during creation or by the fallback assertion. An explicit value supports custom PRF namespaces and low-level composition. It is copied before async WebAuthn work starts, so post-call mutation changes neither the fallback ceremony nor the returned salt.
 
 ### options.timeout
 
@@ -61,14 +57,12 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Returns
 
-`Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`. The returned salt never aliases the caller's input.
-
-The result can be passed straight through as the `credential` argument of [createSecretVault](/reference/create-secret-vault/).
+`Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`. The returned salt is a fresh copy.
 
 ## Errors
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF, or did not return PRF output on the fallback ceremony.
-- [`INPUT_INVALID`](/reference/errors/#input_invalid): `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): an explicit `prfSalt` is not 32 bytes, or the provided `user.id` length is outside 1 to 64 bytes.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
@@ -80,5 +74,6 @@ If the fallback ceremony fails, the passkey from the completed creation ceremony
 
 ## See also
 
-- [createSecretVault](/reference/create-secret-vault/): wrap a secret with this function's result.
+- [createSecretVault](/reference/create-secret-vault/): low-level vault encryption with explicit PRF material.
+- [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create a passkey and vault with a fresh random salt.
 - [Getting started](/getting-started/): the derived-mode flow built on this call.

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -1,0 +1,87 @@
+---
+title: createSecretVaultWithExistingPasskey
+description: Encrypts one secret into a vault using an existing passkey and a fresh random salt.
+---
+
+Evaluates an existing passkey against a fresh random salt and encrypts one secret into a vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+
+## Import
+
+```ts
+import { createSecretVaultWithExistingPasskey } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  createSecretVaultWithExistingPasskey,
+  parseSecretVault,
+} from "@category-labs/mera";
+
+const existing = parseSecretVault(localStorage.getItem("vault"));
+const secret = new TextEncoder().encode("another secret");
+try {
+  const vault = await createSecretVaultWithExistingPasskey({
+    rpId: "account.example.com",
+    credential: existing.credential,
+    secret,
+  });
+  localStorage.setItem("second-vault", JSON.stringify(vault));
+} finally {
+  secret.fill(0);
+}
+```
+
+## Parameters
+
+`options` is a `CreateSecretVaultWithExistingPasskeyOptions`.
+
+### options.rpId
+
+- Type: `string`
+- Required
+
+Relying party ID for the WebAuthn assertion. It must match the ID under which the passkey was created.
+
+### options.credential
+
+- Type: `PasskeyCredentialMetadata`
+- Optional; when omitted, WebAuthn may choose any discoverable credential for the relying party
+
+Credential metadata that restricts the assertion to one passkey. Reported transports are retained in the new vault when the selected credential matches.
+
+### options.secret
+
+- Type: `Uint8Array`
+- Required
+
+Secret bytes to encrypt. Any non-empty length; the library does not interpret them.
+
+### options.timeout
+
+- Type: `number`
+- Optional; browser defaults apply when omitted
+
+WebAuthn timeout in milliseconds.
+
+## Returns
+
+`Promise<PasskeySecretVault>`: a JSON-safe vault containing the selected credential metadata, generated PRF salt, nonce, and ciphertext.
+
+## Errors
+
+- [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `secret` is empty, or `credential.credentialId` is empty or not canonical base64url.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+
+## Notes
+
+A fresh random 32-byte PRF salt is generated for each call and stored in the vault. The secret and supplied credential metadata are copied before the ceremony begins. Caller-owned inputs are not modified or zeroed; internal secret and PRF-output copies are zeroed before the function settles.
+
+## See also
+
+- [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create the first vault together with a passkey.
+- [unwrapSecretVaultWithPasskey](/reference/unwrap-secret-vault-with-passkey/): perform the assertion and decrypt a stored vault.
+- [One output, one purpose](/concepts/security-model/#one-output-one-purpose): why each vault receives a fresh salt.

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -1,0 +1,85 @@
+---
+title: createSecretVaultWithNewPasskey
+description: Creates a passkey and encrypts one secret into a vault with a fresh random salt.
+---
+
+Creates a passkey and encrypts one secret into a vault. Runs one `navigator.credentials.create()` ceremony and may run a fallback `navigator.credentials.get()` ceremony, so it may show one or two browser prompts.
+
+## Import
+
+```ts
+import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
+
+const secret = new TextEncoder().encode("the secret to protect");
+try {
+  const vault = await createSecretVaultWithNewPasskey({
+    rp: { id: "account.example.com", name: "Example" },
+    user: { name: "account@example.com", displayName: "Example account" },
+    secret,
+  });
+  localStorage.setItem("vault", JSON.stringify(vault));
+} finally {
+  secret.fill(0);
+}
+```
+
+## Parameters
+
+`options` is a `CreateSecretVaultWithNewPasskeyOptions`.
+
+### options.rp
+
+- Type: `PublicKeyCredentialRpEntity & { id: string }`
+- Required, including `rp.id`
+
+Relying party identity passed to WebAuthn. The required ID is reused by the fallback assertion.
+
+### options.user
+
+- Type: `{ id?: Uint8Array; name: string; displayName: string }`
+- Required
+
+User identity passed to WebAuthn. `id` must be 1 to 64 bytes when provided. A fresh random 32-byte user handle is generated when it is omitted.
+
+### options.secret
+
+- Type: `Uint8Array`
+- Required
+
+Secret bytes to encrypt. Any non-empty length; the library does not interpret them.
+
+### options.timeout
+
+- Type: `number`
+- Optional; browser defaults apply when omitted
+
+WebAuthn timeout in milliseconds, applied to each ceremony.
+
+## Returns
+
+`Promise<PasskeySecretVault>`: a JSON-safe vault containing the new credential metadata, generated PRF salt, nonce, and ciphertext.
+
+## Errors
+
+- [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF or return a usable 32-byte output.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `secret` is empty, or the provided `user.id` length is outside 1 to 64 bytes.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+
+## Notes
+
+A fresh random 32-byte PRF salt is generated for the vault and stored in it. The secret is copied before either ceremony begins. The caller-owned buffer is not modified or zeroed; internal secret and PRF-output copies are zeroed before the function settles.
+
+If the fallback ceremony or vault encryption fails after creation, the passkey remains on the authenticator and the error does not contain its metadata.
+
+## See also
+
+- [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): create another vault with an existing passkey.
+- [unwrapSecretVaultWithPasskey](/reference/unwrap-secret-vault-with-passkey/): perform the assertion and decrypt a stored vault.
+- [Use an existing secret](/recipes/use-an-existing-secret/): the complete storage and secret-lifetime pattern.

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -3,7 +3,7 @@ title: createSecretVault
 description: Encrypts an arbitrary secret into a passkey-protected vault.
 ---
 
-Encrypts an arbitrary secret into a passkey-protected vault.
+Encrypts an arbitrary secret into a passkey-protected vault from explicit credential, salt, and PRF material. This is the low-level encryption primitive; wrapped-mode workflow functions own the ceremony and random salt.
 
 An AES-256-GCM wrapping key is derived from the PRF output with fixed HKDF-SHA-256 info (`mera.v1.wrap.secret`), which separates it from any other key derived from the same output. The secret is encrypted under fixed additional authenticated data.
 
@@ -44,7 +44,7 @@ localStorage.setItem("vault", JSON.stringify(vault));
 - Type: `{ credentialId: string; transports?: readonly PasskeyCredentialTransport[]; prfSalt: Uint8Array; prfOutput: Uint8Array }`
 - Required
 
-The passkey credential plus the PRF salt and the PRF output it produced. The result of [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) can be passed straight through. `credentialId` must be canonical unpadded base64url and non-empty; `prfSalt` and `prfOutput` must each be exactly 32 bytes.
+The passkey credential plus the PRF salt and the PRF output it produced. A [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) result evaluated with an explicit fresh salt can be passed straight through. `credentialId` must be canonical unpadded base64url and non-empty; `prfSalt` and `prfOutput` must each be exactly 32 bytes.
 
 ### options.secret
 
@@ -72,6 +72,8 @@ Input byte buffers are copied before async cryptographic work starts; mutating t
 
 ## See also
 
+- [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create a passkey and vault in one workflow.
+- [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): create a vault with an existing passkey.
 - [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) and [unwrapSecretVault](/reference/unwrap-secret-vault/): the assertion and decryption that recover the secret.
 - [Use an existing secret](/recipes/use-an-existing-secret/): the full flow with zeroing.
 - [Security model](/concepts/security-model/#one-output-one-purpose): why PRF outputs must not be reused across purposes.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -19,7 +19,6 @@ class MeraError extends Error {
 
 ```ts
 import {
-  getDeterministicPrfSaltV1,
   getPasskeyPrfOutput,
   isMeraError,
 } from "@category-labs/mera";
@@ -27,7 +26,6 @@ import {
 try {
   await getPasskeyPrfOutput({
     rpId: "account.example.com",
-    prfSalt: getDeterministicPrfSaltV1(),
   });
 } catch (error) {
   if (isMeraError(error) && error.code === "PRF_UNAVAILABLE") {

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -3,7 +3,7 @@ title: getDeterministicPrfSaltV1
 description: Returns mera's fixed v1 deterministic PRF salt.
 ---
 
-Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. It is a pure function over a constant.
+Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. The PRF output functions use this value internally when `prfSalt` is omitted; this helper supports explicit protocol interoperability and custom composition.
 
 The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party. [Derived mode](/concepts/derived-and-wrapped/) is built on that stability.
 
@@ -36,9 +36,10 @@ None.
 
 The salt encodes no account selection. Selecting account 0 versus account 7 happens in the derivation scheme the app applies to the PRF output, never in the salt.
 
-Wrapped flows should not use this salt. Each secret vault stores 32 fresh random bytes instead: vaults sharing one PRF output would share a wrapping key ([createSecretVault](/reference/create-secret-vault/)).
+This salt belongs to derived flows. The wrapped-mode creation functions generate and store 32 fresh random bytes for each vault because vaults sharing one PRF output would share a wrapping key.
 
 ## See also
 
-- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): where this salt gets used.
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): evaluate a passkey with this default or an explicit salt.
+- [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create a wrapped vault with an internally generated salt.
 - [Passkeys and the PRF extension](/concepts/passkeys-and-prf/): salts as namespaces.

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -14,14 +14,10 @@ import { getPasskeyPrfOutput } from "@category-labs/mera";
 ## Usage
 
 ```ts
-import {
-  getDeterministicPrfSaltV1,
-  getPasskeyPrfOutput,
-} from "@category-labs/mera";
+import { getPasskeyPrfOutput } from "@category-labs/mera";
 
 const { credentialId, prfOutput } = await getPasskeyPrfOutput({
   rpId: "account.example.com",
-  prfSalt: getDeterministicPrfSaltV1(),
 });
 ```
 
@@ -46,9 +42,9 @@ Credential metadata that restricts the assertion to one passkey: a `credentialId
 ### options.prfSalt
 
 - Type: `Uint8Array`
-- Required
+- Optional; defaults to mera's fixed v1 deterministic salt
 
-PRF salt as 32 raw bytes. Copied before use; the original buffer is not modified.
+PRF salt as 32 raw bytes. An explicit value supports custom PRF namespaces and low-level composition. It is copied before use; the original buffer is not modified.
 
 ### options.timeout
 
@@ -64,13 +60,13 @@ WebAuthn timeout in milliseconds.
 ## Errors
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
-- [`INPUT_INVALID`](/reference/errors/#input_invalid): `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): an explicit `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes
 
-The PRF output is a deterministic function of the credential, `rpId`, and `prfSalt`: the same three inputs reproduce the same 32 bytes, and a different salt yields an unrelated output.
+The PRF output is a deterministic function of the credential, `rpId`, and salt. The same inputs reproduce the same 32 bytes, and a different salt yields an unrelated output. The default salt is permanently the fixed v1 value.
 
 The assertion requires user verification, and the requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the output nor skip the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
@@ -80,6 +76,6 @@ WebAuthn availability is checked before Web Crypto, so an environment missing bo
 
 ## See also
 
-- [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): the fixed salt for derived flows.
+- [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): access the default salt explicitly for protocol interoperability.
 - [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/): the same assertion, driven by a stored vault.
 - [Derive accounts from one passkey](/recipes/derive-accounts/): credential pinning in practice.

--- a/docs/src/content/docs/reference/get-secret-vault-prf-output.md
+++ b/docs/src/content/docs/reference/get-secret-vault-prf-output.md
@@ -72,5 +72,6 @@ The WebAuthn challenge is generated internally, and the raw assertion response i
 
 ## See also
 
+- [unwrapSecretVaultWithPasskey](/reference/unwrap-secret-vault-with-passkey/): perform the assertion and decryption in one call.
 - [unwrapSecretVault](/reference/unwrap-secret-vault/): the decryption step that follows.
 - [Use an existing secret](/recipes/use-an-existing-secret/): the full unlock flow.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -8,9 +8,9 @@ Each exported function has its own page. Types are documented on the pages of th
 ## Passkeys
 
 - [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled.
-- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns the PRF output for the given salt in one call.
-- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the output.
-- [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): returns mera's fixed v1 deterministic PRF salt.
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns its deterministic PRF output in one call.
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the deterministic output.
+- [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): returns the default salt explicitly for interoperability and custom composition.
 
 ## Signing sessions
 
@@ -20,7 +20,10 @@ Each exported function has its own page. Types are documented on the pages of th
 
 ## Secret vault
 
-- [createSecretVault](/reference/create-secret-vault/): encrypts an arbitrary secret into a passkey-protected vault.
+- [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): creates a passkey and encrypts one secret with a fresh random salt.
+- [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): encrypts another secret with an existing passkey and a fresh random salt.
+- [unwrapSecretVaultWithPasskey](/reference/unwrap-secret-vault-with-passkey/): performs the passkey assertion and decrypts a vault.
+- [createSecretVault](/reference/create-secret-vault/): encrypts a secret from explicit credential and PRF material.
 - [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/): performs the WebAuthn assertion needed to unlock a vault.
 - [unwrapSecretVault](/reference/unwrap-secret-vault/): decrypts the secret from a vault.
 - [parseSecretVault](/reference/parse-secret-vault/): parses and validates untrusted vault JSON or objects.

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -37,7 +37,7 @@ A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The creden
 
 ## Notes
 
-A vault that came through this function cannot trigger the `INPUT_INVALID` re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) or [unwrapSecretVault](/reference/unwrap-secret-vault/); what remains is cryptographic failure (`DECRYPT_FAILED`) or ceremony failure.
+A vault that came through this function cannot trigger the `INPUT_INVALID` re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), [unwrapSecretVault](/reference/unwrap-secret-vault/), or [unwrapSecretVaultWithPasskey](/reference/unwrap-secret-vault-with-passkey/). Cryptographic failure (`DECRYPT_FAILED`) and ceremony failure remain possible.
 
 A future vault format will use a higher version number. Rejecting an unknown version keeps an old library from misreading newer data.
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -55,5 +55,8 @@ The vault is plain JSON and can be stored anywhere JSON can: `localStorage`, a d
 
 ## See also
 
-- [createSecretVault](/reference/create-secret-vault/), [parseSecretVault](/reference/parse-secret-vault/), [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), [unwrapSecretVault](/reference/unwrap-secret-vault/): the four functions that produce and consume this format.
+- [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/) and [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): workflow functions that produce this format.
+- [unwrapSecretVaultWithPasskey](/reference/unwrap-secret-vault-with-passkey/): the workflow function that performs the assertion and decryption.
+- [createSecretVault](/reference/create-secret-vault/), [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), and [unwrapSecretVault](/reference/unwrap-secret-vault/): low-level primitives for the same format.
+- [parseSecretVault](/reference/parse-secret-vault/): the validation boundary for stored JSON.
 - [Derived and wrapped modes](/concepts/derived-and-wrapped/): where the vault fits.

--- a/docs/src/content/docs/reference/unwrap-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/unwrap-secret-vault-with-passkey.md
@@ -1,0 +1,81 @@
+---
+title: unwrapSecretVaultWithPasskey
+description: Performs a passkey assertion and decrypts one secret vault.
+---
+
+Performs the passkey assertion for a parsed vault and decrypts its secret. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+
+## Import
+
+```ts
+import { unwrapSecretVaultWithPasskey } from "@category-labs/mera";
+```
+
+## Usage
+
+```ts
+import {
+  parseSecretVault,
+  unwrapSecretVaultWithPasskey,
+} from "@category-labs/mera";
+
+const vault = parseSecretVault(localStorage.getItem("vault"));
+const secret = await unwrapSecretVaultWithPasskey({
+  rpId: "account.example.com",
+  vault,
+});
+try {
+  // use the secret bytes
+} finally {
+  secret.fill(0);
+}
+```
+
+## Parameters
+
+`options` is an `UnwrapSecretVaultWithPasskeyOptions`.
+
+### options.rpId
+
+- Type: `string`
+- Required
+
+Relying party ID for the WebAuthn assertion. It must match the ID under which the vault's passkey was created.
+
+### options.vault
+
+- Type: `PasskeySecretVault`
+- Required
+
+A parsed secret vault. Run untrusted stored data through [parseSecretVault](/reference/parse-secret-vault/) first. The assertion is restricted to the credential stored in the vault.
+
+### options.timeout
+
+- Type: `number`
+- Optional; browser defaults apply when omitted
+
+WebAuthn timeout in milliseconds.
+
+## Returns
+
+`Promise<Uint8Array>`: the decrypted secret bytes as a fresh allocation. The library keeps no reference to this buffer and does not zero it; the caller controls its lifetime.
+
+## Errors
+
+- [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
+- [`DECRYPT_FAILED`](/reference/errors/#decrypt_failed): AES-GCM authentication failed because the PRF output was wrong or the vault was modified.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+
+## Notes
+
+The vault is copied before the assertion starts, so post-call mutation changes neither the credential restriction nor the ciphertext being decrypted. The transient PRF output is zeroed before the function settles, including when decryption fails.
+
+The WebAuthn challenge is generated internally, and the raw assertion response is not returned.
+
+## See also
+
+- [parseSecretVault](/reference/parse-secret-vault/): validate stored JSON before this call.
+- [unwrapSecretVault](/reference/unwrap-secret-vault/): decrypt with an explicitly supplied PRF output.
+- [Use an existing secret](/recipes/use-an-existing-secret/): the complete storage and secret-lifetime pattern.

--- a/docs/src/content/docs/reference/unwrap-secret-vault.md
+++ b/docs/src/content/docs/reference/unwrap-secret-vault.md
@@ -64,5 +64,6 @@ The 32-byte WebAuthn PRF output for the vault's stored salt. Copied before async
 
 ## See also
 
+- [unwrapSecretVaultWithPasskey](/reference/unwrap-secret-vault-with-passkey/): perform the assertion and decryption in one call.
 - [Use an existing secret](/recipes/use-an-existing-secret/): create, store, and unwrap with the zeroing pattern.
 - [Secret vault format](/reference/secret-vault-format/): what the ciphertext actually contains.

--- a/site/index.html
+++ b/site/index.html
@@ -660,11 +660,11 @@ clientDataJSON
         <h3 id="derived-mode">Derived mode</h3>
 
         <p>
-          In derived mode the account is computed from the passkey. mera pins a
-          fixed salt (<code>getDeterministicPrfSaltV1()</code>), so the same
-          passkey yields the same account. The application runs the
-          passkey-derived bytes through its derivation scheme of choice; mera's
-          demo wallet app feeds them into BIP-39 and derives keys with
+          In derived mode the account is computed from the passkey. mera's PRF
+          output methods use a fixed v1 salt by default, so the same passkey
+          yields the same account. The application runs the passkey-derived
+          bytes through its derivation scheme of choice; mera's demo wallet app
+          feeds them into BIP-39 and derives keys with
           <a
             href="https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki"
             >BIP-32</a
@@ -791,7 +791,6 @@ clientDataJSON
 
         <pre><code class="language-typescript">import {
   createSecp256k1SigningSession,
-  getDeterministicPrfSaltV1,
   getEvmAddress,
   getPasskeyPrfOutput,
 } from "@category-labs/mera"
@@ -801,8 +800,7 @@ import { wordlist } from "@scure/bip39/wordlists/english.js"
 
 const rpId = "account.example.com"
 
-const prfSalt = getDeterministicPrfSaltV1()
-const { prfOutput } = await getPasskeyPrfOutput({ rpId, prfSalt })
+const { prfOutput } = await getPasskeyPrfOutput({ rpId })
 
 // App-owned derivation: the PRF output is BIP-39 entropy, so the same phrase
 // imported into a standard wallet reproduces the same account.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,14 +17,20 @@ export {
 export { createSecp256k1SigningSession } from "./secp256k1.js";
 export type {
   CreateSecretVaultOptions,
+  CreateSecretVaultWithExistingPasskeyOptions,
+  CreateSecretVaultWithNewPasskeyOptions,
   GetSecretVaultPrfOutputOptions,
   UnwrapSecretVaultOptions,
+  UnwrapSecretVaultWithPasskeyOptions,
 } from "./secret.js";
 export {
   createSecretVault,
+  createSecretVaultWithExistingPasskey,
+  createSecretVaultWithNewPasskey,
   getSecretVaultPrfOutput,
   parseSecretVault,
   unwrapSecretVault,
+  unwrapSecretVaultWithPasskey,
 } from "./secret.js";
 export type {
   CreatePasskeyResult,

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -52,8 +52,8 @@ type CreatePasskeyInput = {
  * Inputs for creating a passkey and obtaining its first WebAuthn PRF output in one call.
  *
  * Tightens `CreatePasskeyOptions`: `rp.id` is required so the fallback ceremony
- * can target the same relying party. `prfSalt` defaults to Mera's fixed v1
- * deterministic salt.
+ * can target the same relying party. `prfSalt` defaults to the fixed v1 value
+ * returned by {@link getDeterministicPrfSaltV1}.
  */
 type CreatePasskeyWithPrfOutputInput = Omit<
   CreatePasskeyInput,
@@ -63,7 +63,7 @@ type CreatePasskeyWithPrfOutputInput = Omit<
   rp: PublicKeyCredentialRpEntity & { id: string };
   /**
    * 32-byte PRF salt evaluated during creation, or by the fallback assertion.
-   * Defaults to Mera's fixed v1 deterministic salt.
+   * Defaults to the value returned by {@link getDeterministicPrfSaltV1}.
    */
   prfSalt?: Uint8Array;
 };
@@ -75,8 +75,9 @@ type GetPasskeyPrfOutputInput = {
   /** Credential metadata to restrict the assertion to one passkey. */
   credential?: PasskeyCredentialMetadata;
   /**
-   * PRF salt as 32 raw bytes. Defaults to Mera's fixed v1 deterministic salt.
-   * Copied before use; the original buffer is not modified.
+   * PRF salt as 32 raw bytes. Defaults to the value returned by
+   * {@link getDeterministicPrfSaltV1}. Copied before use; the original buffer is
+   * not modified.
    */
   prfSalt?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
@@ -231,10 +232,11 @@ async function createPasskey({
  * The WebAuthn challenge is generated internally. The raw assertion response is
  * not returned.
  *
- * When `prfSalt` is omitted, Mera's fixed v1 deterministic salt is used. This
- * default is stable across library versions. The PRF output is a deterministic
- * function of the credential, `rpId`, and salt: the same three inputs reproduce
- * the same output, and a different salt yields an unrelated output.
+ * When `prfSalt` is omitted, the value returned by {@link
+ * getDeterministicPrfSaltV1} is used. This default is stable across library
+ * versions. The PRF output is a deterministic function of the credential,
+ * `rpId`, and salt: the same three inputs reproduce the same output, and a
+ * different salt yields an unrelated output.
  *
  * The assertion requires user verification, and the requirement is not
  * configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs
@@ -344,8 +346,9 @@ async function getPasskeyPrfOutput({
  * WebAuthn challenges are generated internally. Raw attestation and assertion
  * responses are not returned.
  *
- * When `prfSalt` is omitted, Mera's fixed v1 deterministic salt is used. This
- * default is stable across library versions.
+ * When `prfSalt` is omitted, the value returned by {@link
+ * getDeterministicPrfSaltV1} is used. This default is stable across library
+ * versions.
  *
  * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of
  * an explicit input does not change the fallback ceremony or returned salt.

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -1,3 +1,4 @@
+import { getDeterministicPrfSaltV1 } from "./derived.js";
 import {
   asArrayBuffer,
   base64UrlDecode,
@@ -51,8 +52,8 @@ type CreatePasskeyInput = {
  * Inputs for creating a passkey and obtaining its first WebAuthn PRF output in one call.
  *
  * Tightens `CreatePasskeyOptions`: `rp.id` is required so the fallback ceremony
- * can target the same relying party, and `prfSalt` is required so apps choose
- * whether this flow is deterministic or random-key.
+ * can target the same relying party. `prfSalt` defaults to Mera's fixed v1
+ * deterministic salt.
  */
 type CreatePasskeyWithPrfOutputInput = Omit<
   CreatePasskeyInput,
@@ -60,8 +61,11 @@ type CreatePasskeyWithPrfOutputInput = Omit<
 > & {
   /** Relying party identity passed to WebAuthn. `id` is required here. */
   rp: PublicKeyCredentialRpEntity & { id: string };
-  /** 32-byte PRF salt evaluated during creation, or by the fallback assertion. */
-  prfSalt: Uint8Array;
+  /**
+   * 32-byte PRF salt evaluated during creation, or by the fallback assertion.
+   * Defaults to Mera's fixed v1 deterministic salt.
+   */
+  prfSalt?: Uint8Array;
 };
 
 /** Inputs for requesting the first WebAuthn PRF output from a passkey. */
@@ -70,8 +74,11 @@ type GetPasskeyPrfOutputInput = {
   rpId: string;
   /** Credential metadata to restrict the assertion to one passkey. */
   credential?: PasskeyCredentialMetadata;
-  /** PRF salt as 32 raw bytes; copied before use, the original buffer is not modified. */
-  prfSalt: Uint8Array;
+  /**
+   * PRF salt as 32 raw bytes. Defaults to Mera's fixed v1 deterministic salt.
+   * Copied before use; the original buffer is not modified.
+   */
+  prfSalt?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
   timeout?: number;
 };
@@ -224,9 +231,10 @@ async function createPasskey({
  * The WebAuthn challenge is generated internally. The raw assertion response is
  * not returned.
  *
- * The PRF output is a deterministic function of the credential, `rpId`, and
- * `prfSalt`: the same three inputs reproduce the same output, and a different
- * salt yields an unrelated output.
+ * When `prfSalt` is omitted, Mera's fixed v1 deterministic salt is used. This
+ * default is stable across library versions. The PRF output is a deterministic
+ * function of the credential, `rpId`, and salt: the same three inputs reproduce
+ * the same output, and a different salt yields an unrelated output.
  *
  * The assertion requires user verification, and the requirement is not
  * configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs
@@ -237,7 +245,7 @@ async function createPasskey({
  * @see {@link https://www.w3.org/TR/webauthn-3/#prf-extension | WebAuthn: the PRF extension}
  * @see {@link https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement | WebAuthn: UserVerificationRequirement}
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
- * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
+ * @throws MeraError with code `INPUT_INVALID` when an explicit `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
@@ -251,11 +259,12 @@ async function getPasskeyPrfOutput({
     assertCredentialApiAvailable();
 
     const challenge = randomBytes(32);
-    if (prfSalt.length !== 32) {
+    const prfSaltCopy = copyBytes(prfSalt ?? getDeterministicPrfSaltV1());
+    if (prfSaltCopy.length !== 32) {
       throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
     }
 
-    const prf = { eval: { first: asArrayBuffer(prfSalt) } };
+    const prf = { eval: { first: asArrayBuffer(prfSaltCopy) } };
 
     const publicKey: PublicKeyCredentialRequestOptions = {
       rpId,
@@ -335,14 +344,17 @@ async function getPasskeyPrfOutput({
  * WebAuthn challenges are generated internally. Raw attestation and assertion
  * responses are not returned.
  *
+ * When `prfSalt` is omitted, Mera's fixed v1 deterministic salt is used. This
+ * default is stable across library versions.
+ *
  * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of
- * the input does not change the fallback ceremony or returned salt.
+ * an explicit input does not change the fallback ceremony or returned salt.
  *
  * If the fallback ceremony fails, the passkey from the completed creation
  * ceremony still exists on the authenticator, but the thrown error does not
  * carry its metadata.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, or does not return PRF output on the fallback ceremony.
- * @throws MeraError with code `INPUT_INVALID` when `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when an explicit `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
@@ -352,7 +364,7 @@ async function createPasskeyWithPrfOutput({
   timeout,
   prfSalt,
 }: CreatePasskeyWithPrfOutputInput): Promise<CreatePasskeyWithPrfOutputResult> {
-  const prfSaltCopy = copyBytes(prfSalt);
+  const prfSaltCopy = copyBytes(prfSalt ?? getDeterministicPrfSaltV1());
 
   const credential = await createPasskey({
     rp,
@@ -489,6 +501,7 @@ export type {
   GetPasskeyPrfOutputOptions,
 };
 export {
+  assertCredentialApiAvailable,
   copyPrfOutput,
   createPasskey,
   createPasskeyWithPrfOutput,

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -6,8 +6,13 @@ import {
   copyBytes,
 } from "./encoding.js";
 import { MeraError, type MeraErrorCode } from "./errors.js";
-import { getPasskeyPrfOutput } from "./passkey.js";
+import {
+  assertCredentialApiAvailable,
+  createPasskeyWithPrfOutput,
+  getPasskeyPrfOutput,
+} from "./passkey.js";
 import type {
+  PasskeyCredentialMetadata,
   PasskeyCredentialTransport,
   PasskeyPrfResult,
   PasskeySecretVault,
@@ -192,8 +197,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /** Inputs for encrypting one arbitrary secret into a vault. */
 type CreateSecretVaultInput = {
   /**
-   * Passkey credential plus the PRF salt and PRF output it produced. The result
-   * of `createPasskeyWithPrfOutput` can be passed straight through.
+   * Passkey credential plus the PRF salt and PRF output it produced. Wrapped
+   * flows use a fresh salt for each secret.
    */
   credential: {
     /** Passkey credential ID as canonical unpadded base64url. */
@@ -277,6 +282,184 @@ async function createSecretVault({
   } finally {
     prfOutputCopy.fill(0);
     secretCopy.fill(0);
+  }
+}
+
+/** Inputs for creating a secret vault together with a new passkey. */
+type CreateSecretVaultWithNewPasskeyInput = {
+  /** Relying party identity passed directly to WebAuthn. `id` is required. */
+  rp: PublicKeyCredentialRpEntity & { id: string };
+  /** User identity passed to WebAuthn. `id` is copied before use. */
+  user: {
+    /** User handle. Must be 1 to 64 bytes when provided. */
+    id?: Uint8Array;
+    /** User name displayed or stored by the authenticator. */
+    name: string;
+    /** Human-readable display name for the authenticator UI. */
+    displayName: string;
+  };
+  /** Secret bytes to encrypt. Any non-empty length. */
+  secret: Uint8Array;
+  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
+  timeout?: number;
+};
+
+/** Inputs for creating a secret vault with an existing passkey. */
+type CreateSecretVaultWithExistingPasskeyInput = {
+  /** Relying party ID for the WebAuthn assertion. */
+  rpId: string;
+  /** Credential metadata to restrict the assertion to one passkey. */
+  credential?: PasskeyCredentialMetadata;
+  /** Secret bytes to encrypt. Any non-empty length. */
+  secret: Uint8Array;
+  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
+  timeout?: number;
+};
+
+/** Copies and validates a secret before a WebAuthn ceremony can start. */
+function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (secret.length === 0) {
+    throw new MeraError("INPUT_INVALID", "secret must not be empty");
+  }
+
+  return copyBytes(secret);
+}
+
+/** Copies credential metadata before async WebAuthn work starts. */
+function copyCredentialMetadata(
+  credential: PasskeyCredentialMetadata | undefined,
+): PasskeyCredentialMetadata | undefined {
+  if (credential === undefined) {
+    return undefined;
+  }
+
+  return {
+    credentialId: credential.credentialId,
+    ...(credential.transports !== undefined
+      ? { transports: [...credential.transports] }
+      : {}),
+  };
+}
+
+/**
+ * Checks WebAuthn before generating a random vault salt so ceremony helpers
+ * keep their existing error precedence when WebAuthn and Web Crypto are both
+ * unavailable.
+ */
+function getRandomVaultPrfSalt(): Uint8Array<ArrayBuffer> {
+  assertCredentialApiAvailable();
+  return randomBytes(PRF_SALT_LENGTH);
+}
+
+/**
+ * Creates a passkey and encrypts one secret into a vault.
+ *
+ * A fresh random PRF salt is generated internally and stored in the returned
+ * vault. The passkey creation may require a fallback assertion when the
+ * authenticator does not evaluate PRF during creation.
+ *
+ * @param options - Passkey creation inputs and secret bytes; fields are documented on {@link CreateSecretVaultWithNewPasskeyOptions}.
+ * @returns A JSON-safe secret vault containing the new credential metadata.
+ * @remarks
+ * Invokes `navigator.credentials.create()`, which may show browser or
+ * authenticator UI. On authenticators that do not evaluate PRF during
+ * creation, also invokes `navigator.credentials.get()`, which means a second
+ * browser prompt.
+ *
+ * `secret` is copied and validated before either ceremony starts. Post-call
+ * mutation does not change the encrypted secret, and the caller-owned buffer
+ * is not modified or zeroed. The internal secret and PRF output are zeroed
+ * before the function settles, including on failure.
+ *
+ * If the fallback ceremony or vault encryption fails, the passkey from the
+ * completed creation ceremony still exists on the authenticator, but the
+ * thrown error does not carry its metadata.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF or return a usable 32-byte PRF output.
+ * @throws MeraError with code `INPUT_INVALID` when `secret` is empty, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ */
+async function createSecretVaultWithNewPasskey({
+  rp,
+  user,
+  secret,
+  timeout,
+}: CreateSecretVaultWithNewPasskeyInput): Promise<PasskeySecretVault> {
+  const secretCopy = copyNonEmptySecret(secret);
+  let prfOutput: Uint8Array | undefined;
+
+  try {
+    const credential = await createPasskeyWithPrfOutput({
+      rp,
+      user,
+      ...(timeout !== undefined ? { timeout } : {}),
+      prfSalt: getRandomVaultPrfSalt(),
+    });
+    prfOutput = credential.prfOutput;
+
+    return await createSecretVault({ credential, secret: secretCopy });
+  } finally {
+    secretCopy.fill(0);
+    prfOutput?.fill(0);
+  }
+}
+
+/**
+ * Evaluates an existing passkey against a fresh random salt and encrypts one
+ * secret into a vault.
+ *
+ * @param options - Passkey assertion inputs and secret bytes; fields are documented on {@link CreateSecretVaultWithExistingPasskeyOptions}.
+ * @returns A JSON-safe secret vault containing the selected credential metadata.
+ * @remarks
+ * Invokes `navigator.credentials.get()`, which may show browser or
+ * authenticator UI. When `credential` is omitted, WebAuthn may choose any
+ * discoverable credential for the relying party.
+ *
+ * A fresh random PRF salt is generated internally and stored in the returned
+ * vault. `secret` and `credential` are copied before the ceremony starts, so
+ * post-call mutation does not change the operation. Caller-owned inputs are
+ * not modified or zeroed. The internal secret and PRF output are zeroed before
+ * the function settles, including on failure.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
+ * @throws MeraError with code `INPUT_INVALID` when `secret` is empty, or `credential.credentialId` is empty or not canonical base64url.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ */
+async function createSecretVaultWithExistingPasskey({
+  rpId,
+  credential,
+  secret,
+  timeout,
+}: CreateSecretVaultWithExistingPasskeyInput): Promise<PasskeySecretVault> {
+  const secretCopy = copyNonEmptySecret(secret);
+  const credentialCopy = copyCredentialMetadata(credential);
+  let prfOutput: Uint8Array | undefined;
+
+  try {
+    const prfSalt = getRandomVaultPrfSalt();
+    const evaluated = await getPasskeyPrfOutput({
+      rpId,
+      ...(credentialCopy !== undefined ? { credential: credentialCopy } : {}),
+      prfSalt,
+      ...(timeout !== undefined ? { timeout } : {}),
+    });
+    prfOutput = evaluated.prfOutput;
+
+    return await createSecretVault({
+      credential: {
+        credentialId: evaluated.credentialId,
+        ...(credentialCopy?.credentialId === evaluated.credentialId &&
+        credentialCopy.transports !== undefined
+          ? { transports: credentialCopy.transports }
+          : {}),
+        prfSalt,
+        prfOutput,
+      },
+      secret: secretCopy,
+    });
+  } finally {
+    secretCopy.fill(0);
+    prfOutput?.fill(0);
   }
 }
 
@@ -398,6 +581,22 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
   return { version: 1, credential, prfSalt, nonce, ciphertext };
 }
 
+/** Copies a parsed vault before a WebAuthn ceremony can yield control. */
+function copySecretVault(vault: PasskeySecretVault): PasskeySecretVault {
+  return {
+    version: vault.version,
+    credential: {
+      credentialId: vault.credential.credentialId,
+      ...(vault.credential.transports !== undefined
+        ? { transports: [...vault.credential.transports] }
+        : {}),
+    },
+    prfSalt: vault.prfSalt,
+    nonce: vault.nonce,
+    ciphertext: vault.ciphertext,
+  };
+}
+
 /** Inputs for the WebAuthn assertion that unlocks a secret vault. */
 type GetSecretVaultPrfOutputInput = {
   /** Relying party ID for the WebAuthn assertion. */
@@ -440,10 +639,72 @@ async function getSecretVaultPrfOutput({
   });
 }
 
+/** Inputs for performing the passkey ceremony and decrypting a secret vault. */
+type UnwrapSecretVaultWithPasskeyInput = {
+  /** Relying party ID for the WebAuthn assertion. */
+  rpId: string;
+  /** Parsed secret vault. Copied before use. */
+  vault: PasskeySecretVault;
+  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
+  timeout?: number;
+};
+
+/**
+ * Performs the passkey assertion for a vault and decrypts its secret.
+ *
+ * @param options - Relying party and parsed vault; fields are documented on {@link UnwrapSecretVaultWithPasskeyOptions}.
+ * @returns The decrypted secret bytes. The returned buffer is a fresh allocation owned by the caller.
+ * @remarks
+ * Invokes `navigator.credentials.get()`, which may show browser or
+ * authenticator UI. The assertion is restricted to the credential stored in
+ * the vault.
+ *
+ * The vault is copied before the ceremony starts, so post-call mutation does
+ * not change the assertion or ciphertext being decrypted. The internal PRF
+ * output is zeroed before the function settles, including when decryption
+ * fails. The returned secret is not zeroed; its lifetime belongs to the
+ * caller.
+ * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
+ * @throws MeraError with code `INPUT_INVALID` when the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
+ * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
+ * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
+ * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
+ */
+async function unwrapSecretVaultWithPasskey({
+  rpId,
+  vault,
+  timeout,
+}: UnwrapSecretVaultWithPasskeyInput): Promise<Uint8Array<ArrayBuffer>> {
+  const vaultCopy = copySecretVault(vault);
+  const { prfOutput } = await getSecretVaultPrfOutput({
+    rpId,
+    vault: vaultCopy,
+    ...(timeout !== undefined ? { timeout } : {}),
+  });
+
+  try {
+    return await unwrapSecretVault({ vault: vaultCopy, prfOutput });
+  } finally {
+    prfOutput.fill(0);
+  }
+}
+
 /** Options accepted by `createSecretVault`. */
 type CreateSecretVaultOptions = Parameters<typeof createSecretVault>[0];
+/** Options accepted by `createSecretVaultWithExistingPasskey`. */
+type CreateSecretVaultWithExistingPasskeyOptions = Parameters<
+  typeof createSecretVaultWithExistingPasskey
+>[0];
+/** Options accepted by `createSecretVaultWithNewPasskey`. */
+type CreateSecretVaultWithNewPasskeyOptions = Parameters<
+  typeof createSecretVaultWithNewPasskey
+>[0];
 /** Options accepted by `unwrapSecretVault`. */
 type UnwrapSecretVaultOptions = Parameters<typeof unwrapSecretVault>[0];
+/** Options accepted by `unwrapSecretVaultWithPasskey`. */
+type UnwrapSecretVaultWithPasskeyOptions = Parameters<
+  typeof unwrapSecretVaultWithPasskey
+>[0];
 /** Options accepted by `getSecretVaultPrfOutput`. */
 type GetSecretVaultPrfOutputOptions = Parameters<
   typeof getSecretVaultPrfOutput
@@ -451,12 +712,18 @@ type GetSecretVaultPrfOutputOptions = Parameters<
 
 export type {
   CreateSecretVaultOptions,
+  CreateSecretVaultWithExistingPasskeyOptions,
+  CreateSecretVaultWithNewPasskeyOptions,
   GetSecretVaultPrfOutputOptions,
   UnwrapSecretVaultOptions,
+  UnwrapSecretVaultWithPasskeyOptions,
 };
 export {
   createSecretVault,
+  createSecretVaultWithExistingPasskey,
+  createSecretVaultWithNewPasskey,
   getSecretVaultPrfOutput,
   parseSecretVault,
   unwrapSecretVault,
+  unwrapSecretVaultWithPasskey,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,8 +61,8 @@ type CreatePasskeyResult = PasskeyCredentialMetadata & {
 /**
  * Result of creating a passkey together with its first PRF output.
  *
- * `prfSalt` is the salt WebAuthn evaluated, so downstream helpers (in
- * particular `createSecretVault`) can be invoked with this result alone.
+ * `prfSalt` is the salt WebAuthn evaluated. It is returned for explicit
+ * low-level composition and protocol interoperability.
  */
 type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
   /** PRF salt that was evaluated. Always 32 bytes and never aliases the caller input. */

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -8,4 +8,9 @@ test("returns the fixed v1 deterministic PRF salt", () => {
   expect(bytesToHex(salt)).toBe(
     "0843291565a6314a928d60d0e51a6d0c46a82b3faaa6e47560b920312ba35f90",
   );
+
+  salt.fill(0);
+  expect(bytesToHex(getDeterministicPrfSaltV1())).toBe(
+    "0843291565a6314a928d60d0e51a6d0c46a82b3faaa6e47560b920312ba35f90",
+  );
 });

--- a/test/passkey.e2e.ts
+++ b/test/passkey.e2e.ts
@@ -89,13 +89,12 @@ test("creates a PRF-capable passkey and returns stable PRF output", async ({
   });
 });
 
-test("createPasskeyWithPrfOutput returns the first PRF output in one call", async ({
+test("PRF output helpers use the deterministic v1 salt by default", async ({
   page,
 }) => {
   await withVirtualAuthenticator(page, async () => {
     const result = await page.evaluate(async () => {
       const mera = await import("@category-labs/mera");
-      const prfSalt = crypto.getRandomValues(new Uint8Array(32));
       const created = await mera.createPasskeyWithPrfOutput({
         rp: { id: "localhost", name: "Mera Test" },
         user: {
@@ -103,18 +102,17 @@ test("createPasskeyWithPrfOutput returns the first PRF output in one call", asyn
           name: "nad",
           displayName: "nad",
         },
-        prfSalt,
       });
 
-      // Same salt against the same credential reproduces the PRF output.
+      // Omission uses the same stable salt for returning assertions.
       const repeated = await mera.getPasskeyPrfOutput({
         rpId: "localhost",
         credential: created,
-        prfSalt: created.prfSalt,
       });
 
       return {
         credentialId: created.credentialId,
+        expectedSalt: Array.from(mera.getDeterministicPrfSaltV1()),
         prfSalt: Array.from(created.prfSalt),
         prfOutput: Array.from(created.prfOutput),
         repeated: Array.from(repeated.prfOutput),
@@ -123,42 +121,86 @@ test("createPasskeyWithPrfOutput returns the first PRF output in one call", asyn
 
     expect(result.credentialId).toMatch(/^[A-Za-z0-9_-]+$/u);
     expect(result.prfSalt).toHaveLength(32);
+    expect(result.prfSalt).toEqual(result.expectedSalt);
     expect(result.prfOutput).toHaveLength(32);
     expect(result.prfOutput).toEqual(result.repeated);
   });
 });
 
-test("createSecretVault round-trips a secret through a real passkey ceremony", async ({
+test("wrapped-mode orchestrators create independent vaults and decrypt them", async ({
   page,
 }) => {
   await withVirtualAuthenticator(page, async () => {
     const result = await page.evaluate(async () => {
       const mera = await import("@category-labs/mera");
-      const phrase =
+      const firstPhrase =
         "legal winner thank year wave sausage worth useful legal winner thank yellow";
-      const credential = await mera.createPasskeyWithPrfOutput({
+      const secondPhrase =
+        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above";
+
+      const firstVault = await mera.createSecretVaultWithNewPasskey({
         rp: { id: "localhost", name: "Mera Test" },
         user: {
           id: crypto.getRandomValues(new Uint8Array(32)),
           name: "nad",
           displayName: "nad",
         },
-        prfSalt: crypto.getRandomValues(new Uint8Array(32)),
+        secret: new TextEncoder().encode(firstPhrase),
       });
-      const vault = await mera.createSecretVault({
-        credential,
-        secret: new TextEncoder().encode(phrase),
-      });
-      // Re-run the ceremony from the persisted vault, exactly as a reveal would.
-      const { prfOutput } = await mera.getSecretVaultPrfOutput({
-        rpId: "localhost",
-        vault: mera.parseSecretVault(JSON.stringify(vault)),
-      });
-      const secret = await mera.unwrapSecretVault({ vault, prfOutput });
 
-      return { phrase, revealed: new TextDecoder().decode(secret) };
+      const secondVault = await mera.createSecretVaultWithExistingPasskey({
+        rpId: "localhost",
+        credential: firstVault.credential,
+        secret: new TextEncoder().encode(secondPhrase),
+      });
+
+      const parsedFirst = mera.parseSecretVault(JSON.stringify(firstVault));
+      const parsedSecond = mera.parseSecretVault(JSON.stringify(secondVault));
+      const firstSecret = await mera.unwrapSecretVaultWithPasskey({
+        rpId: "localhost",
+        vault: parsedFirst,
+      });
+      const secondSecret = await mera.unwrapSecretVaultWithPasskey({
+        rpId: "localhost",
+        vault: parsedSecond,
+      });
+
+      const tampered = {
+        ...parsedFirst,
+        ciphertext: `${parsedFirst.ciphertext[0] === "A" ? "B" : "A"}${parsedFirst.ciphertext.slice(1)}`,
+      };
+      let tamperCode: string | undefined;
+      try {
+        await mera.unwrapSecretVaultWithPasskey({
+          rpId: "localhost",
+          vault: tampered,
+        });
+      } catch (error) {
+        tamperCode = mera.isMeraError(error) ? error.code : undefined;
+      }
+
+      const revealedFirst = new TextDecoder().decode(firstSecret);
+      const revealedSecond = new TextDecoder().decode(secondSecret);
+      firstSecret.fill(0);
+      secondSecret.fill(0);
+
+      return {
+        firstPhrase,
+        secondPhrase,
+        firstSalt: firstVault.prfSalt,
+        secondSalt: secondVault.prfSalt,
+        firstCredential: firstVault.credential,
+        secondCredential: secondVault.credential,
+        revealedFirst,
+        revealedSecond,
+        tamperCode,
+      };
     });
 
-    expect(result.revealed).toBe(result.phrase);
+    expect(result.revealedFirst).toBe(result.firstPhrase);
+    expect(result.revealedSecond).toBe(result.secondPhrase);
+    expect(result.firstSalt).not.toBe(result.secondSalt);
+    expect(result.secondCredential).toEqual(result.firstCredential);
+    expect(result.tamperCode).toBe("DECRYPT_FAILED");
   });
 });

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { getDeterministicPrfSaltV1 } from "../dist/derived.js";
 import {
   copyPrfOutput,
   createPasskey,
@@ -68,6 +69,136 @@ test("copyPrfOutput rejects PRF output that is not 32 bytes", () => {
   expectError(() => copyPrfOutput(new ArrayBuffer(33)), "PRF_UNAVAILABLE");
   // Valid byte values, so a plain array fails on length, not element checks.
   expectError(() => copyPrfOutput([1, 2, 3]), "PRF_UNAVAILABLE");
+});
+
+test("createPasskey without prfSalt does not evaluate or return PRF output", async () => {
+  let createOptions: PublicKeyCredentialCreationOptions | undefined;
+  const navigator = {
+    credentials: {
+      async create({ publicKey }: CredentialCreationOptions) {
+        createOptions = publicKey;
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          response: {},
+          getClientExtensionResults: () => ({
+            prf: {
+              enabled: true,
+              results: { first: new Uint8Array(32).fill(7).buffer },
+            },
+          }),
+        };
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    const result = await createPasskey({
+      rp: { id: "example.com", name: "Mera Test" },
+      user: { name: "nad", displayName: "nad" },
+    });
+
+    expect(result.prfOutput).toBeUndefined();
+  });
+
+  expect(createOptions?.extensions?.prf).toEqual({});
+});
+
+test("PRF output helpers default to Mera's fixed v1 salt", async () => {
+  const evaluatedSalts: Uint8Array[] = [];
+
+  function readSalt(value: BufferSource | undefined): ArrayBuffer {
+    if (!(value instanceof ArrayBuffer)) {
+      throw new Error("expected PRF salt as an ArrayBuffer");
+    }
+    evaluatedSalts.push(new Uint8Array(value));
+    return value;
+  }
+
+  const navigator = {
+    credentials: {
+      async create({ publicKey }: CredentialCreationOptions) {
+        readSalt(publicKey?.extensions?.prf?.eval?.first);
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          response: {},
+          getClientExtensionResults: () => ({ prf: { enabled: true } }),
+        };
+      },
+      async get({ publicKey }: CredentialRequestOptions) {
+        const salt = readSalt(publicKey?.extensions?.prf?.eval?.first);
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          getClientExtensionResults: () => ({
+            prf: { results: { first: salt } },
+          }),
+        };
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    const expected = getDeterministicPrfSaltV1();
+    const created = await createPasskeyWithPrfOutput({
+      rp: { id: "example.com", name: "Mera Test" },
+      user: { name: "nad", displayName: "nad" },
+    });
+    expect(created.prfSalt).toEqual(expected);
+    expect(created.prfOutput).toEqual(expected);
+
+    created.prfSalt.fill(255);
+
+    const recreated = await createPasskeyWithPrfOutput({
+      rp: { id: "example.com", name: "Mera Test" },
+      user: { name: "nad", displayName: "nad" },
+    });
+    expect(recreated.prfSalt).toEqual(expected);
+
+    const asserted = await getPasskeyPrfOutput({ rpId: "example.com" });
+    expect(asserted.prfOutput).toEqual(expected);
+  });
+
+  expect(evaluatedSalts).toHaveLength(5);
+  for (const salt of evaluatedSalts) {
+    expect(salt).toEqual(getDeterministicPrfSaltV1());
+  }
+});
+
+test("PRF output helpers reject an explicit salt of the wrong length", async () => {
+  let prompted = false;
+  const navigator = {
+    credentials: {
+      async create() {
+        prompted = true;
+        throw new Error("creation must not start");
+      },
+      async get() {
+        prompted = true;
+        throw new Error("assertion must not start");
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    await expect(
+      createPasskeyWithPrfOutput({
+        rp: { id: "example.com", name: "Mera Test" },
+        user: { name: "nad", displayName: "nad" },
+        prfSalt: new Uint8Array(31),
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+
+    await expect(
+      getPasskeyPrfOutput({
+        rpId: "example.com",
+        prfSalt: new Uint8Array(31),
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+
+  expect(prompted).toBe(false);
 });
 
 test("passkey helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable", async () => {

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -2,9 +2,14 @@ import { utf8ToBytes } from "@noble/hashes/utils.js";
 import { expect, test } from "@playwright/test";
 import {
   createSecretVault,
+  createSecretVaultWithExistingPasskey,
+  createSecretVaultWithNewPasskey,
+  getDeterministicPrfSaltV1,
+  type PasskeyCredentialTransport,
   type PasskeySecretVault,
   parseSecretVault,
   unwrapSecretVault,
+  unwrapSecretVaultWithPasskey,
 } from "../dist/index.js";
 import { expectError, withStubbedGlobal } from "./helpers.js";
 
@@ -28,6 +33,19 @@ async function createTestVault(
     },
     secret,
   });
+}
+
+function readPrfSalt(
+  publicKey:
+    | PublicKeyCredentialRequestOptions
+    | PublicKeyCredentialCreationOptions
+    | undefined,
+): Uint8Array {
+  const first = publicKey?.extensions?.prf?.eval?.first;
+  if (!(first instanceof ArrayBuffer)) {
+    throw new Error("expected PRF salt as an ArrayBuffer");
+  }
+  return new Uint8Array(first);
 }
 
 test("creates a secret vault and unwraps the exact bytes", async () => {
@@ -69,6 +87,290 @@ test("createSecretVault snapshots caller-owned byte inputs before async work", a
   await expect(
     unwrapSecretVault({ vault, prfOutput: PRF_OUTPUT }),
   ).resolves.toEqual(SECRET);
+});
+
+test("wrapped-mode creation rejects an empty secret before prompting", async () => {
+  let ceremonyCount = 0;
+  const navigator = {
+    credentials: {
+      async create() {
+        ceremonyCount += 1;
+        throw new Error("creation must not start");
+      },
+      async get() {
+        ceremonyCount += 1;
+        throw new Error("assertion must not start");
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    await expect(
+      createSecretVaultWithNewPasskey({
+        rp: { id: "example.com", name: "Mera Test" },
+        user: { name: "nad", displayName: "nad" },
+        secret: new Uint8Array(0),
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+
+    await expect(
+      createSecretVaultWithExistingPasskey({
+        rpId: "example.com",
+        secret: new Uint8Array(0),
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+
+  expect(ceremonyCount).toBe(0);
+});
+
+test("wrapped-mode ceremony helpers check WebAuthn before Web Crypto", async () => {
+  const vault = await createTestVault();
+
+  await withStubbedGlobal("navigator", undefined, async () => {
+    await withStubbedGlobal("crypto", undefined, async () => {
+      await expect(
+        createSecretVaultWithNewPasskey({
+          rp: { id: "example.com", name: "Mera Test" },
+          user: { name: "nad", displayName: "nad" },
+          secret: SECRET,
+        }),
+      ).rejects.toMatchObject({ code: "PASSKEY_OPERATION_FAILED" });
+
+      await expect(
+        createSecretVaultWithExistingPasskey({
+          rpId: "example.com",
+          secret: SECRET,
+        }),
+      ).rejects.toMatchObject({ code: "PASSKEY_OPERATION_FAILED" });
+
+      await expect(
+        unwrapSecretVaultWithPasskey({ rpId: "example.com", vault }),
+      ).rejects.toMatchObject({ code: "PASSKEY_OPERATION_FAILED" });
+    });
+  });
+});
+
+test("wrapped-mode creation preserves PRF failures and caller-owned secrets", async () => {
+  const newPasskeySecret = new Uint8Array(SECRET);
+  const existingPasskeySecret = new Uint8Array(SECRET);
+  const navigator = {
+    credentials: {
+      async create() {
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          response: {},
+          getClientExtensionResults: () => ({ prf: { enabled: false } }),
+        };
+      },
+      async get() {
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          getClientExtensionResults: () => ({ prf: {} }),
+        };
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    await expect(
+      createSecretVaultWithNewPasskey({
+        rp: { id: "example.com", name: "Mera Test" },
+        user: { name: "nad", displayName: "nad" },
+        secret: newPasskeySecret,
+      }),
+    ).rejects.toMatchObject({ code: "PRF_UNAVAILABLE" });
+
+    await expect(
+      createSecretVaultWithExistingPasskey({
+        rpId: "example.com",
+        secret: existingPasskeySecret,
+      }),
+    ).rejects.toMatchObject({ code: "PRF_UNAVAILABLE" });
+  });
+
+  expect(newPasskeySecret).toEqual(SECRET);
+  expect(existingPasskeySecret).toEqual(SECRET);
+});
+
+test("createSecretVaultWithExistingPasskey rejects an empty credential ID without prompting", async () => {
+  let asserted = false;
+  const navigator = {
+    credentials: {
+      async get() {
+        asserted = true;
+        throw new Error("assertion must not start");
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    await expect(
+      createSecretVaultWithExistingPasskey({
+        rpId: "example.com",
+        credential: { credentialId: "" },
+        secret: SECRET,
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+
+  expect(asserted).toBe(false);
+});
+
+test("createSecretVaultWithNewPasskey owns a random salt and snapshots the secret", async () => {
+  let releaseCreation: (() => void) | undefined;
+  const creationGate = new Promise<void>((resolve) => {
+    releaseCreation = resolve;
+  });
+  let evaluatedSalt: Uint8Array | undefined;
+
+  const navigator = {
+    credentials: {
+      async create({ publicKey }: CredentialCreationOptions) {
+        evaluatedSalt = readPrfSalt(publicKey);
+        await creationGate;
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          response: { getTransports: () => ["internal"] },
+          getClientExtensionResults: () => ({
+            prf: {
+              enabled: true,
+              results: { first: evaluatedSalt?.buffer },
+            },
+          }),
+        };
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    const secret = new Uint8Array(SECRET);
+    const pending = createSecretVaultWithNewPasskey({
+      rp: { id: "example.com", name: "Mera Test" },
+      user: { name: "nad", displayName: "nad" },
+      secret,
+    });
+
+    secret.fill(0);
+    releaseCreation?.();
+
+    const vault = await pending;
+    if (evaluatedSalt === undefined) {
+      throw new Error("expected a PRF salt");
+    }
+
+    expect(vault.credential).toEqual({
+      credentialId: "AQIDBA",
+      transports: ["internal"],
+    });
+    expect(vault.prfSalt).not.toBe(
+      Buffer.from(getDeterministicPrfSaltV1()).toString("base64url"),
+    );
+    await expect(
+      unwrapSecretVault({ vault, prfOutput: evaluatedSalt }),
+    ).resolves.toEqual(SECRET);
+  });
+});
+
+test("createSecretVaultWithExistingPasskey snapshots inputs and preserves transports", async () => {
+  let releaseAssertion: (() => void) | undefined;
+  const assertionGate = new Promise<void>((resolve) => {
+    releaseAssertion = resolve;
+  });
+  let evaluatedSalt: Uint8Array | undefined;
+
+  const navigator = {
+    credentials: {
+      async get({ publicKey }: CredentialRequestOptions) {
+        evaluatedSalt = readPrfSalt(publicKey);
+        await assertionGate;
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          getClientExtensionResults: () => ({
+            prf: { results: { first: evaluatedSalt?.buffer } },
+          }),
+        };
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    const transports: PasskeyCredentialTransport[] = ["usb"];
+    const credential = { credentialId: "AQIDBA", transports };
+    const secret = new Uint8Array(SECRET);
+    const pending = createSecretVaultWithExistingPasskey({
+      rpId: "example.com",
+      credential,
+      secret,
+    });
+
+    credential.credentialId = "BQYHCA";
+    transports[0] = "nfc";
+    secret.fill(0);
+    releaseAssertion?.();
+
+    const vault = await pending;
+    if (evaluatedSalt === undefined) {
+      throw new Error("expected a PRF salt");
+    }
+
+    expect(vault.credential).toEqual({
+      credentialId: "AQIDBA",
+      transports: ["usb"],
+    });
+    await expect(
+      unwrapSecretVault({ vault, prfOutput: evaluatedSalt }),
+    ).resolves.toEqual(SECRET);
+  });
+});
+
+test("unwrapSecretVaultWithPasskey snapshots the vault before prompting", async () => {
+  const stored = await createTestVault();
+  const vault = {
+    ...stored,
+    credential: {
+      ...stored.credential,
+      transports: [...(stored.credential.transports ?? [])],
+    },
+  };
+  let releaseAssertion: (() => void) | undefined;
+  const assertionGate = new Promise<void>((resolve) => {
+    releaseAssertion = resolve;
+  });
+
+  const navigator = {
+    credentials: {
+      async get() {
+        await assertionGate;
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          getClientExtensionResults: () => ({
+            prf: { results: { first: PRF_OUTPUT.buffer } },
+          }),
+        };
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    const pending = unwrapSecretVaultWithPasskey({
+      rpId: "example.com",
+      vault,
+    });
+
+    vault.credential.credentialId = "BQYHCA";
+    vault.prfSalt = "invalid";
+    vault.nonce = "invalid";
+    vault.ciphertext = "invalid";
+    releaseAssertion?.();
+
+    await expect(pending).resolves.toEqual(SECRET);
+  });
 });
 
 test("unwrapSecretVault fails with the wrong PRF output", async () => {


### PR DESCRIPTION
## Summary
- Make PRF salt handling optional across vault creation and unwrap flows.
- Update derived-account and passkey documentation, README examples, and the demo to reflect the new behavior.
- Refresh the public reference docs and error descriptions to match the revised API surface.

## Testing
- Updated and added tests covering derived PRF behavior, passkey flows, and secret vault handling.
- Local test suite validation passed for the affected areas.