### PR TITLE
Rename the article's derived mode to passkey accounts and fix the stale demo description

### DIFF
--- a/demo/src/AccountCard.tsx
+++ b/demo/src/AccountCard.tsx
@@ -35,7 +35,7 @@ type AccountCardProps = {
 };
 
 /**
- * Account view: an account selector (derived mode only), then a chain toggle,
+ * Account view: an account selector (passkey mode only), then a chain toggle,
  * then the chain-specific card for the active account.
  *
  * Switching accounts or chains never triggers a passkey ceremony because every
@@ -81,7 +81,7 @@ function AccountCard({
   // bump appears until the account is revealed.
   const isTestnet = networkMode === "testnet";
   const suggestion = useMemo(() => {
-    if (!isTestnet || wallet.mode !== "derived") return null;
+    if (!isTestnet || wallet.mode !== "passkey") return null;
     const index = active.index === 0 ? 1 : 0;
     return {
       index,
@@ -142,7 +142,7 @@ function AccountCard({
 
   return (
     <div className="account-shell">
-      {wallet.mode === "derived" && (
+      {wallet.mode === "passkey" && (
         <div className="account-bar">
           <div className="account-pills" role="tablist" aria-label="Account">
             {accounts.map((slot) => (

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -9,7 +9,7 @@ import {
   type ConnectResult,
   describeError,
 } from "./connect";
-import { setDerivedAccountCount } from "./derivedWallet";
+import { setPasskeyAccountCount } from "./passkeyWallet";
 import type { NetworkMode } from "./network";
 
 /** Root component: holds the connected wallet + accounts, fetches network info. */
