### PR TITLE
Revise repository documentation for the new contributor workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Why
+
+<!--
+Explain the problem or risk that makes this change necessary. Do not restate
+what reviewers can infer from the diff. If this replaces an existing path,
+explain why the replacement is equivalent or better and which behavior or
+coverage remains.
+-->
+
+## Notes for reviewers
+
+<!--
+Optional. Link related issues or discussions, identify non-obvious constraints
+or trade-offs, request attention on a particular area, or note manual
+validation and follow-up that are not visible in the diff or CI. Remove this
+section when there is nothing to add.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 - Document security-sensitive behavior explicitly, especially for key material, randomness, WebAuthn prompts, encryption nonces, storage formats, and mutation/zeroing behavior.
 - Document thrown `MeraError` codes with the appropriate JSDoc tag.
 - Examples should be runnable, concise, and focused on library behavior, not on provider boilerplate.
-- README examples should reflect actual tested behavior.
+- The root README is a nontechnical project overview. Installation, examples, compatibility, security details, API documentation, and the demo live on the documentation website.
 - Keep documentation prose neutral: name keys, secrets, and passkeys plainly ("the passkey", "one encrypted secret") rather than attributing them to the reader ("your passkey", "a secret you provide" / "you own").
 - Internal helpers with non-obvious invariants should have short `//` comments or full JSDoc.
 - Document observable behavior, not caller instructions: state what a function does to its inputs and outputs (for example, "the input is copied before use; the original buffer is not modified") rather than what the caller may or should do with them. Callers derive correct usage from the stated facts.
@@ -56,8 +56,8 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 
 - Write PR descriptions for reviewers who need to understand the reason for the change, not just the diff.
 - Start with the problem or risk that motivated the change. If the PR replaces one path with another, explain why the replacement is equivalent or better, including what behavior still runs and what coverage is added or preserved.
-- Keep the implementation summary short and concrete after the rationale.
-- List the validation that was run and any follow-up outside the diff, such as branch-protection changes or rollout notes.
+- Add only context that is not visible in the diff or CI, such as a related discussion, a non-obvious constraint or trade-off, manual validation, requested review focus, or follow-up outside the diff.
+- Do not restate the implementation or automated validation that reviewers can inspect directly.
 
 ## File Scope Guidelines
 
@@ -69,7 +69,7 @@ This file should stay stable and process-oriented.
 - coding and API design principles
 - safety and review expectations
 
