### PR TITLE
Add derivation pipeline and BIP-32 tree diagrams to the entropy page

### DIFF
--- a/docs/src/assets/diagrams/bip32-tree.svg
+++ b/docs/src/assets/diagrams/bip32-tree.svg
@@ -1,36 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 308" width="640" height="308" role="img" class="mera-diagram">
-  <title>One master seed derives a tree of keys. The BIP-44 paths m/44'/60'/0'/0/0 and m/44'/60'/0'/0/1 name two EVM accounts, and the SLIP-0010 path m/44'/501'/0'/0' names a Solana account. The same seed and path produce the same key on any machine.</title>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 640 308"
+  width="640"
+  height="308"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    One master seed derives a tree of keys. The BIP-44 paths m/44'/60'/0'/0/0
+    and m/44'/60'/0'/0/1 name two EVM accounts, and the SLIP-0010 path
+    m/44'/501'/0'/0' names a Solana account. The same seed and path produce the
+    same key on any machine.
+  </title>
   <defs>
-    <marker id="bt-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" class="d-head"/>
+    <marker
+      id="bt-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
     </marker>
   </defs>
 
-  <rect class="d-secret" x="230" y="20" width="180" height="44" rx="8"/>
+  <rect class="d-secret" x="230" y="20" width="180" height="44" rx="8" />
   <text x="320" y="48" text-anchor="middle">Master seed</text>
 
-  <path class="d-edge" d="M320 64 L118 190" marker-end="url(#bt-arrow)"/>
-  <path class="d-edge" d="M320 64 V190" marker-end="url(#bt-arrow)"/>
-  <path class="d-edge" d="M320 64 L522 190" marker-end="url(#bt-arrow)"/>
+  <path class="d-edge" d="M320 64 L118 190" marker-end="url(#bt-arrow)" />
+  <path class="d-edge" d="M320 64 V190" marker-end="url(#bt-arrow)" />
+  <path class="d-edge" d="M320 64 L522 190" marker-end="url(#bt-arrow)" />
 
-  <rect class="d-underlay" x="50" y="162" width="136" height="20"/>
-  <rect class="d-underlay" x="252" y="162" width="136" height="20"/>
-  <rect class="d-underlay" x="454" y="162" width="136" height="20"/>
-  <text x="118" y="176" text-anchor="middle" class="d-mono">m/44'/60'/0'/0/0</text>
-  <text x="320" y="176" text-anchor="middle" class="d-mono">m/44'/60'/0'/0/1</text>
-  <text x="522" y="176" text-anchor="middle" class="d-mono">m/44'/501'/0'/0'</text>
+  <rect class="d-underlay" x="50" y="162" width="136" height="20" />
+  <rect class="d-underlay" x="252" y="162" width="136" height="20" />
+  <rect class="d-underlay" x="454" y="162" width="136" height="20" />
+  <text x="118" y="176" text-anchor="middle" class="d-mono">
+    m/44'/60'/0'/0/0
+  </text>
+  <text x="320" y="176" text-anchor="middle" class="d-mono">
+    m/44'/60'/0'/0/1
+  </text>
+  <text x="522" y="176" text-anchor="middle" class="d-mono">
+    m/44'/501'/0'/0'
+  </text>
 
-  <rect class="d-secret" x="24" y="196" width="188" height="56" rx="8"/>
+  <rect class="d-secret" x="24" y="196" width="188" height="56" rx="8" />
   <text x="118" y="220" text-anchor="middle">EVM account 0</text>
-  <text x="118" y="239" text-anchor="middle" class="d-sub">secp256k1 · BIP-32</text>
+  <text x="118" y="239" text-anchor="middle" class="d-sub">
+    secp256k1 · BIP-32
+  </text>
 
-  <rect class="d-secret" x="226" y="196" width="188" height="56" rx="8"/>
+  <rect class="d-secret" x="226" y="196" width="188" height="56" rx="8" />
   <text x="320" y="220" text-anchor="middle">EVM account 1</text>
