### PR TITLE
Point docs links and Pages build at mera.category.xyz

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -31,8 +31,7 @@ jobs:
           path: docs
           node-version: 24
         env:
-          DOCS_SITE: https://category-labs.github.io
-          DOCS_BASE: /mera
+          DOCS_SITE: https://mera.category.xyz
 
   deploy:
     name: Deploy

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Developers can use mera to:
 
 ## Documentation and demo
 
-Installation, guides, compatibility information, the security model, the API reference, and the live demo are on the [mera documentation website](https://determined-tenderness-production-79fe.up.railway.app/).
+Installation, guides, compatibility information, the security model, the API reference, and the live demo are on the [mera documentation website](https://mera.category.xyz/).
 
 ## Repository
 
@@ -24,7 +24,7 @@ Installation, guides, compatibility information, the security model, the API ref
 
 ## Status
 
-mera is an experimental reference implementation. The documentation describes its [security model](https://determined-tenderness-production-79fe.up.railway.app/concepts/security-model/) and [known authenticator support](https://determined-tenderness-production-79fe.up.railway.app/concepts/authenticator-support/).
+mera is an experimental reference implementation. The documentation describes its [security model](https://mera.category.xyz/concepts/security-model/) and [known authenticator support](https://mera.category.xyz/concepts/authenticator-support/).
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "signing",
     "crypto"
   ],
-  "homepage": "https://github.com/category-labs/mera#readme",
+  "homepage": "https://mera.category.xyz",
   "bugs": {
     "url": "https://github.com/category-labs/mera/issues"
   },


### PR DESCRIPTION
## Why

The docs site now serves from the custom domain https://mera.category.xyz (DNS resolves through GitHub Pages and the site is live). The Pages build still stamped canonical URLs, redirects, and social-card metadata with the old `https://category-labs.github.io` site and `/mera` base path, and the README and npm `homepage` sent readers to the retired Railway URL.

Dropping `DOCS_BASE` is safe because the astro config already treats an unset base as empty; the redirect and link-prefixing logic degrades to identity.

## Notes for reviewers

Built the site locally with the new env values: 33 pages build cleanly, no `/mera`-prefixed links remain, and `og:image` and the sitemap point at the custom domain. `docs/CNAME` is left as is — it never reaches the build artifact, and Actions-based Pages deploys keep the custom domain in repo settings.