### PR TITLE
Record the new docs audience and passkey-account terminology in the writing guidance

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,6 +2,14 @@
 
 Guidance for authoring content in this site (`src/content/docs/`). [site/WRITING.md](../site/WRITING.md) governs voice for everything published under the mera name; this file adds the structure and mechanics specific to the docs site.
 
+## Audience
+
+The reader is a strong software engineer who may know none of blockchain, cryptography, or WebAuthn. Build explanations bottom-up: start from concrete pieces the reader can hold ("32 random bytes", "a 12-word phrase"), then assemble them into the larger mechanism.
+
+Define every complex concept or acronym on first mention in a page: one to three sentences, tied to the step the reader is in, linking the owning page for depth. Later mentions on the same page reuse the short name without re-explaining. The foundations concept page (`concepts/entropy-keys-and-accounts`) owns the blockchain background; glosses elsewhere link there rather than re-teaching it.
+
+Reference pages are exempt: they state facts and link to the page that teaches.
+
 ## Information architecture
 
 The site follows the Diátaxis split (<https://diataxis.fr/>): each page does one job.
@@ -47,6 +55,8 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 `site/WRITING.md` applies in full. The rules that carry the most weight here:
 
 - Say "account". "Wallet" is only for wallet apps: MetaMask, Phantom, the demo.
+- Say "passkey account", never "derived account". "Derive" survives as the verb: derive a key, a derivation path, address derivation.
+- Passkey accounts are the default path; secret vaults are the advanced option for secrets that predate the passkey. Never present the two as coequal alternatives.
 - Word choice fits technical documentation. Plain nouns over narrative or dramatic ones: "trade-offs", never "stories"; "complication", never "trap". A word that belongs in a blog headline gets replaced.
 - Calm explanation, no marketing. If a sentence would fit in a product brochure, rewrite it.
 - Named wallet apps are examples, never an exhaustive list.

--- a/site/WRITING.md
+++ b/site/WRITING.md
@@ -22,11 +22,11 @@ Editorial guidance for the content in `index.html` (the "A passkey is enough" ar
 
 ## Scope decisions
 
-- Audience: crypto/wallet developers. ERC-4337, EOAs, bundlers need no introduction; WebAuthn internals do.
+- Audience: strong software engineers who may know none of blockchain, cryptography, or WebAuthn. Define complex concepts and acronyms on first mention (one to three sentences, tied to the point being made); reuse the short name afterward. ERC-4337, EOAs, and bundlers need introduction too.
 - The library is an experimental reference implementation: no network-support claims ("EVM and Solana today"). The entropy is chain-agnostic — any KDF, any chain. Chains appear only as examples.
 - Keep the library/app boundary honest: mera produces entropy and signing sessions; derivation belongs to the app. Don't credit mera with what the demo does.
 - The secret-vault pattern stays conceptual: what it enables, not how it's implemented.
-- Derived accounts and secret vaults are parallel options with different trade-offs; don't frame one as fixing a constraint of the other.
+- Say "passkey account", never "derived account"; "derive" stays as the verb (derive a key, a derivation path). Passkey accounts are the default pattern; secret vaults are the advanced option, mainly for secrets that predate the passkey. Don't present the two as coequal alternatives.
 - Every technical claim should be checkable against the README or the code.
 - Don't reference sections by number ("as section 2 showed"); name the thing in place — headings will move.
 - The post is about the idea, not the repository: no code-location or housekeeping sections.


### PR DESCRIPTION
Reader feedback on the docs site said the content is good but dense, and that the cryptography used before the passkey step (entropy, derivation) is not explained. We decided to retarget the docs at strong software engineers who may not know blockchain, cryptography, or WebAuthn, rename the "derived accounts" concept to "passkey accounts", and reposition secret vaults as the advanced option rather than a coequal pattern.

This PR records those decisions in the guidance files first, so the content PRs stacked on top of it are reviewed against the new rules:

- `docs/AGENTS.md` gains an Audience section (bottom-up explanations, every complex concept or acronym defined in 1-3 sentences on first mention per page, reference pages exempt) and the terminology rules ("passkey account" never "derived account"; vaults are advanced, not parallel).
- `site/WRITING.md` scope decisions replace the old audience line ("crypto/wallet developers... need no introduction") and the old parallel-options framing, which now contradict the direction.

Stacked series: guidance (this PR) → foundations concept page → concept split + rename sweep → density passes → demo rename → site article.