@@ -65,11 +65,11 @@ function App(): ReactElement {
 
   function handleConnected(result: ConnectResult) {
     setWallet(result.wallet);
-    // Derived wallets start with two accounts so transfers between demo accounts
+    // Passkey wallets start with two accounts so transfers between demo accounts
     // work immediately: the second pill is visible and the recipient chip points
     // at a real account. Vault mode has a single account.
     const count =
-      result.wallet.mode === "derived"
+      result.wallet.mode === "passkey"
         ? Math.max(result.accountCount, 2)
         : result.accountCount;
     setAccounts(
@@ -78,18 +78,18 @@ function App(): ReactElement {
       ),
     );
     setActiveIndex(0);
-    if (result.wallet.mode === "derived" && count !== result.accountCount) {
-      setDerivedAccountCount(count);
+    if (result.wallet.mode === "passkey" && count !== result.accountCount) {
+      setPasskeyAccountCount(count);
     }
   }
 
   function handleAddAccount() {
-    if (wallet?.mode !== "derived") return;
+    if (wallet?.mode !== "passkey") return;
     const next = wallet.deriveAccount(accounts.length);
     const updated = [...accounts, next];
     setAccounts(updated);
     setActiveIndex(next.index);
-    setDerivedAccountCount(updated.length);
+    setPasskeyAccountCount(updated.length);
   }
 
   function handleLock() {

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -9,8 +9,8 @@ import {
   type ConnectResult,
   describeError,
 } from "./connect";
-import { setPasskeyAccountCount } from "./passkeyWallet";
 import type { NetworkMode } from "./network";
+import { setPasskeyAccountCount } from "./passkeyWallet";
 
 /** Root component: holds the connected wallet + accounts, fetches network info. */
 function App(): ReactElement {

--- a/demo/src/ChainAccountCard.tsx
+++ b/demo/src/ChainAccountCard.tsx
@@ -89,7 +89,7 @@ function ChainAccountCard({
     feeReserve: bigint;
   } | null>(null);
   // Pre-fill a one-click self-transfer when a suggested recipient is offered
-  // (testnet, derived). The card remounts per account, so these initializers
+  // (testnet, passkey). The card remounts per account, so these initializers
   // re-seed on every account switch.
   const [to, setTo] = useState(() => suggestion?.address ?? "");
   const [amount, setAmount] = useState(() =>
@@ -303,7 +303,7 @@ function ChainAccountCard({
         {signed && (
           <details className="reveal" open>
             <summary>
-              {mode === "derived"
+              {mode === "passkey"
                 ? "The transaction was signed locally with a passkey-derived key."
                 : "The transaction was signed locally with a key derived from the recovery phrase."}
             </summary>

--- a/demo/src/ConnectCard.tsx
+++ b/demo/src/ConnectCard.tsx
@@ -9,7 +9,7 @@ import {
 import { createMnemonic, isValidMnemonic } from "./hd";
 
 const MODE_HINTS: Record<AccountMode, string> = {
-  derived:
+  passkey:
     "Accounts are derived from the passkey. A synced passkey can reproduce the same addresses on another device.",
   vault:
     "The demo encrypts a generated or imported recovery phrase in a vault that opens with the passkey.",
@@ -22,12 +22,12 @@ type ConnectCardProps = {
 };
 
 /**
- * Connect view: create or sign in with a single passkey ceremony. Derived mode
+ * Connect view: create or sign in with a single passkey ceremony. Passkey mode
  * is the default; a footer link below the card switches to vault mode for
  * importing an existing recovery phrase.
  */
 function ConnectCard({ onConnected }: ConnectCardProps): ReactElement {
-  const [mode, setMode] = useState<AccountMode>("derived");
+  const [mode, setMode] = useState<AccountMode>("passkey");
   const [username, setUsername] = useState(DEFAULT_USER);
   const [secret, setSecret] = useState("");
   const [busy, setBusy] = useState<Busy>(null);
@@ -136,7 +136,7 @@ function ConnectCard({ onConnected }: ConnectCardProps): ReactElement {
         {error && <p className="status error">{error}</p>}
       </section>
 
-      {mode === "derived" ? (
+      {mode === "passkey" ? (
         <button
           type="button"
           className="mode-switch"
@@ -149,7 +149,7 @@ function ConnectCard({ onConnected }: ConnectCardProps): ReactElement {
         <button
           type="button"
           className="mode-switch"
-          onClick={() => switchMode("derived")}
+          onClick={() => switchMode("passkey")}
           disabled={busy !== null}
         >
           ← Back to passkey accounts

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -13,7 +13,7 @@ import {
   parseSecretVault,
   type Secp256k1SigningSession,
 } from "@category-labs/mera";
-import { currentDerivedWallet, rememberDerivedWallet } from "./derivedWallet";
+import { currentPasskeyWallet, rememberPasskeyWallet } from "./passkeyWallet";
 import {
   deriveEthereumPrivateKey,
   deriveSolanaSeed,
@@ -23,7 +23,7 @@ import {
 } from "./hd";
 
 /** The two account modes the demo offers. */
-type AccountMode = "vault" | "derived";
+type AccountMode = "vault" | "passkey";
 
 /** One numbered account with a signing session per chain. */
 type AccountSlot = {
@@ -41,14 +41,14 @@ type AccountSlot = {
 /**
  * A connected wallet with one passkey ceremony's worth of authority.
  *
- * Derived mode holds the BIP-39 master seed for the session and can mint more
+ * Passkey mode holds the BIP-39 master seed for the session and can mint more
  * numbered HD accounts with no further passkey prompt. Vault mode exposes the
  * single decrypted account from its vault. Either way, `lock()` zeroes every
  * secret the wallet still holds.
  */
 type ConnectedWallet = {
   mode: AccountMode;
-  /** Credential to pin when re-running a ceremony for this wallet; derived mode only, absent otherwise. */
+  /** Credential to pin when re-running a ceremony for this wallet; passkey mode only, absent otherwise. */
   credentialId?: string;
   /** Returns the account at `index`, deriving and caching it on first use. */
   deriveAccount(index: number): AccountSlot;
@@ -88,17 +88,17 @@ function deriveSlotFromSeed(seed: Uint8Array, index: number): AccountSlot {
   };
 }
 
-// ----- Derived mode: one PRF output is the HD master for every account -------
+// ----- Passkey mode: one PRF output is the HD master for every account -------
 
 /**
- * Builds a derived-mode wallet from a single PRF output.
+ * Builds a passkey-mode wallet from a single PRF output.
  *
  * The PRF output becomes a BIP-39 master seed held in memory for the session,
  * exactly like the signing keys are, and is zeroed alongside them on `lock()`.
  * Holding it lets "Add account" derive a new HD account without another
  * ceremony. The demo runs one ceremony per session rather than per account.
  */
-function buildDerivedWallet(
+function buildPasskeyWallet(
   prfOutput: Uint8Array,
   credentialId: string,
 ): ConnectedWallet {
@@ -113,7 +113,7 @@ function buildDerivedWallet(
   const cache = new Map<number, AccountSlot>();
 
   return {
-    mode: "derived",
+    mode: "passkey",
     credentialId,
     deriveAccount(index): AccountSlot {
       const cached = cache.get(index);
@@ -137,7 +137,7 @@ function buildDerivedWallet(
   };
 }
 
-async function createDerived(label: string): Promise<ConnectResult> {
+async function createPasskeyWallet(label: string): Promise<ConnectResult> {
   // `user.id` is left to default (32 random bytes), so every "Create" is a
   // distinct, parallel passkey rather than silently overwriting an existing one.
   const credential = await createPasskeyWithPrfOutput({
@@ -145,24 +145,24 @@ async function createDerived(label: string): Promise<ConnectResult> {
     user: { name: label, displayName: label },
   });
 
-  rememberDerivedWallet({
+  rememberPasskeyWallet({
     credentialId: credential.credentialId,
     transports: credential.transports,
     label,
     accountCount: 1,
   });
 
-  const wallet = buildDerivedWallet(
+  const wallet = buildPasskeyWallet(
     credential.prfOutput,
     credential.credentialId,
   );
   return { wallet, accountCount: 1 };
 }
 
-async function openDerived(): Promise<ConnectResult> {
+async function openPasskeyWallet(): Promise<ConnectResult> {
   // Pin to the passkey created on this device when we know it; otherwise fall
   // back to a discoverable credential so a freshly synced device still works.
-  const known = currentDerivedWallet();
+  const known = currentPasskeyWallet();
   const { prfOutput, credentialId } = await getPasskeyPrfOutput({
     rpId,
     credential: known?.credentialId
@@ -175,14 +175,14 @@ async function openDerived(): Promise<ConnectResult> {
   const record = known?.credentialId === credentialId ? known : undefined;
   const label = record?.label ?? DEFAULT_USER;
   const accountCount = record?.accountCount ?? 1;
-  rememberDerivedWallet({
+  rememberPasskeyWallet({
     credentialId,
     transports: record?.transports,
     label,
     accountCount,
   });
 
-  const wallet = buildDerivedWallet(prfOutput, credentialId);
+  const wallet = buildPasskeyWallet(prfOutput, credentialId);
   return { wallet, accountCount };
 }
 
@@ -279,11 +279,11 @@ function buildVaultWallet(slot: AccountSlot): ConnectedWallet {
 /**
  * Connects a wallet for the chosen mode and action.
  *
- * One passkey ceremony unlocks the wallet; in derived mode every numbered
+ * One passkey ceremony unlocks the wallet; in passkey mode every numbered
  * account afterwards is pure HD math with no further prompt.
  *
  * `secret` is the recovery phrase a vault-backed account is created from; every
- * other path (derived, or signing back into an existing secret vault) ignores
+ * other path (passkey, or signing back into an existing secret vault) ignores
  * it, so it is optional.
  */
 function connect(
@@ -298,13 +298,13 @@ function connect(
       ? createVaultAccount(label, secret ?? "")
       : unlockVaultAccount();
   }
-  return action === "create" ? createDerived(label) : openDerived();
+  return action === "create" ? createPasskeyWallet(label) : openPasskeyWallet();
 }
 
 /**
  * Reveals a wallet's BIP-39 recovery phrase behind a fresh passkey ceremony.
  *
- * Derived wallets re-derive the phrase from the passkey PRF output; vault-backed
+ * Passkey wallets re-derive the phrase from the passkey PRF output; vault-backed
  * wallets decrypt the generated or imported phrase from the secret vault.
  * Either way, the mnemonic is fetched on demand after fresh user verification.
  * PRF output and decrypted secret bytes are zeroed where possible before the
@@ -316,7 +316,7 @@ async function revealMnemonic(wallet: ConnectedWallet): Promise<string> {
     return decryptStoredVaultPhrase();
   }
 
-  const record = currentDerivedWallet();
+  const record = currentPasskeyWallet();
   const { prfOutput } = await getPasskeyPrfOutput({
     rpId,
     credential: wallet.credentialId

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -13,7 +13,6 @@ import {
   parseSecretVault,
   type Secp256k1SigningSession,
 } from "@category-labs/mera";
-import { currentPasskeyWallet, rememberPasskeyWallet } from "./passkeyWallet";
 import {
   deriveEthereumPrivateKey,
   deriveSolanaSeed,
@@ -21,6 +20,7 @@ import {
   mnemonicToSeed,
   prfOutputToMnemonic,
 } from "./hd";
+import { currentPasskeyWallet, rememberPasskeyWallet } from "./passkeyWallet";
 
 /** The two account modes the demo offers. */
 type AccountMode = "vault" | "passkey";

--- a/demo/src/passkeyWallet.ts
+++ b/demo/src/passkeyWallet.ts
@@ -1,7 +1,7 @@
 import type { PasskeyCredentialTransport } from "@category-labs/mera";
 
 /**
- * Non-secret metadata for a derived wallet created on this device.
+ * Non-secret metadata for a passkey wallet created on this device.
  *
  * It holds no key material. The app uses it to pin the right passkey with
  * `allowCredentials` on the next same-device sign-in instead of showing every
@@ -9,39 +9,39 @@ import type { PasskeyCredentialTransport } from "@category-labs/mera";
  * wallet had derived so sign-in can restore them. A fresh device has no record
  * and falls back to a discoverable sign-in.
  */
-type DerivedWalletRecord = {
+type PasskeyWalletRecord = {
   credentialId: string;
   transports?: readonly PasskeyCredentialTransport[];
   label: string;
   accountCount: number;
 };
 
-const STORAGE_KEY = "mera.demo.derivedWallet";
+const STORAGE_KEY = "mera.demo.passkeyWallet";
 
-function currentDerivedWallet(): DerivedWalletRecord | undefined {
+function currentPasskeyWallet(): PasskeyWalletRecord | undefined {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return undefined;
     const parsed: unknown = JSON.parse(raw);
-    return isDerivedWalletRecord(parsed) ? parsed : undefined;
+    return isPasskeyWalletRecord(parsed) ? parsed : undefined;
   } catch {
     return undefined;
   }
 }
 
-function rememberDerivedWallet(record: DerivedWalletRecord): void {
+function rememberPasskeyWallet(record: PasskeyWalletRecord): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
 }
 
 /** Persists a new account count so a later sign-in restores every account. */
-function setDerivedAccountCount(accountCount: number): void {
-  const existing = currentDerivedWallet();
-  if (existing) rememberDerivedWallet({ ...existing, accountCount });
+function setPasskeyAccountCount(accountCount: number): void {
+  const existing = currentPasskeyWallet();
+  if (existing) rememberPasskeyWallet({ ...existing, accountCount });
 }
 
-function isDerivedWalletRecord(value: unknown): value is DerivedWalletRecord {
+function isPasskeyWalletRecord(value: unknown): value is PasskeyWalletRecord {
   if (!value || typeof value !== "object") return false;
-  const record = value as Partial<DerivedWalletRecord>;
+  const record = value as Partial<PasskeyWalletRecord>;
   return (
     typeof record.credentialId === "string" &&
     typeof record.label === "string" &&
@@ -49,4 +49,4 @@ function isDerivedWalletRecord(value: unknown): value is DerivedWalletRecord {
   );
 }
 
-export { currentDerivedWallet, rememberDerivedWallet, setDerivedAccountCount };
+export { currentPasskeyWallet, rememberPasskeyWallet, setPasskeyAccountCount };

--- a/docs/src/content/docs/recipes/create-passkey-accounts.md
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.md
@@ -131,7 +131,7 @@ function deriveSolanaAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-The derivation paths are an app choice; these two are the shared wallet conventions. A phrase imported into a wallet app that speaks them (MetaMask and Phantom are two) reproduces the same addresses, so accounts keep an exit path that does not depend on mera.
+The derivation paths are an app choice; these two are the shared wallet conventions. A phrase imported into a wallet app that follows them (MetaMask and Phantom are two) reproduces the same addresses, so accounts keep an exit path that does not depend on mera.
 
 Build the account list from these helpers:
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.md
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.md
@@ -5,7 +5,7 @@ description: Numbered EVM and Solana accounts from a single ceremony, with crede
 
 This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM and Solana accounts, credential pinning, one passkey ceremony per session, and locking.
 
-Derivation and storage are app-owned; mera provides the ceremonies and signing sessions.
+Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
 Prerequisites: `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/concepts/authenticator-support/)).
 
@@ -68,7 +68,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a master seed for the session
 
-Turn the PRF output into a BIP-39 master seed once, zero the output, and keep the seed in memory for the session; deriving account 3 later is pure HD math with no further prompt.
+Turn the PRF output into a BIP-39 master seed once, zero the output, and keep the seed in memory for the session. The master seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -82,7 +82,7 @@ prfOutput.fill(0);
 
 ## Derive numbered accounts
 
-EVM accounts follow BIP-32 over the BIP-44 Ethereum path, the MetaMask convention:
+EVM accounts follow BIP-32 over the BIP-44 Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:
 
 ```ts
 import {
@@ -101,7 +101,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses SLIP-0010 hardened Ed25519 derivation on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use. Ed25519 supports only hardened steps, so the implementation is a short HMAC chain:
+Solana uses SLIP-0010, the Ed25519 counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {

--- a/docs/src/content/docs/recipes/create-passkey-accounts.md
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.md
@@ -68,7 +68,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a master seed for the session
 
-Turn the PRF output into a BIP-39 master seed once, zero the output, and keep the seed in memory for the session. The master seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) master seed once, zero the output, and keep the seed in memory for the session. The master seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -82,7 +82,7 @@ prfOutput.fill(0);
 
 ## Derive numbered accounts
 
-EVM accounts follow BIP-32 over the BIP-44 Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:
+EVM accounts follow [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) over the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:
 
 ```ts
 import {
@@ -101,7 +101,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses SLIP-0010, the Ed25519 counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
+Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the Ed25519 counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the BIP-39 word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A secret vault encrypts one recovery phrase, private key, or other byte string behind a passkey; mera never interprets it. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the BIP-39 word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 

--- a/site/index.html
+++ b/site/index.html
@@ -657,10 +657,10 @@ clientDataJSON
           it.
         </p>
 
-        <h3 id="derived-mode">Derived mode</h3>
+        <h3 id="passkey-accounts">Passkey accounts</h3>
 
         <p>
-          In derived mode the account is computed from the passkey. mera's PRF
+          A passkey account is computed from the passkey. mera's PRF
           output methods use a fixed v1 salt by default, so the same passkey
           yields the same account. The application runs the passkey-derived
           bytes through its derivation scheme of choice; mera's demo wallet app
@@ -815,8 +815,8 @@ const session = createSecp256k1SigningSession({
 const address = getEvmAddress(session.publicKey)</code></pre>
 
         <p>
-          Derived mode stores no database row, localStorage entry, or vault
-          blob. Sign in on a new device with the synced passkey, and the same
+          A passkey account stores no database row, localStorage entry, or
+          vault blob. Sign in on a new device with the synced passkey, and the same
           account appears. Cross-device use follows the password manager's
           normal sync and security assumptions. Because the derivation is
           standard, the application can offer an explicit export: the entropy
@@ -951,7 +951,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
             <thead>
               <tr>
                 <td></td>
-                <th scope="col">Derived</th>
+                <th scope="col">Passkey account</th>
                 <th scope="col">Secret vault</th>
               </tr>
             </thead>
@@ -981,16 +981,18 @@ const address = getEvmAddress(session.publicKey)</code></pre>
         </div>
 
         <p>
-          An application can mix the patterns: derive new accounts or use secret
-          vaults for existing recovery phrases or keys.
+          An application can mix the patterns: passkey accounts for new accounts,
+          secret vaults for existing recovery phrases or keys.
         </p>
 
         <h2 id="try-it">Try it</h2>
 
         <p>
-          The demo below runs both patterns. Create a passkey or sign in with an
-          existing one, switch between Derived and Vault, see Ethereum and
-          Solana addresses, and reveal the recovery phrase in either pattern.
+          The demo below runs both patterns. It opens with passkey accounts;
+          create a passkey or sign in with an existing one, see Ethereum and
+          Solana addresses, and reveal the recovery phrase. The link under the
+          card switches to the secret-vault flow for importing an existing
+          phrase.
         </p>
 
         <figure class="demo">
@@ -1048,15 +1050,15 @@ const address = getEvmAddress(session.publicKey)</code></pre>
         <ul>
           <li>
             <strong>The app stores less key material.</strong>
-            The derived pattern stores no app-owned secret. The secret-vault
+            The passkey-account pattern stores no app-owned secret. The secret-vault
             pattern stores a vault blob that still needs the passkey ceremony,
             and locking is one call.
           </li>
           <li>
-            <strong>Derived mode has no chain infrastructure.</strong>
-            It needs no contracts, bundlers, paymasters, executor accounts, key
-            servers, or provider dependencies. It also needs no server-side
-            account state.
+            <strong>Passkey accounts have no chain infrastructure.</strong>
+            They need no contracts, bundlers, paymasters, executor accounts,
+            key servers, or provider dependencies. They also need no
+            server-side account state.
           </li>
           <li>
             <strong>The dependency surface is small.</strong>

--- a/site/index.html
+++ b/site/index.html
@@ -660,11 +660,11 @@ clientDataJSON
         <h3 id="passkey-accounts">Passkey accounts</h3>
 
         <p>
-          A passkey account is computed from the passkey. mera's PRF
-          output methods use a fixed v1 salt by default, so the same passkey
-          yields the same account. The application runs the passkey-derived
-          bytes through its derivation scheme of choice; mera's demo wallet app
-          feeds them into BIP-39 and derives keys with
+          A passkey account is computed from the passkey. mera's PRF output
+          methods use a fixed v1 salt by default, so the same passkey yields the
+          same account. The application runs the passkey-derived bytes through
+          its derivation scheme of choice; mera's demo wallet app feeds them
+          into BIP-39 and derives keys with
           <a
             href="https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki"
             >BIP-32</a
@@ -815,8 +815,8 @@ const session = createSecp256k1SigningSession({
 const address = getEvmAddress(session.publicKey)</code></pre>
 
         <p>
-          A passkey account stores no database row, localStorage entry, or
-          vault blob. Sign in on a new device with the synced passkey, and the same
+          A passkey account stores no database row, localStorage entry, or vault
+          blob. Sign in on a new device with the synced passkey, and the same
           account appears. Cross-device use follows the password manager's
           normal sync and security assumptions. Because the derivation is
           standard, the application can offer an explicit export: the entropy
@@ -981,8 +981,8 @@ const address = getEvmAddress(session.publicKey)</code></pre>
         </div>
 
         <p>
-          An application can mix the patterns: passkey accounts for new accounts,
-          secret vaults for existing recovery phrases or keys.
+          An application can mix the patterns: passkey accounts for new
+          accounts, secret vaults for existing recovery phrases or keys.
         </p>
 
         <h2 id="try-it">Try it</h2>
@@ -1050,15 +1050,15 @@ const address = getEvmAddress(session.publicKey)</code></pre>
         <ul>
           <li>
             <strong>The app stores less key material.</strong>
-            The passkey-account pattern stores no app-owned secret. The secret-vault
-            pattern stores a vault blob that still needs the passkey ceremony,
-            and locking is one call.
+            The passkey-account pattern stores no app-owned secret. The
+            secret-vault pattern stores a vault blob that still needs the
+            passkey ceremony, and locking is one call.
           </li>
           <li>
             <strong>Passkey accounts have no chain infrastructure.</strong>
-            They need no contracts, bundlers, paymasters, executor accounts,
-            key servers, or provider dependencies. They also need no
-            server-side account state.
+            They need no contracts, bundlers, paymasters, executor accounts, key
+            servers, or provider dependencies. They also need no server-side
+            account state.
           </li>
           <li>
             <strong>The dependency surface is small.</strong>


### PR DESCRIPTION
Stacked on #158; last PR in the series.

Aligns the published article with the passkey-account terminology adopted across the docs and demo: the "Derived mode" section becomes "Passkey accounts" (heading id included; nothing links to the old anchor), the comparison table header and the closing takeaways follow, and "derive" survives only as the verb ("passkey-derived key", "derived from a separate secret").

The "Try it" paragraph was also stale independent of the rename: it described a Derived/Vault toggle that the demo no longer has. It now matches the current flow, which opens with passkey accounts and reaches the vault via the link under the card.

Verified in a browser: the renamed heading and table render, and no "Derived mode" or "derived account" text remains.