-  <text x="320" y="239" text-anchor="middle" class="d-sub">secp256k1 · BIP-32</text>
+  <text x="320" y="239" text-anchor="middle" class="d-sub">
+    secp256k1 · BIP-32
+  </text>
 
-  <rect class="d-secret" x="428" y="196" width="188" height="56" rx="8"/>
+  <rect class="d-secret" x="428" y="196" width="188" height="56" rx="8" />
   <text x="522" y="220" text-anchor="middle">Solana account 0</text>
-  <text x="522" y="239" text-anchor="middle" class="d-sub">Ed25519 · SLIP-0010</text>
+  <text x="522" y="239" text-anchor="middle" class="d-sub">
+    Ed25519 · SLIP-0010
+  </text>
 
-  <text x="320" y="290" text-anchor="middle" class="d-note">The same seed and path produce the same key on any machine.</text>
+  <text x="320" y="290" text-anchor="middle" class="d-note">
+    The same seed and path produce the same key on any machine.
+  </text>
 </svg>

--- a/docs/src/assets/diagrams/bip32-tree.svg
+++ b/docs/src/assets/diagrams/bip32-tree.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 308" width="640" height="308" role="img" class="mera-diagram">
+  <title>One master seed derives a tree of keys. The BIP-44 paths m/44'/60'/0'/0/0 and m/44'/60'/0'/0/1 name two EVM accounts, and the SLIP-0010 path m/44'/501'/0'/0' names a Solana account. The same seed and path produce the same key on any machine.</title>
+  <defs>
+    <marker id="bt-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" class="d-head"/>
+    </marker>
+  </defs>
+
+  <rect class="d-secret" x="230" y="20" width="180" height="44" rx="8"/>
+  <text x="320" y="48" text-anchor="middle">Master seed</text>
+
+  <path class="d-edge" d="M320 64 L118 190" marker-end="url(#bt-arrow)"/>
+  <path class="d-edge" d="M320 64 V190" marker-end="url(#bt-arrow)"/>
+  <path class="d-edge" d="M320 64 L522 190" marker-end="url(#bt-arrow)"/>
+
+  <rect class="d-underlay" x="50" y="162" width="136" height="20"/>
+  <rect class="d-underlay" x="252" y="162" width="136" height="20"/>
+  <rect class="d-underlay" x="454" y="162" width="136" height="20"/>
+  <text x="118" y="176" text-anchor="middle" class="d-mono">m/44'/60'/0'/0/0</text>
+  <text x="320" y="176" text-anchor="middle" class="d-mono">m/44'/60'/0'/0/1</text>
+  <text x="522" y="176" text-anchor="middle" class="d-mono">m/44'/501'/0'/0'</text>
+
+  <rect class="d-secret" x="24" y="196" width="188" height="56" rx="8"/>
+  <text x="118" y="220" text-anchor="middle">EVM account 0</text>
+  <text x="118" y="239" text-anchor="middle" class="d-sub">secp256k1 · BIP-32</text>
+
+  <rect class="d-secret" x="226" y="196" width="188" height="56" rx="8"/>
+  <text x="320" y="220" text-anchor="middle">EVM account 1</text>
+  <text x="320" y="239" text-anchor="middle" class="d-sub">secp256k1 · BIP-32</text>
+
+  <rect class="d-secret" x="428" y="196" width="188" height="56" rx="8"/>
+  <text x="522" y="220" text-anchor="middle">Solana account 0</text>
+  <text x="522" y="239" text-anchor="middle" class="d-sub">Ed25519 · SLIP-0010</text>
+
+  <text x="320" y="290" text-anchor="middle" class="d-note">The same seed and path produce the same key on any machine.</text>
+</svg>

