### PR TITLE
Increase docs demo height tracking in the hero

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,6 @@ npm run build    # static site in dist/
 npm run preview  # serve the built site
 ```
 
-Pages live in `src/content/docs/` as Markdown/MDX. The visual style is `src/styles/mera.css`, which maps the demo app’s palette and the `site/` article’s typography onto Starlight's CSS variables. The landing page is `src/components/Hero.astro`; it embeds the hosted demo app through `src/components/DemoEmbed.astro` in a fixed-height panel that the demo scrolls inside.
+Pages live in `src/content/docs/` as Markdown/MDX. The visual style is `src/styles/mera.css`, which maps the demo app’s palette and the `site/` article’s typography onto Starlight's CSS variables. The landing page is `src/components/Hero.astro`; it embeds the hosted demo app through `src/components/DemoEmbed.astro`. The frame follows the demo's content height in stacked layouts and uses a viewport-sized sticky panel on wide screens.
 
 Authoring guidance (page structure, voice, review checklist) lives in [AGENTS.md](./AGENTS.md).

--- a/docs/src/components/DemoEmbed.astro
+++ b/docs/src/components/DemoEmbed.astro
@@ -1,8 +1,8 @@
 ---
-// Renders the demo app in an iframe that fills its container; the host
-// element decides the size, and the demo scrolls inside when its content is
-// taller. The delegated permissions let passkey ceremonies and clipboard
-// writes run in-frame.
+// Renders the demo app in an iframe. The demo reports its content height so
+// stacked layouts can show it without an inner scrollbar; wide layouts may
+// still constrain it to the viewport. The delegated permissions let passkey
+// ceremonies and clipboard writes run in-frame.
 const DEMO_ORIGIN = "https://demo-production-8ad3.up.railway.app";
 const DEMO_PERMISSIONS = [
   "publickey-credentials-create",
@@ -15,15 +15,42 @@ const DEMO_PERMISSIONS = [
 
 <iframe
   src={DEMO_ORIGIN}
+  data-demo-origin={DEMO_ORIGIN}
   title="mera demo"
   class="not-content"
   allow={DEMO_PERMISSIONS}></iframe>
+
+<script>
+  window.addEventListener("message", (event) => {
+    const data = event.data;
+    if (
+      data?.type !== "mera:resize" ||
+      !Number.isFinite(data.height) ||
+      data.height <= 0
+    ) {
+      return;
+    }
+
+    for (const frame of document.querySelectorAll<HTMLIFrameElement>(
+      "iframe[data-demo-origin]",
+    )) {
+      if (
+        frame.contentWindow === event.source &&
+        frame.dataset.demoOrigin === event.origin
+      ) {
+        frame.style.setProperty(
+          "--demo-content-height",
+          `${Math.ceil(data.height)}px`,
+        );
+      }
+    }
+  });
+</script>
 
 <style>
   iframe {
     display: block;
     width: 100%;
-    height: 100%;
     border: none;
   }
 </style>

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -186,7 +186,6 @@ const features = [
   .demo {
     display: flex;
     flex-direction: column;
-    height: clamp(30rem, calc(100dvh - var(--sl-nav-height) - 8rem), 34rem);
     margin: 0;
     overflow: hidden;
     border: 1px solid var(--sl-color-hairline);
@@ -195,7 +194,8 @@ const features = [
   }
 
   .demo :global(iframe) {
-    flex: 1;
+    flex: none;
+    height: var(--demo-content-height, clamp(42rem, 110dvh, 52rem));
     min-height: 0;
   }
 
@@ -294,6 +294,11 @@ const features = [
       height: 100%;
     }
 
+    .demo :global(iframe) {
+      flex: 1;
+      height: 100%;
+    }
+
     .actions {
       display: flex;
       flex-wrap: wrap;
@@ -313,7 +318,7 @@ const features = [
   }
 
   /* Tighten the left column on short laptop viewports without changing the
-     demo's independent scrolling behavior. */
+     sticky demo's viewport-sized panel. */
   @media (min-width: 56rem) and (max-height: 53rem) {
     .copy {
       gap: 1rem;


### PR DESCRIPTION
## Summary
- Let the docs hero demo size itself from the embedded app's reported content height in stacked layouts.
- Keep the wide-screen hero treatment as a sticky viewport-sized panel.
- Update the docs README and component comments to match the new behavior.

## Testing
- Not run (not requested)