### PR TITLE
Define cryptography and WebAuthn terms on first use in getting started and concepts

### DIFF
--- a/docs/src/content/docs/concepts/authenticator-support.md
+++ b/docs/src/content/docs/concepts/authenticator-support.md
@@ -29,7 +29,7 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 ## The desktop Chrome complication
 
-On desktop Chrome, only passkeys saved to Google Password Manager carry PRF; the local profile authenticator lacks the CTAP2 `hmac-secret` extension.
+On desktop Chrome, only passkeys saved to Google Password Manager carry PRF; the local profile authenticator lacks the CTAP2 [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) extension.
 
 Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but returns no PRF output, so mera cannot use it; [createPasskey](/reference/create-passkey/) documents the ordering caveat.
 

--- a/docs/src/content/docs/concepts/authenticator-support.md
+++ b/docs/src/content/docs/concepts/authenticator-support.md
@@ -3,7 +3,7 @@ title: Authenticator support
 description: Which authenticators deliver WebAuthn PRF, and since when.
 ---
 
-mera requires three things from the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification.
+mera requires three things from the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/) defines all three.
 
 In the table, `✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -3,7 +3,7 @@ title: Passkeys and the PRF extension
 description: What a passkey is, what the PRF extension adds, and why its output is stable.
 ---
 
-A passkey is a discoverable WebAuthn credential: a key pair created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
+A passkey is a discoverable WebAuthn credential. WebAuthn is the browser standard for signing in with key pairs instead of passwords; a credential is one such key pair, created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
 
@@ -13,11 +13,11 @@ A passkey is a discoverable WebAuthn credential: a key pair created at a website
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
 
-The requirement is not configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
+The requirement is not configurable. Authenticators built on `hmac-secret`, the CTAP primitive behind PRF (CTAP is the protocol browsers use to talk to authenticators), keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
 
 ## The PRF extension
 
-The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) gives each credential a pseudorandom function. The caller passes a 32-byte salt with the ceremony and the authenticator returns 32 bytes.
+The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) gives each credential a pseudorandom function: a function whose output looks random but is fully determined by its inputs. The caller passes a 32-byte salt with the ceremony and the authenticator returns 32 bytes.
 
 PRF output is determined by the credential, relying party ID, and salt. Those inputs produce the same 32 bytes on every synced device; a different salt produces unrelated output. Salts act as namespaces, which is why passkey accounts share one [fixed salt](/reference/get-deterministic-prf-salt-v1/) while each secret vault gets a fresh random one.
 
@@ -25,7 +25,7 @@ PRF output is determined by the credential, relying party ID, and salt. Those in
 
 The output is suitable as the root secret for accounts. It is stable wherever the passkey syncs, it appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony.
 
-Fed to a key-derivation scheme, the output produces a hierarchy of accounts; used as key material, it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
+Fed to a key-derivation scheme, the deterministic computation that turns one root secret into per-account keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)), the output produces a hierarchy of accounts; used as key material, it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
 
 ## Ceremonies and prompts
 
@@ -39,5 +39,6 @@ Signing itself never prompts: a [signing session](/concepts/signing-sessions/) h
 
 ## See also
 
+- [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): what the 32 bytes become once the app holds them.
 - [Authenticator support](/concepts/authenticator-support/): which stacks deliver PRF today.
 - [Getting started](/getting-started/): the ceremony-to-signature path in code.

--- a/docs/src/content/docs/concepts/passkeys-and-prf.md
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.md
@@ -3,7 +3,7 @@ title: Passkeys and the PRF extension
 description: What a passkey is, what the PRF extension adds, and why its output is stable.
 ---
 
-A passkey is a discoverable WebAuthn credential. WebAuthn is the browser standard for signing in with key pairs instead of passwords; a credential is one such key pair, created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
+A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords; a credential is one such key pair, created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
 
@@ -13,7 +13,7 @@ A passkey is a discoverable WebAuthn credential. WebAuthn is the browser standar
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
 
-The requirement is not configurable. Authenticators built on `hmac-secret`, the CTAP primitive behind PRF (CTAP is the protocol browsers use to talk to authenticators), keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
+The requirement is not configurable. Authenticators built on [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the CTAP primitive behind PRF ([CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) is the protocol browsers use to talk to authenticators), keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
 
 ## The PRF extension
 

--- a/docs/src/content/docs/concepts/security-model.md
+++ b/docs/src/content/docs/concepts/security-model.md
@@ -3,7 +3,7 @@ title: Security model
 description: What mera protects, what it cannot, and the risks left to the app.
 ---
 
-mera has a narrow scope: it runs passkey ceremonies, returns entropy to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/).
+mera has a narrow scope: it runs passkey ceremonies, returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/).
 
 ## What the library handles
 
@@ -11,7 +11,7 @@ Input buffers are copied before any async work starts, so mutating a buffer afte
 
 Owned copies are zeroed where possible. A signing session zeroes the caller's private-key buffer when it consumes it, even when construction throws, and zeroes its own copy on `lock()`. [createSecretVault](/reference/create-secret-vault/) zeroes its internal secret and PRF-output copies. Secret-vault workflow functions also zero the transient secret and PRF-output copies they own before settling.
 
-WebAuthn challenges are generated internally. So are AES-GCM nonces, 12 fresh bytes per encryption, which means a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
+WebAuthn challenges are generated internally. So are AES-GCM nonces: a nonce is a value that must never repeat under one encryption key, so the library generates 12 fresh bytes per encryption and a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
 
 ## What a compromised runtime sees
 
@@ -27,7 +27,7 @@ Treat the rpId as a long-lived choice. Before any planned migration, accounts ne
 
 ## One output, one purpose
 
-If one PRF output is reused for unrelated purposes, exposing it compromises them all. Use a different salt per purpose, or split one output with a purpose-labeled KDF.
+If one PRF output is reused for unrelated purposes, exposing it compromises them all. Use a different salt per purpose, or split one output with a purpose-labeled key-derivation function (KDF), a deterministic function that turns one secret into separate purpose-specific keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)).
 
 A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. The secret-vault creation functions generate a fresh random 32-byte salt for each secret; the [createSecretVault](/reference/create-secret-vault/) page documents the low-level requirement.
 

--- a/docs/src/content/docs/concepts/signing-sessions.md
+++ b/docs/src/content/docs/concepts/signing-sessions.md
@@ -5,11 +5,11 @@ description: How a session owns its private key, why signing never prompts, and 
 
 A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing.
 
-Two constructors exist, one per curve: [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests and [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
+Two constructors exist, one per signature scheme ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces both): [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests, a digest being the fixed-length hash of the content to sign, and [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 
 ## Independent of passkeys
 
-A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of entropy into a chain-specific private key, is app-owned by design; [passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of key material.
+A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design; [passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of key material.
 
 Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the ceremony that produced the entropy, and it covers any number of signatures.
 

--- a/docs/src/content/docs/concepts/signing-sessions.md
+++ b/docs/src/content/docs/concepts/signing-sessions.md
@@ -5,7 +5,7 @@ description: How a session owns its private key, why signing never prompts, and 
 
 A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing.
 
-Two constructors exist, one per signature scheme ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces both): [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests, a digest being the fixed-length hash of the content to sign, and [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
+Two constructors exist, one per signature scheme ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces both): [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests (a digest is the fixed-length hash of the content to sign) and [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 
 ## Independent of passkeys
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -22,7 +22,7 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a discoverable passkey and evaluates its PRF in one call. The PRF (pseudorandom function) is a function each passkey carries: pass it a salt, a 32-byte input that acts as a namespace, and it returns 32 bytes that are stable for that passkey and salt ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/)).
+`createPasskeyWithPrfOutput` creates a discoverable passkey and evaluates its PRF in one call. The PRF (pseudorandom function) is a function each passkey carries: given a salt, a 32-byte input acting as a namespace, it returns 32 bytes stable for that passkey and salt ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/)).
 
 ```ts
 import { createPasskeyWithPrfOutput } from "@category-labs/mera";