--- a/docs/src/assets/diagrams/derivation-pipeline.svg
+++ b/docs/src/assets/diagrams/derivation-pipeline.svg
@@ -1,61 +1,95 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 536" width="640" height="536" role="img" class="mera-diagram">
-  <title>Pipeline from entropy to an address. Entropy, encoded as a seed phrase by BIP-39, derives a master seed, then a private key via a derivation path, then a public key via a one-way function, then an address. The entropy, seed phrase, master seed, and private key are secret; the public key and address are safe to share.</title>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 640 536"
+  width="640"
+  height="536"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    Pipeline from entropy to an address. Entropy, encoded as a seed phrase by
+    BIP-39, derives a master seed, then a private key via a derivation path,
+    then a public key via a one-way function, then an address. The entropy, seed
+    phrase, master seed, and private key are secret; the public key and address
+    are safe to share.
+  </title>
   <defs>
-    <marker id="dp-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" class="d-head"/>
+    <marker
+      id="dp-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
     </marker>
   </defs>
 
   <!-- entropy and its BIP-39 phrase encoding -->
-  <rect class="d-secret" x="30" y="24" width="220" height="56" rx="8"/>
+  <rect class="d-secret" x="30" y="24" width="220" height="56" rx="8" />
   <text x="140" y="48" text-anchor="middle">Entropy</text>
   <text x="140" y="67" text-anchor="middle" class="d-sub">32 random bytes</text>
 
-  <rect class="d-secret" x="400" y="24" width="210" height="56" rx="8"/>
+  <rect class="d-secret" x="400" y="24" width="210" height="56" rx="8" />
   <text x="505" y="48" text-anchor="middle">Seed phrase</text>
   <text x="505" y="67" text-anchor="middle" class="d-sub">12 or 24 words</text>
 
-  <path class="d-edge d-dashed" d="M258 52 H392" marker-start="url(#dp-arrow)" marker-end="url(#dp-arrow)"/>
+  <path
+    class="d-edge d-dashed"
+    d="M258 52 H392"
+    marker-start="url(#dp-arrow)"
+    marker-end="url(#dp-arrow)"
+  />
   <text x="325" y="42" text-anchor="middle" class="d-note">BIP-39</text>
-  <text x="325" y="74" text-anchor="middle" class="d-sub">adds no security</text>
+  <text x="325" y="74" text-anchor="middle" class="d-sub">
+    adds no security
+  </text>
 
   <!-- the derivation spine -->
-  <path class="d-edge" d="M140 80 V126" marker-end="url(#dp-arrow)"/>
+  <path class="d-edge" d="M140 80 V126" marker-end="url(#dp-arrow)" />
   <text x="152" y="107" class="d-note">key derivation (KDF)</text>
 
-  <rect class="d-secret" x="30" y="132" width="220" height="56" rx="8"/>
+  <rect class="d-secret" x="30" y="132" width="220" height="56" rx="8" />
   <text x="140" y="156" text-anchor="middle">Master seed</text>
-  <text x="140" y="175" text-anchor="middle" class="d-sub">extends into a tree of keys</text>
+  <text x="140" y="175" text-anchor="middle" class="d-sub">
+    extends into a tree of keys
+  </text>
 
-  <path class="d-edge" d="M140 188 V234" marker-end="url(#dp-arrow)"/>
+  <path class="d-edge" d="M140 188 V234" marker-end="url(#dp-arrow)" />
   <text x="152" y="205" class="d-note">BIP-32 / SLIP-0010 derivation</text>
   <text x="152" y="223" class="d-mono">m/44'/60'/0'/0/0</text>
 
-  <rect class="d-secret" x="30" y="240" width="220" height="56" rx="8"/>
+  <rect class="d-secret" x="30" y="240" width="220" height="56" rx="8" />
   <text x="140" y="264" text-anchor="middle">Private key</text>
-  <text x="140" y="283" text-anchor="middle" class="d-sub">a 256-bit secret number</text>
+  <text x="140" y="283" text-anchor="middle" class="d-sub">
+    a 256-bit secret number
+  </text>
 
