### PR TITLE
Make derived mode the demo default, move vault behind a footer link

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -4,7 +4,6 @@ import { ConnectCard } from "./ConnectCard";
 import { type EthereumContext, getEthereumContext } from "./chains/ethereum";
 import { getSolanaContext, type SolanaContext } from "./chains/solana";
 import {
-  type AccountMode,
   type AccountSlot,
   type ConnectedWallet,
   type ConnectResult,
@@ -24,7 +23,6 @@ function App(): ReactElement {
   );
   const [solanaError, setSolanaError] = useState<string | null>(null);
 
-  const [mode, setMode] = useState<AccountMode>("derived");
   const [networkMode, setNetworkMode] = useState<NetworkMode>("testnet");
 
   const [wallet, setWallet] = useState<ConnectedWallet | null>(null);
@@ -144,11 +142,7 @@ function App(): ReactElement {
           onLock={handleLock}
         />
       ) : (
-        <ConnectCard
-          mode={mode}
-          onModeChange={setMode}
-          onConnected={handleConnected}
-        />
+        <ConnectCard onConnected={handleConnected} />
       )}
     </main>
   );

--- a/demo/src/ConnectCard.tsx
+++ b/demo/src/ConnectCard.tsx
@@ -8,45 +8,41 @@ import {
 } from "./connect";
 import { createMnemonic, isValidMnemonic } from "./hd";
 
-const MODES: { id: AccountMode; label: string; hint: string }[] = [
-  {
-    id: "derived",
-    label: "Derived",
-    hint: "Accounts are derived from the passkey. A synced passkey can reproduce the same addresses on another device.",
-  },
-  {
-    id: "vault",
-    label: "Vault",
-    hint: "The demo encrypts a generated or imported recovery phrase in a vault that opens with the passkey.",
-  },
-];
+const MODE_HINTS: Record<AccountMode, string> = {
+  derived:
+    "Accounts are derived from the passkey. A synced passkey can reproduce the same addresses on another device.",
+  vault:
+    "The demo encrypts a generated or imported recovery phrase in a vault that opens with the passkey.",
+};
 
 type Busy = "create" | "signin" | null;
 
 type ConnectCardProps = {
-  mode: AccountMode;
-  onModeChange: (mode: AccountMode) => void;
   onConnected: (result: ConnectResult) => void;
 };
 