@@ -41,7 +41,7 @@ mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, t
 
 ## Derive an account
 
-The PRF output is entropy: 32 bytes an attacker cannot predict, strong enough to be the root of every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through BIP-39, the standard that encodes entropy as a phrase of common words, and BIP-32, the standard that derives numbered keys from one seed, so the account can be imported into wallet apps that speak those standards.
+The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through BIP-39, which encodes entropy as a phrase of common words, and BIP-32, which derives numbered keys from one seed, so the account can be imported into wallet apps that speak those standards.
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -56,7 +56,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`m/44'/60'/0'/0/0` is a BIP-44 derivation path, the address of one key in the tree BIP-32 grows from the seed; this one selects the first Ethereum account, the same key MetaMask derives first from an imported phrase.
+`m/44'/60'/0'/0/0` is a BIP-44 derivation path naming one key in the BIP-32 tree; this one selects the first Ethereum account, the key MetaMask derives first from an imported phrase.
 
 ## Sign
 
@@ -97,7 +97,7 @@ Without `credential`, the browser offers any discoverable passkey it holds for t
 
 ## Where next
 
-- [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): the background for every term this page glossed in passing.
+- [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): the background behind the terms this page glosses.
 - [Create passkey accounts](/recipes/create-passkey-accounts/): numbered accounts, credential pinning, Solana keys.
 - [Passkey accounts](/concepts/passkey-accounts/): why the same passkey reproduces the same accounts, and what losing it means.
 - [Secret vaults](/concepts/secret-vaults/): encrypting a secret that already exists behind the passkey.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -41,7 +41,7 @@ mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, t
 
 ## Derive an account
 