-  <path class="d-edge" d="M140 296 V342" marker-end="url(#dp-arrow)"/>
-  <text x="152" y="323" class="d-note">one-way — infeasible to reverse</text>
+  <path class="d-edge" d="M140 296 V342" marker-end="url(#dp-arrow)" />
+  <text x="152" y="323" class="d-note">one-way: infeasible to reverse</text>
 
-  <rect class="d-node" x="30" y="348" width="220" height="56" rx="8"/>
+  <rect class="d-node" x="30" y="348" width="220" height="56" rx="8" />
   <text x="140" y="372" text-anchor="middle">Public key</text>
   <text x="140" y="391" text-anchor="middle" class="d-sub">safe to share</text>
 
-  <path class="d-edge" d="M140 404 V450" marker-end="url(#dp-arrow)"/>
+  <path class="d-edge" d="M140 404 V450" marker-end="url(#dp-arrow)" />
   <text x="152" y="431" class="d-note">a short encoding of the public key</text>
 
-  <rect class="d-node" x="30" y="456" width="220" height="56" rx="8"/>
+  <rect class="d-node" x="30" y="456" width="220" height="56" rx="8" />
   <text x="140" y="480" text-anchor="middle">Address</text>
-  <text x="140" y="499" text-anchor="middle" class="d-sub">safe to publish</text>
+  <text x="140" y="499" text-anchor="middle" class="d-sub">
+    safe to publish
+  </text>
 
   <!-- side note and legend -->
   <text x="402" y="170" class="d-note">Only the entropy is unpredictable;</text>
   <text x="402" y="190" class="d-note">everything after it is recomputed,</text>
   <text x="402" y="210" class="d-note">never stored.</text>
 
-  <rect class="d-secret" x="402" y="292" width="14" height="14" rx="3"/>
-  <text x="424" y="304" class="d-note">secret — protect it</text>
-  <rect class="d-node" x="402" y="322" width="14" height="14" rx="3"/>
-  <text x="424" y="334" class="d-note">public — safe to share</text>
+  <rect class="d-secret" x="402" y="292" width="14" height="14" rx="3" />
+  <text x="424" y="304" class="d-note">secret material</text>
+  <rect class="d-node" x="402" y="322" width="14" height="14" rx="3" />
+  <text x="424" y="334" class="d-note">safe to share</text>
 </svg>