-/** Connect view: pick a mode, then create or sign in with a single passkey ceremony. */
-function ConnectCard({
-  mode,
-  onModeChange,
-  onConnected,
-}: ConnectCardProps): ReactElement {
+/**
+ * Connect view: create or sign in with a single passkey ceremony. Derived mode
+ * is the default; a footer link below the card switches to vault mode for
+ * importing an existing recovery phrase.
+ */
+function ConnectCard({ onConnected }: ConnectCardProps): ReactElement {
+  const [mode, setMode] = useState<AccountMode>("derived");
   const [username, setUsername] = useState(DEFAULT_USER);
   const [secret, setSecret] = useState("");
   const [busy, setBusy] = useState<Busy>(null);
   const [error, setError] = useState<string | null>(null);
-
-  const activeMode = MODES.find((entry) => entry.id === mode) ?? MODES[0];
 
   const trimmedSecret = secret.trim();
   const secretValid = isValidMnemonic(trimmedSecret);
 
   function generate() {
     setSecret(createMnemonic());
+    setError(null);
+  }
+
+  function switchMode(next: AccountMode) {
+    setMode(next);
     setError(null);
   }
 
@@ -63,94 +59,103 @@ function ConnectCard({
   }
 
   return (
-    <section className="card">
-      <div className="segmented" role="tablist" aria-label="Account mode">
-        {MODES.map((entry) => (
+    <>
+      <section className="card">
+        <p className="hint">{MODE_HINTS[mode]}</p>
+
+        {mode === "vault" && (
+          <div className="secret">
+            <label className="field">
+              <span className="field-head">
+                Recovery phrase
+                <button
+                  type="button"
+                  className="link small"
+                  onClick={generate}
+                  disabled={busy !== null}
+                >
+                  Generate
+                </button>
+              </span>
+              <input
+                value={secret}
+                placeholder="Generate a recovery phrase, or paste one from a wallet app"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                onChange={(event) => setSecret(event.target.value)}
+                disabled={busy !== null}
+              />
+            </label>
+
+            {trimmedSecret.length > 0 && !secretValid && (
+              <p className="status error">
+                That is not a valid recovery phrase.
+              </p>
+            )}
+
+            <p className="hint">
+              The phrase is generated on the device or imported. Anyone with it
+              controls the account.
+            </p>
+          </div>
+        )}
+
+        <label className="field">
+          <span>Passkey name</span>
+          <input
+            value={username}
+            autoComplete="username"
+            spellCheck={false}
+            onChange={(event) => setUsername(event.target.value)}
+            disabled={busy !== null}
+          />
+        </label>
+        <p className="hint">This name is used only when creating a passkey.</p>
+
+        <div className="actions">
           <button
-            key={entry.id}
             type="button"
-            role="tab"
-            aria-selected={entry.id === mode}
-            className={entry.id === mode ? "segment active" : "segment"}
-            onClick={() => onModeChange(entry.id)}
+            className="btn primary"
+            onClick={() => run("create")}
+            disabled={busy !== null || (mode === "vault" && !secretValid)}
+          >
+            {busy === "create" ? "Waiting for passkey…" : "Create account"}
+          </button>
+          <button
+            type="button"
+            className="btn"
+            onClick={() => run("signin")}
             disabled={busy !== null}
           >
-            {entry.label}
+            {busy === "signin" ? "Waiting for passkey…" : "Sign in"}
           </button>
-        ))}
-      </div>
-      <p className="hint">{activeMode.hint}</p>
-
-      {mode === "vault" && (
-        <div className="secret">
-          <label className="field">
-            <span className="field-head">
-              Recovery phrase
-              <button
-                type="button"
-                className="link small"
-                onClick={generate}
-                disabled={busy !== null}
-              >
-                Generate
-              </button>
-            </span>
-            <input
-              value={secret}
-              placeholder="Generate a recovery phrase, or paste one from a wallet app"
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck={false}
-              onChange={(event) => setSecret(event.target.value)}
-              disabled={busy !== null}
-            />
-          </label>
-
-          {trimmedSecret.length > 0 && !secretValid && (
-            <p className="status error">That is not a valid recovery phrase.</p>
-          )}
-
-          <p className="hint">
-            The phrase is generated on the device or imported. Anyone with it
-            controls the account.
-          </p>
         </div>
+
+        {error && <p className="status error">{error}</p>}
+      </section>
+
+      {mode === "derived" ? (
+        <button
+          type="button"
+          className="mode-switch"
+          onClick={() => switchMode("vault")}
+          disabled={busy !== null}
+        >
+          Import existing secret →
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="mode-switch"
+          onClick={() => switchMode("derived")}
+          disabled={busy !== null}
+        >
+          ← Back to passkey accounts
+        </button>
       )}
-
-      <label className="field">
-        <span>Passkey name</span>
-        <input
-          value={username}
-          autoComplete="username"
-          spellCheck={false}
-          onChange={(event) => setUsername(event.target.value)}
-          disabled={busy !== null}
-        />
-      </label>
-      <p className="hint">This name is used only when creating a passkey.</p>
-
-      <div className="actions">
-        <button
-          type="button"
-          className="btn primary"
-          onClick={() => run("create")}
-          disabled={busy !== null || (mode === "vault" && !secretValid)}
-        >
-          {busy === "create" ? "Waiting for passkey…" : "Create account"}
-        </button>
-        <button
-          type="button"
-          className="btn"
-          onClick={() => run("signin")}
-          disabled={busy !== null}
-        >
-          {busy === "signin" ? "Waiting for passkey…" : "Sign in"}
-        </button>
-      </div>
-
-      {error && <p className="status error">{error}</p>}
-    </section>
+    </>
   );
 }
 

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -26,22 +26,33 @@
   box-sizing: border-box;
 }
 
+/* body and `#root` form a flex-column chain that hands the viewport height down
+   to `.app`, so `.app` can pin its footer link to the bottom of the page.
+   Horizontal centering stays on `.app` itself (`margin-inline: auto`): React
+   mounts into `<div id="root">` between body and `.app`, so centering applied
+   to body would center that full-width container instead. */
 body {
   margin: 0;
   min-height: 100vh;
   padding: 24px;
+  display: flex;
+  flex-direction: column;
   background: var(--bg);
   color: var(--text);
 }
 
+#root {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
 .app {
-  /* `margin-inline: auto` instead of body-level grid or flex centering. React mounts
-     into a `<div id="root">` between body and `.app`, so any centering applied
-     to body centers that container, which already fills the width. Self-centering
-     `.app` remains centered regardless of the container's layout. */
-  margin: 48px auto;
+  margin: 48px auto 0;
   width: min(420px, 100%);
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   gap: 18px;
 }
 
@@ -415,6 +426,32 @@ input:focus-visible {
 .field-head .link {
   text-transform: none;
   letter-spacing: normal;
+}
+
+/* Mode switch at the bottom of the connect screen: `margin-top: auto` pushes it
+   to the bottom of the viewport-filling `.app` column (and collapses to the
+   plain column gap when embedded, where the page hugs its content). Quiet by
+   default, accent on hover. */
+.mode-switch {
+  align-self: center;
+  margin-top: auto;
+  border: none;
+  background: none;
+  padding: 4px 8px;
+  color: var(--muted);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 550;
+  cursor: pointer;
+}
+
+.mode-switch:hover:not(:disabled) {
+  color: var(--accent);
+}
+
+.mode-switch:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
 .hint {


### PR DESCRIPTION
## Why

The demo's connect screen opened with a Derived/Vault segmented control that presented both modes as equal choices, while derived is the flow the demo is meant to showcase and vault exists mainly for importing an existing recovery phrase. The connect screen now opens directly on the derived card, and vault mode sits behind an "Import existing secret →" link pinned to the bottom of the page (with a "← Back to passkey accounts" link to return). Both connect paths in `connect.ts` are untouched, so vault mode keeps its full behavior — recovery-phrase validation, Generate, and the disabled states — just reached via the link.

## Notes for reviewers

- Mode state moved from `App` into `ConnectCard`, since the footer link must disable while a passkey ceremony is in flight and nothing outside the connect screen uses the mode anymore.
- To pin the link to the viewport bottom, `body`/`#root`/`.app` became a flex-column chain and `.app` switched from `grid` to an equivalent flex column; the link uses `margin-top: auto`. Verified in the browser that embedded mode (`data-embedded`) still hugs its content — the link collapses to the normal 18px gap below the card, so the iframe height reporting is unaffected.
- Manually verified standalone desktop and 375px mobile layouts, mode switching in both directions, and that Create account stays disabled in vault mode until a valid phrase is entered. The `.segmented` CSS stays because the chain toggle in the account view still uses it.

## Screenshots

| Derived (default) | Vault, via "Import existing secret" |
| --- | --- |
| ![connect-derived.png](https://github.com/user-attachments/assets/977096a0-b758-46fb-a2f0-56062c8220d4) | ![connect-vault.png](https://github.com/user-attachments/assets/ffe15783-35f5-4632-80ea-b1122dd53b35) |