-Project commands and the testing workflow live in the README's Development section.
+Project commands and the testing workflow live in `CONTRIBUTING.md`.
 
 ### What Not to Include
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,58 @@
+# Contributor Covenant Code of Conduct
+
+## Our commitment
+
+We are committed to a welcoming, safe, and equitable community. Participation is open to everyone acting in good faith and with respect for the dignity, rights, experiences, and contributions of others.
+
+## Expected behavior
+
+Community members are expected to:
+
+- engage honestly and respectfully;
+- respect different viewpoints and experiences;
+- give and accept constructive feedback;
+- take responsibility for their words and actions;
+- repair harm when possible;
+- support the purpose and well-being of the community.
+
+## Unacceptable behavior
+
+The following behavior is not accepted:
+
+- harassment, threats, intimidation, or stalking;
+- discriminatory or demeaning language or conduct;
+- sexualized language, imagery, or unwanted attention;
+- personal attacks, insults, or sustained disruption;
+- publishing private information without permission;
+- encouraging or helping others to engage in these behaviors.
+
+## Reporting
+
+For conduct tied to a GitHub comment, issue, pull request, or discussion, use that item's **Report content** action and choose the option to report it to the repository administrators when available. Repository administrators can review these reports privately when GitHub's reported-content feature is enabled.
+
+When there is no reportable GitHub item, use [GitHub's abuse reporting form](https://support.github.com/contact/report-abuse) and include the repository URL and the relevant context. Do not open a public issue to report a conduct incident.
+
+Reports will be handled as privately as GitHub's reporting tools allow. Maintainers will consider the safety of the reporter and other affected people when reviewing an incident.
+
+## Enforcement responsibilities
+
+Maintainers are responsible for applying this code fairly. They may remove, edit, or reject comments, commits, issues, pull requests, and other contributions that conflict with it. They may also limit or end a person's participation when needed to protect the community.
+
+## Addressing harm
+
+Maintainers will consider the impact, context, and pattern of behavior. Depending on the severity of an incident, they may use the following steps and may skip a step when necessary:
+
+1. **Warning.** A private explanation of the violation, the expected change, and any repair requested.
+2. **Limited participation.** A temporary limit on specific interactions or activities, with clear conditions for return.
+3. **Temporary suspension.** Removal from community spaces for a stated period after serious or repeated violations.
+4. **Permanent removal.** Permanent exclusion when severe harm or an established pattern makes continued participation unsafe.
+
+Enforcement decisions should be proportionate, documented privately, and focused on preventing further harm.
+
+## Scope
+
+This code applies in this repository's community spaces and when someone officially represents the project in a GitHub interaction.
+
+## Attribution
+
+This code is adapted from [Contributor Covenant 3.0](https://www.contributor-covenant.org/version/3/0/), which is stewarded by the Organization for Ethical Source and licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to mera
+
+Issues and pull requests are welcome. Focused fixes can go directly to a pull request. Open an issue before starting broad work or a public API change so the approach can be discussed first.
+
+Participation in the project is governed by [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
+
+## Repository guidance
+
+[AGENTS.md](./AGENTS.md) defines the repository's design, API, documentation, TypeScript, and review principles. Changes to the documentation website follow the additional structure and mechanics in [docs/AGENTS.md](./docs/AGENTS.md).
+
+## Development
+
+The repository requires Node.js 24 or newer and npm. Install the root dependencies before running library checks:
+
+```sh
+npm ci
+```
+
+Run the checks relevant to the change:
+
+```sh
+npm run check       # lint and format checks for the repository
+npm test            # library build, test typecheck, and Playwright tests
+npm run check:pack  # publishable package contents, exports, and types
+```
+
+Run `npm test` for library or test changes. Run `npm run check:pack` when packaged files, exports, types, or package metadata change.
+
+The demo compiles against the built library:
+
+```sh
+npm run build
+cd demo
+npm ci
+npm run build
+```
+
+Build the documentation website from its package directory:
+
+```sh
+cd docs
+npm ci
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -1,142 +1,37 @@
 # mera
 
-Passkey-backed signing sessions for accounts across chains.
+Accounts on any chain and platform, backed by a passkey.
 
-mera gets stable, authenticator-bound entropy from a WebAuthn passkey. The browser's WebAuthn PRF extension gives the library 32 bytes per ceremony. Apps can feed those bytes into their own account derivation, or encrypt an app-held secret such as a recovery phrase or private key into a passkey-protected vault.
+mera is an experimental TypeScript library for building passkey-backed accounts. It gives applications authenticator-bound entropy and lockable signing sessions while leaving account derivation, recovery, storage, and product flows under application control.
 
-The result is ordinary signing material for the app to use. No smart-account deployment or custom on-chain verifier is required.
+Developers can use mera to:
 
-- Signing sessions for secp256k1 and Ed25519, address helpers for EVM and Solana.
-- One user-verification prompt can cover a session of signatures.
-- Key derivation stays app-owned; mera hands the app entropy.
-- Cross-platform: a native iOS or Android app tied to the same domain can use the same passkey and derive the same accounts.
+- create new accounts from a passkey without adding smart-account contracts or a custody service;
+- protect an existing recovery phrase, private key, or other secret with a passkey;
+- keep account derivation and recovery choices in the application;
+- use the same passkey across web, iOS, and Android applications tied to the same domain.
 
-## Account patterns
+## Documentation and demo
 
-**Derived.** mera uses its fixed deterministic salt to reproduce the same PRF output for the same PRF-capable passkey and `rpId`. The app derives account keys from that output with its chosen scheme. The demo uses BIP-39/BIP-32 for secp256k1 and SLIP-0010 for Ed25519.
+Installation, guides, compatibility information, the security model, the API reference, and the live demo are on the [mera documentation website](https://determined-tenderness-production-79fe.up.railway.app/).
 
-Cross-device use requires the passkey to be available on the new device. This mode fits stateless account access across devices.
+## Repository
 
-Derived mode stores no app-owned secret to recover. The account may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's `rpId` after a domain migration. Recovery then depends on an app-provided export, import, or backup path.
+- [`src/`](./src/) contains the library source.
+- [`demo/`](./demo/) contains the live demo application source.
+- [`docs/`](./docs/) contains the documentation website.
+- [`test/`](./test/) contains the library test suite.
 
-**Secret vault.** An AES-256-GCM blob holds one secret: a recovery phrase, a private key, or any bytes. The passkey ceremony produces the key material needed to decrypt it. The blob can live in `localStorage`, a backend, or a sync service. This pattern fits existing-account imports.
+## Status
 
-## Install
+mera is an experimental reference implementation. The documentation describes its [security model](https://determined-tenderness-production-79fe.up.railway.app/concepts/security-model/) and [known authenticator support](https://determined-tenderness-production-79fe.up.railway.app/concepts/authenticator-support/).
 
-```sh
-npm install @category-labs/mera
-```
+## Contributing
 
-The `@category-labs/mera/viem` entry point requires `viem` (^2.28.0) as an optional peer dependency; the root entry point does not use it.
+Issues and pull requests are welcome. See the [contribution guide](./CONTRIBUTING.md) and [code of conduct](./CODE_OF_CONDUCT.md).
 
-## Quick example
-
-A derived-mode example: one passkey ceremony, then app-owned BIP-39/BIP-32 key derivation with `@scure/bip32` and `@scure/bip39`, as in the demo.
-
-```ts
-import {
-  createSecp256k1SigningSession,
-  getEvmAddress,
-  getPasskeyPrfOutput,
-} from "@category-labs/mera"
-import { HDKey } from "@scure/bip32"
-import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39"
-import { wordlist } from "@scure/bip39/wordlists/english.js"
-
-const rpId = "account.example.com"
-
-const { prfOutput } = await getPasskeyPrfOutput({ rpId })
-
-// App-owned derivation: the PRF output is BIP-39 entropy, so the same phrase
-// imported into a standard wallet reproduces the same account.
-const mnemonic = entropyToMnemonic(prfOutput, wordlist)
-const seed = mnemonicToSeedSync(mnemonic)
-const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0")
-if (node.privateKey === null) throw new Error("derivation produced no key")
-
-const session = createSecp256k1SigningSession({
-  // Copy out of the HDKey so the signing session can own and later zero it.
-  consumePrivateKey: new Uint8Array(node.privateKey),
-})
-const address = getEvmAddress(session.publicKey)
-```
-
-Reusing one PRF output unchanged for unrelated purposes (key derivation and app-data encryption, say) links those secrets. Use a different PRF salt per purpose, or split one output with a purpose-labeled KDF.
-
-Derived flows use mera's fixed v1 salt internally. Secret-vault functions generate and store a fresh random salt for each secret.
-
-## Supported authenticators
-
-mera requires the WebAuthn PRF extension, discoverable credentials, and user verification. If the browser/OS/authenticator combination can't deliver PRF, the library throws `PRF_UNAVAILABLE`.
-
-`✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
-
-| Authenticator            | Browser                           | OS                          | Status                     | Supported since                              |
-| ------------------------ | --------------------------------- | --------------------------- | -------------------------- | -------------------------------------------- |
-| 1Password                | any browser with 1Password active | any                         | ✓                          | 2.26.1 beta / Android 8.10.38 beta (2024-07) |
-| iCloud Keychain          | Safari                            | iOS 18+                     | ✓                          | Safari 18 / iOS 18 (2024-09)                 |
-| iCloud Keychain          | Safari                            | macOS 15+                   | ✓                          | Safari 18 / macOS 15 (2024-09)               |
-| iCloud Keychain          | Chrome                            | macOS 15+                   | ✓                          | Chrome 132+ (2025-01)                        |
-| iCloud Keychain          | Chrome                            | iOS 18+                     | ✓                          | Safari 18 / iOS 18 (2024-09)                 |
-| iCloud Keychain          | Firefox                           | macOS 15+                   | ✓                          | Firefox 139+ (2025-05)                       |
-| Google Password Manager  | Chrome                            | Android                     | ✓                          | Known by 2026-06                             |
-| Google Password Manager  | Chrome                            | Desktop (signed-in)         | ✓                          | Chrome 132+ (2025-01)                        |
-| Chrome profile           | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
-| Google Password Manager  | Edge                              | Android                     | ✓                          | Known by 2026-06                             |
-| Windows Password Manager | Edge                              | Windows 11 25H2+            | ✓                          | Windows 11 25H2 + 2026-02 update             |
-| Windows Password Manager | Chrome                            | Windows 11 25H2+            | ✓                          | Chrome 147+ (2026-04)                        |
-| Windows Password Manager | Firefox 148+                      | Windows 11 25H2+            | ✓                          | Firefox 148+ (2026-02)                       |
-| YubiKey 5C Nano          | Chrome                            | Desktop                     | ✓                          | Chrome 116+; YubiKey 5.2+ hmac-secret        |
-| Bitwarden                | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
-| Dashlane                 | Chrome                            | Desktop                     | Not supported (2026-06-01) |                                              |
-| Proton Pass              | Chrome                            | Desktop                     | ✓                          | Latest public version (2026-06)              |
-
-On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local Chrome profile authenticator does not implement the CTAP2 `hmac-secret` extension, so a passkey created there returns `prf.enabled: false`.
-
-Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony.
-
-For the broader PRF compatibility matrix, see Corbado's [Passkeys & WebAuthn PRF for End-to-End Encryption](https://www.corbado.com/blog/passkeys-prf-webauthn).
-
-## API reference
-
-Names only; editor hover shows the full JSDoc.
-
-- **Passkey ceremonies**: `createPasskey`, `createPasskeyWithPrfOutput`, `getPasskeyPrfOutput`
-- **Deterministic PRF salt**: `getDeterministicPrfSaltV1`
-- **Signing sessions**: `createSecp256k1SigningSession`, `createEd25519SigningSession`
-- **Secret vault workflows**: `createSecretVaultWithNewPasskey`, `createSecretVaultWithExistingPasskey`, `decryptSecretVaultWithPasskey`
-- **Secret vault primitives**: `createSecretVault`, `decryptSecretVault`, `parseSecretVault`, `getSecretVaultPrfOutput`
-- **Chain addresses**: `getEvmAddress`, `isEvmAddress`, `getSolanaAddress`, `isSolanaAddress`
-- **viem adapter** (`@category-labs/mera/viem`): `toViemAccount`
-- **Errors**: `MeraError`, `isMeraError`, `MeraErrorCode`
-
-## Detailed docs
-
-Secret-vault flows, demo HD derivation recipes (BIP-39/BIP-32, SLIP-0010), the secret vault format, and the viem adapter live in the developer documentation.
-
-## Security
-
-A compromised JavaScript runtime can observe key material during app-owned derivation or import, and can sign with an active session until `session.lock()`. Recovery export should be handled as a separate app-owned flow that reruns WebAuthn PRF or decrypts a vault with fresh user verification.
-
-Recovery phrases become JavaScript strings when displayed or exported. Unlike `Uint8Array` buffers, strings cannot be zeroed in place; apps can only drop references and keep their lifetime short.
-
-mera zeroes owned byte buffers where possible, but host apps should treat revealed recovery phrases as high-risk UI state.
-
-**Dependency scope.** Runtime dependencies are `@noble/*` and `@scure/*` only. The root `devDependencies` (build/test tooling) and the unpublished `demo/` app never ship to library consumers.
-
-## Development
-
-```sh
-npm ci
-npm test            # build, typecheck the tests, run the full Playwright suite
-npm run test:e2e    # end-to-end passkey ceremonies only (virtual authenticator)
-npm run check       # Biome lint + format
-npm run check:pack  # verify the publishable tarball
-```
-
-The docs site is a standalone package; see [docs/README.md](./docs/README.md).
+mera is developed by [Category Labs](https://github.com/category-labs).
 
 ## License
 
-Licensed under either of [Apache License](./LICENSE-APACHE), Version
-2.0 or [MIT License](./LICENSE-MIT) at your option.
+Licensed under either the [Apache License 2.0](./LICENSE-APACHE) or the [MIT License](./LICENSE-MIT), at the licensee's option.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -31,7 +31,7 @@ Fixed section order:
 
 Parameters use subheadings and lists, never wide tables. The content column is narrow; a five-column table does not survive it. Tables are reserved for genuinely tabular data, like the authenticator matrix.
 
-Source of truth is the JSDoc in `src/`. Write reference prose from it, and check the README when the JSDoc is silent. When the two disagree, the code wins; flag the README in the PR.
+Source of truth is the JSDoc in `src/`. Write reference prose from it. When the JSDoc is silent, inspect the implementation and tests.
 
 ## Recipes
 
@@ -66,12 +66,12 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 
 ## Accuracy
 
-- Every claim must be checkable against the README or the JSDoc in `src/`.
+- Every claim must be checkable against the JSDoc, implementation, or tests.
 - Implementation details live only on the page that owns them: error codes and library internals on the reference, demo internals (derivation schemes, storage, UI) in the recipes that adapt its code. Every other page links to the owning page instead of restating the detail, so a demo or library change touches one page.
 - Examples import only the public API plus explicitly declared app-side dependencies.
 - Examples define every identifier they use. Values the app supplies enter through a placeholder with realistic shape and provenance: `crypto.getRandomValues(new Uint8Array(32))` for key material, `new TextEncoder().encode(...)` for secret text, a literal for addresses and rpIds. Never use an all-zero buffer where the library validates the value; an all-zero secp256k1 key throws.
 - Security-sensitive behavior is stated plainly on the page where the risk is acted on: key material lifetimes, zeroing, nonce handling, prompt counts, and what the library cannot protect against.
-- Support claims are date-stamped. The authenticator matrix lives in the README; this site mirrors it, and updates land in both places.
+- Support claims are date-stamped. The authenticator matrix lives on the authenticator-support page and is maintained there only.
 
 ## Mechanics
 


### PR DESCRIPTION
## Summary
- Reframe the root README as a short project overview and move installation, usage, compatibility, security, API, and demo details to the documentation site.
- Add `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md` to centralize contribution, security disclosure, and community policy guidance.
- Update AGENTS guidance so project workflow and documentation source-of-truth rules point to the new files.
- Add a PR template that prompts contributors to explain the motivation for changes.

## Testing
- Not run (not requested)