--- a/docs/src/assets/diagrams/derivation-pipeline.svg
+++ b/docs/src/assets/diagrams/derivation-pipeline.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 536" width="640" height="536" role="img" class="mera-diagram">
+  <title>Pipeline from entropy to an address. Entropy, encoded as a seed phrase by BIP-39, derives a master seed, then a private key via a derivation path, then a public key via a one-way function, then an address. The entropy, seed phrase, master seed, and private key are secret; the public key and address are safe to share.</title>
+  <defs>
+    <marker id="dp-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" class="d-head"/>
+    </marker>
+  </defs>
+
+  <!-- entropy and its BIP-39 phrase encoding -->
+  <rect class="d-secret" x="30" y="24" width="220" height="56" rx="8"/>
+  <text x="140" y="48" text-anchor="middle">Entropy</text>
+  <text x="140" y="67" text-anchor="middle" class="d-sub">32 random bytes</text>
+
+  <rect class="d-secret" x="400" y="24" width="210" height="56" rx="8"/>
+  <text x="505" y="48" text-anchor="middle">Seed phrase</text>
+  <text x="505" y="67" text-anchor="middle" class="d-sub">12 or 24 words</text>
+
+  <path class="d-edge d-dashed" d="M258 52 H392" marker-start="url(#dp-arrow)" marker-end="url(#dp-arrow)"/>
+  <text x="325" y="42" text-anchor="middle" class="d-note">BIP-39</text>
+  <text x="325" y="74" text-anchor="middle" class="d-sub">adds no security</text>
+
+  <!-- the derivation spine -->
+  <path class="d-edge" d="M140 80 V126" marker-end="url(#dp-arrow)"/>
+  <text x="152" y="107" class="d-note">key derivation (KDF)</text>
+
+  <rect class="d-secret" x="30" y="132" width="220" height="56" rx="8"/>
+  <text x="140" y="156" text-anchor="middle">Master seed</text>
+  <text x="140" y="175" text-anchor="middle" class="d-sub">extends into a tree of keys</text>
+
+  <path class="d-edge" d="M140 188 V234" marker-end="url(#dp-arrow)"/>
+  <text x="152" y="205" class="d-note">BIP-32 / SLIP-0010 derivation</text>
+  <text x="152" y="223" class="d-mono">m/44'/60'/0'/0/0</text>
+
+  <rect class="d-secret" x="30" y="240" width="220" height="56" rx="8"/>
+  <text x="140" y="264" text-anchor="middle">Private key</text>
+  <text x="140" y="283" text-anchor="middle" class="d-sub">a 256-bit secret number</text>
+
+  <path class="d-edge" d="M140 296 V342" marker-end="url(#dp-arrow)"/>
+  <text x="152" y="323" class="d-note">one-way — infeasible to reverse</text>
+
+  <rect class="d-node" x="30" y="348" width="220" height="56" rx="8"/>
+  <text x="140" y="372" text-anchor="middle">Public key</text>
+  <text x="140" y="391" text-anchor="middle" class="d-sub">safe to share</text>
+
+  <path class="d-edge" d="M140 404 V450" marker-end="url(#dp-arrow)"/>
+  <text x="152" y="431" class="d-note">a short encoding of the public key</text>
+
+  <rect class="d-node" x="30" y="456" width="220" height="56" rx="8"/>
+  <text x="140" y="480" text-anchor="middle">Address</text>
+  <text x="140" y="499" text-anchor="middle" class="d-sub">safe to publish</text>
+
+  <!-- side note and legend -->
+  <text x="402" y="170" class="d-note">Only the entropy is unpredictable;</text>
+  <text x="402" y="190" class="d-note">everything after it is recomputed,</text>
+  <text x="402" y="210" class="d-note">never stored.</text>
+
+  <rect class="d-secret" x="402" y="292" width="14" height="14" rx="3"/>
+  <text x="424" y="304" class="d-note">secret — protect it</text>
+  <rect class="d-node" x="402" y="322" width="14" height="14" rx="3"/>
+  <text x="424" y="334" class="d-note">public — safe to share</text>
+</svg>

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -3,7 +3,12 @@ title: Entropy, keys, and accounts
 description: How random bytes become a private key, an address, and a reproducible family of accounts.
 ---
 
+import DerivationPipeline from "../../../assets/diagrams/derivation-pipeline.svg";
+import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
+
 The blockchain background the rest of the docs assume: how 32 random bytes become a private key, an account, and a reproducible family of accounts. Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
+
+<DerivationPipeline />
 
 ## Randomness and entropy
 
@@ -30,6 +35,8 @@ Control of an account is the ability to sign: a transaction is valid when its si
 A key-derivation function (KDF) turns one secret into others: the output looks random, and the same input always produces the same output. A key that can be recomputed never needs to be stored.
 
 BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one master seed into a tree of child keys, where a derivation path such as `m/44'/60'/0'/0/0` names one key. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account. (BIP is a Bitcoin Improvement Proposal; several became standards beyond Bitcoin.)
+
+<Bip32Tree />
 
 ## Seed phrases
 