-The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through BIP-39, which encodes entropy as a phrase of common words, and BIP-32, which derives numbered keys from one seed, so the account can be imported into wallet apps that speak those standards.
+The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), which encodes entropy as a phrase of common words, and [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), which derives numbered keys from one seed, so the account can be imported into wallet apps that speak those standards.
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -56,7 +56,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`m/44'/60'/0'/0/0` is a BIP-44 derivation path naming one key in the BIP-32 tree; this one selects the first Ethereum account, the key MetaMask derives first from an imported phrase.
+`m/44'/60'/0'/0/0` is a [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) derivation path naming one key in the BIP-32 tree; this one selects the first Ethereum account, the key MetaMask derives first from an imported phrase.
 
 ## Sign
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -22,7 +22,7 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a discoverable passkey and evaluates its PRF in one call.
+`createPasskeyWithPrfOutput` creates a discoverable passkey and evaluates its PRF in one call. The PRF (pseudorandom function) is a function each passkey carries: pass it a salt, a 32-byte input that acts as a namespace, and it returns 32 bytes that are stable for that passkey and salt ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/)).
 
 ```ts
 import { createPasskeyWithPrfOutput } from "@category-labs/mera";
@@ -37,11 +37,11 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 
 The call prompts once or twice when the authenticator needs a follow-up assertion to evaluate PRF.
 
-mera uses its fixed v1 salt for this call. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID; [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
+mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID; [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 
-The PRF output is entropy. This walkthrough maps it through BIP-39 and BIP-32 so the account can be imported into wallet apps that speak those standards.
+The PRF output is entropy: 32 bytes an attacker cannot predict, strong enough to be the root of every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through BIP-39, the standard that encodes entropy as a phrase of common words, and BIP-32, the standard that derives numbered keys from one seed, so the account can be imported into wallet apps that speak those standards.
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -55,6 +55,8 @@ const seed = mnemonicToSeedSync(mnemonic);
 const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
+
+`m/44'/60'/0'/0/0` is a BIP-44 derivation path, the address of one key in the tree BIP-32 grows from the seed; this one selects the first Ethereum account, the same key MetaMask derives first from an imported phrase.
 
 ## Sign
 
@@ -95,6 +97,7 @@ Without `credential`, the browser offers any discoverable passkey it holds for t
 
 ## Where next
 
+- [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): the background for every term this page glossed in passing.
 - [Create passkey accounts](/recipes/create-passkey-accounts/): numbered accounts, credential pinning, Solana keys.
 - [Passkey accounts](/concepts/passkey-accounts/): why the same passkey reproduces the same accounts, and what losing it means.
 - [Secret vaults](/concepts/secret-vaults/): encrypting a secret that already exists behind the passkey.


### PR DESCRIPTION
Stacked on #155.

The docs feedback said the material before the passkey step (entropy, derivation) is unexplained for readers outside blockchain and cryptography. This PR applies the define-on-first-use rule from #153 to the tutorial and the concept pages: each complex term gets a 1-3 sentence gloss at its first mention, tied to the step the reader is in, with the foundations page (#154) carrying the depth.

Terms covered: PRF and salt (getting started, passkeys-and-prf), rpId, entropy (linked to the foundations page at each first use), BIP-39/BIP-32/BIP-44 path, WebAuthn, CTAP and hmac-secret, pseudorandom function, key-derivation scheme, digest, nonce, KDF. Reference pages are untouched per the rule's exemption.

Review focus: whether any gloss restates what its page already said nearby, and whether the getting-started additions keep the walkthrough readable.