### PR TITLE
Add PRF function and ceremony prompt diagrams to the PRF page

### DIFF
--- a/docs/src/assets/diagrams/prf-function.svg
+++ b/docs/src/assets/diagrams/prf-function.svg
@@ -1,0 +1,77 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 416"
+  width="680"
+  height="416"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    The PRF as a function. The relying party ID and a salt enter the
+    authenticator, where the credential and the PRF live; the PRF returns 32
+    bytes of output. The same credential, relying party ID, and salt produce the
+    same 32 bytes on every synced device; a different salt produces unrelated
+    output.
+  </title>
+  <defs>
+    <marker
+      id="pf-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <!-- inputs supplied by the ceremony -->
+  <rect class="d-node" x="140" y="24" width="190" height="56" rx="8" />
+  <text x="235" y="48" text-anchor="middle">Relying party ID</text>
+  <text x="235" y="67" text-anchor="middle" class="d-mono">
+    account.example.com
+  </text>
+
+  <rect class="d-node" x="350" y="24" width="190" height="56" rx="8" />
+  <text x="445" y="48" text-anchor="middle">Salt</text>
+  <text x="445" y="67" text-anchor="middle" class="d-sub">
+    32 bytes, a namespace
+  </text>
+
+  <path class="d-edge" d="M235 80 L410 143" marker-end="url(#pf-arrow)" />
+  <path class="d-edge" d="M445 80 L455 143" marker-end="url(#pf-arrow)" />
+
+  <!-- the authenticator holds the credential and evaluates the PRF -->
+  <rect class="d-zone" x="140" y="118" width="400" height="128" rx="10" />
+  <text x="156" y="140" class="d-sub">authenticator</text>
+
+  <rect class="d-secret" x="156" y="150" width="190" height="56" rx="8" />
+  <text x="251" y="174" text-anchor="middle">Credential</text>
+  <text x="251" y="193" text-anchor="middle" class="d-sub">
+    never leaves the authenticator
+  </text>
+
+  <path class="d-edge" d="M346 178 H372" marker-end="url(#pf-arrow)" />
+
+  <rect class="d-node" x="380" y="150" width="144" height="56" rx="8" />
+  <text x="452" y="174" text-anchor="middle">PRF</text>
+  <text x="452" y="193" text-anchor="middle" class="d-sub">deterministic</text>
+
+  <path class="d-edge" d="M452 206 V282" marker-end="url(#pf-arrow)" />
+
+  <rect class="d-secret" x="362" y="286" width="180" height="56" rx="8" />
+  <text x="452" y="310" text-anchor="middle">PRF output</text>
+  <text x="452" y="329" text-anchor="middle" class="d-sub">
+    32 bytes, stable
+  </text>
+
+  <text x="340" y="380" text-anchor="middle" class="d-note">
+    The same credential, rpId, and salt produce the same 32 bytes on every
+    synced device.
+  </text>
+  <text x="340" y="402" text-anchor="middle" class="d-note">
+    A different salt produces unrelated output: salts are namespaces.
+  </text>
+</svg>

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -3,6 +3,8 @@ title: Passkeys and the PRF extension
 description: What a passkey is, what the PRF extension adds, and why its output is stable.
 ---
 
+import PrfFunction from "../../../assets/diagrams/prf-function.svg";
+
 A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords; a credential is one such key pair, created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
@@ -20,6 +22,8 @@ The requirement is not configurable. Authenticators built on [`hmac-secret`](htt
 The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) gives each credential a pseudorandom function: a function whose output looks random but is fully determined by its inputs. The caller passes a 32-byte salt with the ceremony and the authenticator returns 32 bytes.
 
 PRF output is determined by the credential, relying party ID, and salt. Those inputs produce the same 32 bytes on every synced device; a different salt produces unrelated output. Salts act as namespaces, which is why passkey accounts share one [fixed salt](/reference/get-deterministic-prf-salt-v1/) while each secret vault gets a fresh random one.
+
+<PrfFunction />
 
 ## Using the output
 

--- a/docs/src/styles/mera.css
+++ b/docs/src/styles/mera.css
@@ -182,6 +182,13 @@ svg.mera-diagram {
   stroke-dasharray: 5 4;
 }
 
+/* A boundary region, such as the authenticator. */
+.mera-diagram .d-zone {
+  fill: none;
+  stroke: var(--sl-color-gray-5);
+  stroke-dasharray: 5 4;
+}
+
 /* Lifts a label off the edge that runs behind it. */
 .mera-diagram .d-underlay {
   fill: var(--sl-color-black);


### PR DESCRIPTION
Second PR in the docs diagram series (stacked on #163). The PRF page states the extension's central facts — output determined by credential, rpId, and salt; salts as namespaces; one prompt per ceremony with a possible follow-up — in prose only. This adds the two diagrams that make them spatial: the PRF as a function with its inputs and the authenticator boundary drawn, and the three ceremonies with their prompt counts against signing's zero.

Adds two shared styles to the diagram language from #163: a dashed `.d-zone` boundary region and a `.d-prompt` pill for user-verification prompts (accent-outlined, against a gray pill for "no prompt").

## Screenshots

![final-prf-diagram-1.png](https://github.com/user-attachments/assets/4f4fa43d-b7be-42ba-8d7e-9f6a96f4d71a)
