### PR TITLE
Allow clipboard write in embedded demo iframe

### DIFF
--- a/docs/src/components/DemoEmbed.astro
+++ b/docs/src/components/DemoEmbed.astro
@@ -1,15 +1,23 @@
 ---
 // Renders the demo app in an iframe that fills its container; the host
 // element decides the size, and the demo scrolls inside when its content is
-// taller. The WebAuthn permissions let passkey ceremonies run in-frame.
+// taller. The delegated permissions let passkey ceremonies and clipboard
+// writes run in-frame.
 const DEMO_ORIGIN = "https://demo-production-8ad3.up.railway.app";
+const DEMO_PERMISSIONS = [
+  "publickey-credentials-create",
+  "publickey-credentials-get",
+  "clipboard-write",
+]
+  .map((permission) => `${permission} ${DEMO_ORIGIN}`)
+  .join("; ");
 ---
 
 <iframe
   src={DEMO_ORIGIN}
   title="mera demo"
   class="not-content"
-  allow="publickey-credentials-create *; publickey-credentials-get *"></iframe>
+  allow={DEMO_PERMISSIONS}></iframe>
 
 <style>
   iframe {


### PR DESCRIPTION
## Summary
- Build the iframe `allow` attribute from the demo origin once and reuse it for all delegated permissions.
- Add `clipboard-write` alongside the existing WebAuthn permissions so the embedded demo can perform clipboard writes in-frame.
- Update the component comment to describe the delegated permissions more accurately.

## Testing
- Not run (not requested)