### PR TITLE
Deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,50 @@
+name: Mera - Docs Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - .github/workflows/docs-pages.yml
+  workflow_dispatch:
+
+# Keep a publishing deployment running while replacing any older queued run
+# with the latest docs build.
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build and upload docs
+        uses: withastro/action@v6
+        with:
+          path: docs
+          node-version: 24
+        env:
+          DOCS_SITE: https://category-labs.github.io
+          DOCS_BASE: /mera
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,10 +1,41 @@
 // @ts-check
+
+import { unified } from "@astrojs/markdown-remark";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import { visit } from "unist-util-visit";
+
+const site = process.env.DOCS_SITE;
+const configuredBase = process.env.DOCS_BASE;
+
+if (configuredBase && !configuredBase.startsWith("/")) {
+  throw new Error("DOCS_BASE must start with a forward slash");
+}
+
+const base = configuredBase?.replace(/\/+$/, "") ?? "";
+/** @param {string} path */
+const withBase = (path) => `${base}${path}`;
+const socialImage = site
+  ? new URL(withBase("/og.png"), site).href
+  : withBase("/og.png");
+
+/** @type {import("unified").Plugin<[], import("mdast").Root>} */
+const prefixRootRelativeLinks = () => (tree) => {
+  visit(tree, "link", (node) => {
+    if (node.url.startsWith("/")) {
+      node.url = withBase(node.url);
+    }
+  });
+};
 
 // https://astro.build/config
 export default defineConfig({
-  redirects: { "/demo": "/" },
+  site,
+  base: base || undefined,
+  redirects: { "/demo": withBase("/") },
+  markdown: {
+    processor: unified({ remarkPlugins: [prefixRootRelativeLinks] }),
+  },
   integrations: [
     starlight({
       title: "mera",
@@ -18,7 +49,7 @@ export default defineConfig({
       head: [
         {
           tag: "meta",
-          attrs: { property: "og:image", content: "/og.png" },
+          attrs: { property: "og:image", content: socialImage },
         },
         {
           tag: "meta",
@@ -46,7 +77,7 @@ export default defineConfig({
         },
         {
           tag: "meta",
-          attrs: { name: "twitter:image", content: "/og.png" },
+          attrs: { name: "twitter:image", content: socialImage },
         },
         {
           tag: "meta",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,10 +8,12 @@
       "name": "mera-docs",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/starlight": "^0.41.3",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "astro": "^7.0.2",
-        "sharp": "^0.34.5"
+        "sharp": "^0.34.5",
+        "unist-util-visit": "^5.1.0"
       },
       "engines": {
         "node": ">=24"

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,10 +9,12 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/starlight": "^0.41.3",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "astro": "^7.0.2",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "unist-util-visit": "^5.1.0"
   },
   "engines": {
     "node": ">=24"

--- a/docs/src/base-path.ts
+++ b/docs/src/base-path.ts
@@ -1,0 +1,8 @@
+const basePath = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+// Astro does not prefix literal links with the configured base path.
+function withBasePath(path: string): string {
+  return path.startsWith("/") ? `${basePath}${path}` : path;
+}
+
+export { withBasePath };

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -5,6 +5,7 @@ import SiteTitle from "virtual:starlight/components/SiteTitle";
 import SocialIcons from "virtual:starlight/components/SocialIcons";
 import ThemeSelect from "virtual:starlight/components/ThemeSelect";
 import config from "virtual:starlight/user-config";
+import { withBasePath } from "../base-path";
 
 // Match Starlight's default search behavior so an explicit Search override
 // can still opt in when Pagefind is disabled.
@@ -28,7 +29,7 @@ const shouldRenderSearch =
     </div>
     <ThemeSelect />
     <LanguageSelect />
-    <a class="header-cta" href="/getting-started/">
+    <a class="header-cta" href={withBasePath("/getting-started/")}>
       <span class="mobile-label">Get started</span>
       <span class="desktop-label">Getting started&nbsp;→</span>
     </a>

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -4,6 +4,7 @@
 // The title, tagline, and action buttons come from the page frontmatter; the
 // rest of the landing copy lives here.
 import { LinkButton } from "@astrojs/starlight/components";
+import { withBasePath } from "../base-path";
 import DemoEmbed from "./DemoEmbed.astro";
 
 const { data } = Astro.locals.starlightRoute.entry;
@@ -51,7 +52,7 @@ const features = [
               {String(index + 1).padStart(2, "0")}
             </span>
             <div>
-              <a href={feature.link}>{feature.title}</a>
+              <a href={withBasePath(feature.link)}>{feature.title}</a>
               <p>{feature.text}</p>
             </div>
           </li>
@@ -66,12 +67,12 @@ const features = [
             ({
               attrs: { class: className, ...attrs } = {},
               icon,
-              link: href,
+              link,
               text,
               variant,
             }) => (
               <LinkButton
-                {href}
+                href={withBasePath(link)}
                 {variant}
                 icon={icon?.name}
                 class:list={[className]}


### PR DESCRIPTION
This pull request introduces comprehensive support for custom documentation base paths and site URLs, improving the handling of root-relative links and social image URLs in the documentation site. It also adds a new GitHub Actions workflow to build and deploy documentation to GitHub Pages. These changes ensure the docs site can be seamlessly deployed under a subpath and that all internal links and metadata remain correct regardless of deployment configuration.

**Documentation base path and site URL handling:**

* Added environment-based configuration for `site` and `base` in `docs/astro.config.mjs`, with validation and utility functions to ensure all root-relative links and social image URLs are correctly prefixed with the configured base path. This includes a custom remark plugin to rewrite Markdown links and updates to Open Graph and Twitter image meta tags. [[1]](diffhunk://#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09fR2-R38) [[2]](diffhunk://#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09fL21-R52) [[3]](diffhunk://#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09fL49-R80)
* Introduced a `withBasePath` utility in `docs/src/base-path.ts` and refactored all relevant UI components (`Header.astro`, `Hero.astro`) to use this function for internal links, ensuring navigation works correctly when the site is deployed under a subpath. [[1]](diffhunk://#diff-0288112ce388e7c8cdeea101a9ac307b4304fc96341127d21b50f72c2054e326R1-R8) [[2]](diffhunk://#diff-de17232c85524d34e75340689237e9c5db61b28f8a195bf26c8eb6e63e929046R8) [[3]](diffhunk://#diff-de17232c85524d34e75340689237e9c5db61b28f8a195bf26c8eb6e63e929046L31-R32) [[4]](diffhunk://#diff-86655bf689908b6f80271679b87389491b7dca87cc676d5fc05c7fa872d320ecR7) [[5]](diffhunk://#diff-86655bf689908b6f80271679b87389491b7dca87cc676d5fc05c7fa872d320ecL54-R55) [[6]](diffhunk://#diff-86655bf689908b6f80271679b87389491b7dca87cc676d5fc05c7fa872d320ecL69-R75)

**Dependencies:**

* Added `@astrojs/markdown-remark` and `unist-util-visit` to `docs/package.json` and `docs/package-lock.json` to support the new Markdown link rewriting functionality. [[1]](diffhunk://#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56R12-R17) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R11-R16)

**CI/CD and deployment:**

* Added a new GitHub Actions workflow `.github/workflows/docs-pages.yml` to automate building and deploying the documentation site to GitHub Pages, with concurrency controls and environment variable support for deployment configuration.