### PR TITLE
Add a round trip diagram to the secret vaults page

### DIFF
--- a/docs/src/assets/diagrams/vault-roundtrip.svg
+++ b/docs/src/assets/diagrams/vault-roundtrip.svg
@@ -1,0 +1,78 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 500"
+  width="680"
+  height="500"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    The vault round trip. A secret, a phrase, a key, or any bytes, is encrypted
+    with AES-256-GCM. The encryption key material is the PRF output of a passkey
+    ceremony run against a fresh random salt for this secret. The result is
+    ordinary vault JSON, stored in localStorage, a backend, or a sync service,
+    with the salt stored inside. Unlocking runs the same ceremony with the
+    stored salt, which reproduces the key and recovers the secret. Tampering
+    with the stored bytes makes decryption fail.
+  </title>
+  <defs>
+    <marker
+      id="vr-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <rect class="d-secret" x="60" y="24" width="240" height="56" rx="8" />
+  <text x="180" y="48" text-anchor="middle">Secret</text>
+  <text x="180" y="67" text-anchor="middle" class="d-sub">
+    a phrase, a key, any bytes
+  </text>
+
+  <path class="d-edge" d="M180 80 V140" marker-end="url(#vr-arrow)" />
+
+  <rect class="d-node" x="60" y="144" width="240" height="56" rx="8" />
+  <text x="180" y="168" text-anchor="middle">AES-256-GCM</text>
+  <text x="180" y="187" text-anchor="middle" class="d-sub">
+    authenticated encryption
+  </text>
+
+  <rect class="d-node" x="380" y="144" width="260" height="56" rx="8" />
+  <text x="510" y="168" text-anchor="middle">Passkey ceremony</text>
+  <text x="510" y="187" text-anchor="middle" class="d-sub">
+    a fresh random salt per secret
+  </text>
+
+  <path class="d-edge" d="M380 172 H308" marker-end="url(#vr-arrow)" />
+  <text x="344" y="162" text-anchor="middle" class="d-sub">PRF output</text>
+  <text x="344" y="188" text-anchor="middle" class="d-sub">32 bytes</text>
+
+  <path class="d-edge" d="M180 200 V260" marker-end="url(#vr-arrow)" />
+  <text x="192" y="234" class="d-sub">the salt is stored in the vault</text>
+
+  <rect class="d-node" x="60" y="264" width="240" height="64" rx="8" />
+  <text x="180" y="290" text-anchor="middle">Vault JSON</text>
+  <text x="180" y="309" text-anchor="middle" class="d-sub">
+    localStorage, a backend, a sync service
+  </text>
+
+  <path class="d-edge" d="M180 328 V388" marker-end="url(#vr-arrow)" />
+  <text x="192" y="352" class="d-sub">unlock: the same ceremony with the</text>
+  <text x="192" y="370" class="d-sub">stored salt reproduces the key</text>
+
+  <rect class="d-secret" x="60" y="392" width="240" height="56" rx="8" />
+  <text x="180" y="416" text-anchor="middle">Secret</text>
+  <text x="180" y="435" text-anchor="middle" class="d-sub">
+    only the ceremony recovers it
+  </text>
+
+  <text x="340" y="488" text-anchor="middle" class="d-note">
+    Tampering with the stored bytes makes decryption fail.
+  </text>
+</svg>

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -7,6 +7,8 @@ sidebar:
     variant: default
 ---
 
+import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
+
 A secret vault holds one secret, a recovery phrase, a private key, any bytes, encrypted so that only a passkey ceremony can decrypt it. Vaults cover the cases where key material must come from outside the passkey. The most important is migration: an existing account moves to passkey sign-in by encrypting its secret once. Apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
 
 ## How a vault works
@@ -14,6 +16,8 @@ A secret vault holds one secret, a recovery phrase, a private key, any bytes, en
 Vaults encrypt with AES-256-GCM, a symmetric cipher that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey against a fresh random salt for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
+
+<VaultRoundtrip />
 
 ## The secret exists on its own
 


### PR DESCRIPTION
Fifth PR in the docs diagram series. The vaults page describes the encrypt-store-unlock cycle in prose. This adds the round trip diagram: the secret through AES-256-GCM keyed by a fresh-salt passkey ceremony, the vault JSON in ordinary storage with the salt inside, and the same ceremony reproducing the key on unlock.

## Screenshots

![vaults-final-diagram-1.png](https://github.com/user-attachments/assets/53bd16a0-b883-4115-9f06-4391805ed101)
