### PR TITLE
Add an ownership overview diagram to getting started

### DIFF
--- a/docs/src/assets/diagrams/getting-started-overview.svg
+++ b/docs/src/assets/diagrams/getting-started-overview.svg
@@ -1,0 +1,97 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 612"
+  width="680"
+  height="612"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    The path from a passkey ceremony to a signature, split by ownership. In
+    mera, a passkey ceremony produces 32 bytes of PRF output. The app derives
+    the private key from that output. Back in mera, a signing session consumes
+    the key and produces signatures without prompts until it is locked. A dashed
+    return path shows signing back in: the same ceremony returns the same 32
+    bytes. No secret is stored anywhere.
+  </title>
+  <defs>
+    <marker
+      id="gs-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <!-- mera: the ceremony and its output -->
+  <rect class="d-zone" x="100" y="24" width="360" height="190" rx="10" />
+  <text x="114" y="46" class="d-sub">mera</text>
+
+  <rect class="d-node" x="130" y="56" width="300" height="56" rx="8" />
+  <text x="280" y="80" text-anchor="middle">Passkey ceremony</text>
+  <text x="280" y="99" text-anchor="middle" class="d-mono">
+    createPasskeyWithPrfOutput
+  </text>
+
+  <path class="d-edge" d="M280 112 V144" marker-end="url(#gs-arrow)" />
+
+  <rect class="d-secret" x="130" y="148" width="300" height="56" rx="8" />
+  <text x="280" y="172" text-anchor="middle">PRF output</text>
+  <text x="280" y="191" text-anchor="middle" class="d-sub">
+    32 bytes of entropy
+  </text>
+
+  <!-- the app: derivation -->
+  <path class="d-edge" d="M280 204 V270" marker-end="url(#gs-arrow)" />
+
+  <rect class="d-zone" x="100" y="242" width="360" height="112" rx="10" />
+  <text x="114" y="264" class="d-sub">the app</text>
+
+  <rect class="d-secret" x="130" y="274" width="300" height="56" rx="8" />
+  <text x="280" y="298" text-anchor="middle">Derive the private key</text>
+  <text x="280" y="317" text-anchor="middle" class="d-mono">
+    @scure/bip39 + @scure/bip32
+  </text>
+
+  <path class="d-edge" d="M280 330 V410" marker-end="url(#gs-arrow)" />
+  <text x="292" y="368" class="d-sub">
+    the session consumes and zeroes the key
+  </text>
+
+  <!-- mera: the signing session -->
+  <rect class="d-zone" x="100" y="382" width="360" height="190" rx="10" />
+  <text x="114" y="404" class="d-sub">mera</text>
+
+  <rect class="d-secret" x="130" y="414" width="300" height="56" rx="8" />
+  <text x="280" y="438" text-anchor="middle">Signing session</text>
+  <text x="280" y="457" text-anchor="middle" class="d-sub">
+    signs without prompts until lock()
+  </text>
+
+  <path class="d-edge" d="M280 470 V502" marker-end="url(#gs-arrow)" />
+
+  <rect class="d-node" x="130" y="506" width="300" height="56" rx="8" />
+  <text x="280" y="530" text-anchor="middle">Signature</text>
+  <text x="280" y="549" text-anchor="middle" class="d-sub">
+    as many as the app asks
+  </text>
+
+  <!-- signing back in reruns the ceremony -->
+  <path
+    class="d-edge d-dashed"
+    d="M430 534 H560 V84 H438"
+    marker-end="url(#gs-arrow)"
+  />
+  <text x="572" y="290" class="d-sub">sign back in:</text>
+  <text x="572" y="310" class="d-sub">same ceremony,</text>
+  <text x="572" y="330" class="d-sub">same 32 bytes</text>
+
+  <text x="280" y="600" text-anchor="middle" class="d-note">
+    No secret is stored anywhere; a later ceremony recomputes the same accounts.
+  </text>
+</svg>

