### PR TITLE
Pin the embedded connect footer link when the frame outgrows the content

### DIFF
--- a/demo/src/embed.ts
+++ b/demo/src/embed.ts
@@ -11,6 +11,13 @@
  * The height is non-sensitive, so it's posted to "*"; the embedding page is the
  * side that validates the message origin before resizing anything.
  */
+// A frame counts as taller than the content only past this slack. Reported
+// heights are Math.ceil'd and embedders apply them back (plus any border) as
+// the frame height, so frame and content can disagree by a few pixels in a
+// content-sized frame; without the slack that rounding could flip the footer
+// pin on and off.
+const FOOTER_PIN_SLACK_PX = 8;
+
 function reportHeightWhenEmbedded(): void {
   if (window.self === window.top) return;
 
@@ -30,7 +37,7 @@ function reportHeightWhenEmbedded(): void {
     // (see styles.css), so pinning keeps the measured height stable and the
     // two states cannot flip-flop through the resize feedback loop.
     document.documentElement.dataset.footerPinned = String(
-      window.innerHeight > height + 8,
+      window.innerHeight > height + FOOTER_PIN_SLACK_PX,
     );
 
     if (height === last) return;

--- a/demo/src/embed.ts
+++ b/demo/src/embed.ts
@@ -21,6 +21,18 @@ function reportHeightWhenEmbedded(): void {
     const height = Math.ceil(
       document.documentElement.getBoundingClientRect().height,
     );
+
+    // Some embedding layouts size the frame from the viewport instead of the
+    // reported height, leaving empty space below the hugged content where the
+    // connect screen's footer link should sit. When the frame is taller than
+    // the content, `data-footer-pinned` switches the link to fixed positioning
+    // at the frame's bottom edge. The content column reserves the link's band
+    // (see styles.css), so pinning keeps the measured height stable and the
+    // two states cannot flip-flop through the resize feedback loop.
+    document.documentElement.dataset.footerPinned = String(
+      window.innerHeight > height + 8,
+    );
+
     if (height === last) return;
     last = height;
     window.parent.postMessage({ type: "mera:resize", height }, "*");
@@ -28,6 +40,9 @@ function reportHeightWhenEmbedded(): void {
 
   new ResizeObserver(post).observe(document.body);
   window.addEventListener("load", post);
+  // The observer tracks content size only; a frame-only resize (embedding
+  // layout change) must also re-evaluate pinning.
+  window.addEventListener("resize", post);
   post();
 }
 

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -672,3 +672,20 @@ html[data-embedded="true"] body {
 html[data-embedded="true"] .app {
   margin: 8px auto;
 }
+
+/* Embedded in a frame taller than the content (embed.ts sets
+   `data-footer-pinned`): the hugged column has no spare height for
+   `margin-top: auto` to distribute, so pin the mode switch to the frame's
+   bottom edge instead. The column reserves the link's own band (column gap +
+   link height), keeping the measured content height the same whether or not
+   the link is in the flow. */
+html[data-footer-pinned="true"] .app:has(.mode-switch) {
+  padding-bottom: 42px;
+}
+
+html[data-footer-pinned="true"] .mode-switch {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+}

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -675,16 +675,20 @@ html[data-embedded="true"] .app {
 
 /* Embedded in a frame taller than the content (embed.ts sets
    `data-footer-pinned`): the hugged column has no spare height for
-   `margin-top: auto` to distribute, so pin the mode switch to the frame's
-   bottom edge instead. The column reserves the link's own band (column gap +
-   link height), keeping the measured content height the same whether or not
-   the link is in the flow. */
+   `margin-top: auto` to distribute, so pin the mode switch just above the
+   frame's bottom edge instead. The column reserves the link's in-flow band so
+   the measured content height stays the same whether or not the link is in
+   the flow; small drift between the reserve and the real band is absorbed by
+   FOOTER_PIN_SLACK_PX in embed.ts. */
 html[data-footer-pinned="true"] .app:has(.mode-switch) {
+  /* The 18px `.app` column gap + the link's ~24px box. */
   padding-bottom: 42px;
 }
 
 html[data-footer-pinned="true"] .mode-switch {
   position: fixed;
+  /* 16px embedded body padding + 8px `.app` margin: the same offset the
+     in-flow link gets in a content-sized frame. */
   bottom: 24px;
   left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
## Why

On the docs landing (mera.category.xyz), "Import existing secret →" sat directly under the connect card instead of at the bottom of the demo panel. Two intentional behaviors collide there: embedded mode hugs its content so `embed.ts` can report a tight height for stacked layouts, while the wide docs layout gives the iframe a viewport-tall sticky panel and ignores the reported heights. With the content hugged, the connect screen's flex column has no spare height for `margin-top: auto` to distribute, so the link could not reach the frame's bottom edge.

`embed.ts` already measures both heights, so it now sets `data-footer-pinned` whenever the frame is taller than the content, and the CSS pins the link to the frame's bottom edge with `position: fixed`. The column reserves the link's band (column gap + link height), which keeps the measured content height the same whether the link is pinned or in flow — that invariant is what prevents the pin toggle and the parent's resize feedback loop from oscillating. Frames shorter than the content (short laptop panel + the taller vault form) release the pin so the link scrolls with the content instead of floating over it. The fix is demo-side only; the docs embed and standalone layouts are untouched.

## Notes for reviewers

Verified in headless Chrome with a two-iframe harness simulating both docs layouts (a fixed viewport-tall frame and one that applies `mera:resize` reports like `DemoEmbed.astro`): the tall frame pins the link 24px above its bottom edge while still reporting the hugged height; the content-sized frame tracks reports (394px → 525px on vault switch) with the link in flow at the same visual gap; shrinking a frame below the content height releases the pin and growing it back re-engages it. Reported heights stayed stable across pin transitions in all cases.

One tooling note: this can't be exercised in the Claude Code browser pane — it never delivers ResizeObserver callbacks, which makes the resize loop look broken there.

## Screenshots

Derived connect screen after the fix, in both embedding shapes:

![embed-fix-derived.png](https://github.com/user-attachments/assets/b9257f41-a3bb-4f17-a4d4-f239fe463e2a)