### PR TITLE
Define seeds, paths, and derivation standards on first use in the recipes

### DIFF
--- a/docs/src/content/docs/recipes/create-passkey-accounts.md
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.md
@@ -131,7 +131,7 @@ function deriveSolanaAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-The derivation paths are an app choice; these two are the shared wallet conventions. A phrase imported into a wallet app that speaks them (MetaMask and Phantom are two) reproduces the same addresses, so accounts keep an exit path that does not depend on mera.
+The derivation paths are an app choice; these two are the shared wallet conventions. A phrase imported into a wallet app that follows them (MetaMask and Phantom are two) reproduces the same addresses, so accounts keep an exit path that does not depend on mera.
 
 Build the account list from these helpers:
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.md
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.md
@@ -5,7 +5,7 @@ description: Numbered EVM and Solana accounts from a single ceremony, with crede
 
 This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM and Solana accounts, credential pinning, one passkey ceremony per session, and locking.
 
-Derivation and storage are app-owned; mera provides the ceremonies and signing sessions.
+Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
 Prerequisites: `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/concepts/authenticator-support/)).
 
@@ -68,7 +68,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a master seed for the session
 
-Turn the PRF output into a BIP-39 master seed once, zero the output, and keep the seed in memory for the session; deriving account 3 later is pure HD math with no further prompt.
+Turn the PRF output into a BIP-39 master seed once, zero the output, and keep the seed in memory for the session. The master seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -82,7 +82,7 @@ prfOutput.fill(0);
 
 ## Derive numbered accounts
 
-EVM accounts follow BIP-32 over the BIP-44 Ethereum path, the MetaMask convention:
+EVM accounts follow BIP-32 over the BIP-44 Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:
 
 ```ts
 import {
@@ -101,7 +101,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses SLIP-0010 hardened Ed25519 derivation on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use. Ed25519 supports only hardened steps, so the implementation is a short HMAC chain:
+Solana uses SLIP-0010, the Ed25519 counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {

--- a/docs/src/content/docs/recipes/create-passkey-accounts.md
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.md
@@ -68,7 +68,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a master seed for the session
 
-Turn the PRF output into a BIP-39 master seed once, zero the output, and keep the seed in memory for the session. The master seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) master seed once, zero the output, and keep the seed in memory for the session. The master seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -82,7 +82,7 @@ prfOutput.fill(0);
 
 ## Derive numbered accounts
 
-EVM accounts follow BIP-32 over the BIP-44 Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:
+EVM accounts follow [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) over the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:
 
 ```ts
 import {
@@ -101,7 +101,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses SLIP-0010, the Ed25519 counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
+Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the Ed25519 counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the BIP-39 word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A secret vault encrypts one recovery phrase, private key, or other byte string behind a passkey; mera never interprets it. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the BIP-39 word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 


### PR DESCRIPTION
Stacked on #156.

The recipes are the densest pages in the docs for a reader outside blockchain: master seed, HD math, BIP-44 paths, SLIP-0010, hardened steps, and HMAC all appeared without introduction. This PR applies the define-on-first-use rule to both recipes, keeping each gloss to a clause or sentence attached to the code it explains: the path-shape convention next to the BIP-44 path, the hardened-step definition next to the HMAC chain that exists because of it, and coin types 60 and 501 next to the literals in the code.

Both recipe intros now also point readers to the foundations page (#154) for the background, and the vault recipe opens by positioning the vault as the pattern for secrets that predate the passkey, matching the framing from #155.