--- a/docs/src/assets/diagrams/prf-function.svg
+++ b/docs/src/assets/diagrams/prf-function.svg
@@ -1,0 +1,77 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 416"
+  width="680"
+  height="416"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    The PRF as a function. The relying party ID and a salt enter the
+    authenticator, where the credential and the PRF live; the PRF returns 32
+    bytes of output. The same credential, relying party ID, and salt produce the
+    same 32 bytes on every synced device; a different salt produces unrelated
+    output.
+  </title>
+  <defs>
+    <marker
+      id="pf-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <!-- inputs supplied by the ceremony -->
+  <rect class="d-node" x="140" y="24" width="190" height="56" rx="8" />
+  <text x="235" y="48" text-anchor="middle">Relying party ID</text>
+  <text x="235" y="67" text-anchor="middle" class="d-mono">
+    account.example.com
+  </text>
+
+  <rect class="d-node" x="350" y="24" width="190" height="56" rx="8" />
+  <text x="445" y="48" text-anchor="middle">Salt</text>
+  <text x="445" y="67" text-anchor="middle" class="d-sub">
+    32 bytes, a namespace
+  </text>
+
+  <path class="d-edge" d="M235 80 L410 143" marker-end="url(#pf-arrow)" />
+  <path class="d-edge" d="M445 80 L455 143" marker-end="url(#pf-arrow)" />
+
+  <!-- the authenticator holds the credential and evaluates the PRF -->
+  <rect class="d-zone" x="140" y="118" width="400" height="128" rx="10" />
+  <text x="156" y="140" class="d-sub">authenticator</text>
+
+  <rect class="d-secret" x="156" y="150" width="190" height="56" rx="8" />
+  <text x="251" y="174" text-anchor="middle">Credential</text>
+  <text x="251" y="193" text-anchor="middle" class="d-sub">
+    never leaves the authenticator
+  </text>
+
+  <path class="d-edge" d="M346 178 H372" marker-end="url(#pf-arrow)" />
+
+  <rect class="d-node" x="380" y="150" width="144" height="56" rx="8" />
+  <text x="452" y="174" text-anchor="middle">PRF</text>
+  <text x="452" y="193" text-anchor="middle" class="d-sub">deterministic</text>
+
+  <path class="d-edge" d="M452 206 V282" marker-end="url(#pf-arrow)" />
+
+  <rect class="d-secret" x="362" y="286" width="180" height="56" rx="8" />
+  <text x="452" y="310" text-anchor="middle">PRF output</text>
+  <text x="452" y="329" text-anchor="middle" class="d-sub">
+    32 bytes, stable
+  </text>
+
+  <text x="340" y="380" text-anchor="middle" class="d-note">
+    The same credential, rpId, and salt produce the same 32 bytes on every
+    synced device.
+  </text>
+  <text x="340" y="402" text-anchor="middle" class="d-note">
+    A different salt produces unrelated output: salts are namespaces.
+  </text>
+</svg>

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -3,6 +3,8 @@ title: Passkeys and the PRF extension
 description: What a passkey is, what the PRF extension adds, and why its output is stable.
 ---
 
+import PrfFunction from "../../../assets/diagrams/prf-function.svg";
+
 A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords; a credential is one such key pair, created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
@@ -20,6 +22,8 @@ The requirement is not configurable. Authenticators built on [`hmac-secret`](htt
 The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) gives each credential a pseudorandom function: a function whose output looks random but is fully determined by its inputs. The caller passes a 32-byte salt with the ceremony and the authenticator returns 32 bytes.
 
 PRF output is determined by the credential, relying party ID, and salt. Those inputs produce the same 32 bytes on every synced device; a different salt produces unrelated output. Salts act as namespaces, which is why passkey accounts share one [fixed salt](/reference/get-deterministic-prf-salt-v1/) while each secret vault gets a fresh random one.
+
+<PrfFunction />
 
 ## Using the output
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,10 +3,14 @@ title: Getting started
 description: Install the library, derive an account, and make a first signature.
 ---
 
+import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
+
 Prerequisites:
 
 - A browser with WebAuthn, in a secure context: HTTPS, or `localhost` during development.
 - A passkey authenticator that supports the WebAuthn PRF extension. [Authenticator support](/concepts/authenticator-support/) lists the combinations known to work; 1Password and iCloud Keychain are good first choices.
+
+<GettingStartedOverview />
 
 ## Install
 

--- a/docs/src/styles/mera.css
+++ b/docs/src/styles/mera.css
@@ -182,6 +182,13 @@ svg.mera-diagram {
   stroke-dasharray: 5 4;
 }
 
+/* A boundary region, such as the authenticator. */
+.mera-diagram .d-zone {
+  fill: none;
+  stroke: var(--sl-color-gray-5);
+  stroke-dasharray: 5 4;
+}
+
 /* Lifts a label off the edge that runs behind it. */
 .mera-diagram .d-underlay {
   fill: var(--sl-color-black);


### PR DESCRIPTION
Third PR in the docs diagram series (stacked on #164). Getting started walks through four steps whose ownership boundary (mera runs ceremonies and signs; the app owns derivation) is stated only in scattered sentences. This adds one overview diagram ahead of the install step: the ceremony-to-signature path drawn through mera/app/mera zones, with a dashed return path for signing back in and the no-stored-secret consequence as the caption.

## Screenshots

![final-gs-diagram-1.png](https://github.com/user-attachments/assets/4bde043c-f374-4924-beb1-534ebb511472)