--- a/docs/src/styles/mera.css
+++ b/docs/src/styles/mera.css
@@ -156,8 +156,16 @@ svg.mera-diagram {
 }
 
 .mera-diagram .d-secret {
-  fill: color-mix(in srgb, var(--sl-color-accent-low) 55%, var(--sl-color-black));
-  stroke: color-mix(in srgb, var(--sl-color-accent) 35%, var(--sl-color-accent-low));
+  fill: color-mix(
+    in srgb,
+    var(--sl-color-accent-low) 55%,
+    var(--sl-color-black)
+  );
+  stroke: color-mix(
+    in srgb,
+    var(--sl-color-accent) 35%,
+    var(--sl-color-accent-low)
+  );
 }
 
 .mera-diagram .d-edge {

--- a/docs/src/styles/mera.css
+++ b/docs/src/styles/mera.css
@@ -113,3 +113,68 @@ h4,
   text-decoration-thickness: 1px;
   text-underline-offset: 0.16em;
 }
+
+/* Diagrams: hand-authored inline SVGs (src/assets/diagrams) share one
+   visual language. Accent-tinted nodes hold secret material; gray nodes
+   are safe to share. */
+svg.mera-diagram {
+  display: block;
+  margin: 2.5rem auto;
+  max-width: 100%;
+  height: auto;
+}
+
+.mera-diagram text {
+  font-family: var(--sl-font);
+  font-size: 15px;
+  font-weight: 500;
+  fill: var(--sl-color-white);
+  letter-spacing: -0.01em;
+}
+
+.mera-diagram .d-sub,
+.mera-diagram .d-note {
+  font-size: 12.5px;
+  font-weight: 400;
+  fill: var(--sl-color-gray-3);
+}
+
+.mera-diagram .d-note {
+  font-size: 13px;
+}
+
+.mera-diagram .d-mono {
+  font-family: var(--sl-font-mono);
+  font-size: 12.5px;
+  font-weight: 400;
+  fill: var(--sl-color-gray-2);
+}
+
+.mera-diagram .d-node {
+  fill: var(--sl-color-gray-7);
+  stroke: var(--sl-color-gray-5);
+}
+
+.mera-diagram .d-secret {
+  fill: color-mix(in srgb, var(--sl-color-accent-low) 55%, var(--sl-color-black));
+  stroke: color-mix(in srgb, var(--sl-color-accent) 35%, var(--sl-color-accent-low));
+}
+
+.mera-diagram .d-edge {
+  fill: none;
+  stroke: var(--sl-color-gray-4);
+  stroke-width: 1.25;
+}
+
+.mera-diagram .d-head {
+  fill: var(--sl-color-gray-4);
+}
+
+.mera-diagram .d-dashed {
+  stroke-dasharray: 5 4;
+}
+
+/* Lifts a label off the edge that runs behind it. */
+.mera-diagram .d-underlay {
+  fill: var(--sl-color-black);
+}


### PR DESCRIPTION
The concepts docs explain one spatial structure — entropy flowing through derivation into keys, and one seed fanning into a tree of accounts — entirely in prose, so readers assemble the mental model themselves across five sections. This PR gives the entropy page the two diagrams that carry that load, and establishes the machinery the rest of the diagram series reuses: hand-authored SVGs in `src/assets/diagrams/` inlined as Astro SVG components (so they inherit the site fonts and palette via CSS variables), a shared `.mera-diagram` style block in `mera.css` defining one visual language (accent-tinted nodes hold secret material, gray nodes are safe to share), and the page's `.md` → `.mdx` conversion.

The one open risk from planning is resolved: MDX pages do get the custom `DOCS_BASE` link-prefixing processor. Verified by building with `DOCS_BASE=/preview` — the converted page has zero unprefixed root-relative hrefs.

Diagram label text follows `docs/AGENTS.md` sentence mechanics (no em dashes), and the SVGs are biome-formatted so `npm run check` passes.

This is the first of seven stacked PRs, one page per PR; follow-ups only add SVGs and convert their page.

## Screenshots

![entropy2-diagram-1.png](https://github.com/user-attachments/assets/024dc61c-7bd3-49a9-9c49-16ee76a32e09)
![entropy2-diagram-2.png](https://github.com/user-attachments/assets/5d675c11-868a-4fa6-a7a3-711cad5569e8)
