### PR TITLE
Add a trust boundary diagram to the security model page

### DIFF
--- a/docs/src/assets/diagrams/trust-boundary.svg
+++ b/docs/src/assets/diagrams/trust-boundary.svg
@@ -1,0 +1,77 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 384"
+  width="680"
+  height="384"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    The trust boundary. The page contains the app, which derives keys from PRF
+    output and decides when to lock sessions, and mera, which copies the bytes
+    it is given and zeroes its own copies. The authenticator sits outside the
+    page, reachable only through WebAuthn ceremonies: it holds the passkey and
+    PRF, the key never leaves, and it asks for user verification. Any script on
+    the page can see key material and sign with an unlocked session.
+  </title>
+  <defs>
+    <marker
+      id="tb-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <rect class="d-zone" x="24" y="24" width="396" height="296" rx="10" />
+  <text x="38" y="46" class="d-sub">the page</text>
+
+  <rect class="d-node" x="48" y="88" width="348" height="80" rx="8" />
+  <text x="222" y="116" text-anchor="middle">The app</text>
+  <text x="222" y="135" text-anchor="middle" class="d-sub">
+    derives keys from PRF output
+  </text>
+  <text x="222" y="153" text-anchor="middle" class="d-sub">
+    decides when to lock sessions
+  </text>
+
+  <rect class="d-node" x="48" y="200" width="348" height="80" rx="8" />
+  <text x="222" y="228" text-anchor="middle">mera</text>
+  <text x="222" y="247" text-anchor="middle" class="d-sub">
+    copies the bytes it is given
+  </text>
+  <text x="222" y="265" text-anchor="middle" class="d-sub">
+    zeroes its own copies
+  </text>
+
+  <path
+    class="d-edge"
+    d="M428 204 H478"
+    marker-start="url(#tb-arrow)"
+    marker-end="url(#tb-arrow)"
+  />
+  <text x="452" y="194" text-anchor="middle" class="d-sub">WebAuthn</text>
+  <text x="452" y="224" text-anchor="middle" class="d-sub">ceremonies</text>
+
+  <rect class="d-secret" x="484" y="130" width="180" height="140" rx="8" />
+  <text x="574" y="166" text-anchor="middle">Authenticator</text>
+  <text x="574" y="188" text-anchor="middle" class="d-sub">
+    holds the passkey and PRF
+  </text>
+  <text x="574" y="206" text-anchor="middle" class="d-sub">
+    the key never leaves
+  </text>
+  <text x="574" y="224" text-anchor="middle" class="d-sub">
+    asks for user verification
+  </text>
+
+  <text x="340" y="360" text-anchor="middle" class="d-note">
+    Any script on the page can see key material and sign with an unlocked
+    session.
+  </text>
+</svg>

--- a/docs/src/assets/diagrams/vault-roundtrip.svg
+++ b/docs/src/assets/diagrams/vault-roundtrip.svg
@@ -1,0 +1,78 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 500"
+  width="680"
+  height="500"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    The vault round trip. A secret, a phrase, a key, or any bytes, is encrypted
+    with AES-256-GCM. The encryption key material is the PRF output of a passkey
+    ceremony run against a fresh random salt for this secret. The result is
+    ordinary vault JSON, stored in localStorage, a backend, or a sync service,
+    with the salt stored inside. Unlocking runs the same ceremony with the
+    stored salt, which reproduces the key and recovers the secret. Tampering
+    with the stored bytes makes decryption fail.
+  </title>
+  <defs>
+    <marker
+      id="vr-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <rect class="d-secret" x="60" y="24" width="240" height="56" rx="8" />
+  <text x="180" y="48" text-anchor="middle">Secret</text>
+  <text x="180" y="67" text-anchor="middle" class="d-sub">
+    a phrase, a key, any bytes
+  </text>
+
+  <path class="d-edge" d="M180 80 V140" marker-end="url(#vr-arrow)" />
+
+  <rect class="d-node" x="60" y="144" width="240" height="56" rx="8" />
+  <text x="180" y="168" text-anchor="middle">AES-256-GCM</text>
+  <text x="180" y="187" text-anchor="middle" class="d-sub">
+    authenticated encryption
+  </text>
+
+  <rect class="d-node" x="380" y="144" width="260" height="56" rx="8" />
+  <text x="510" y="168" text-anchor="middle">Passkey ceremony</text>
+  <text x="510" y="187" text-anchor="middle" class="d-sub">
+    a fresh random salt per secret
+  </text>
+
+  <path class="d-edge" d="M380 172 H308" marker-end="url(#vr-arrow)" />
+  <text x="344" y="162" text-anchor="middle" class="d-sub">PRF output</text>
+  <text x="344" y="188" text-anchor="middle" class="d-sub">32 bytes</text>
+
+  <path class="d-edge" d="M180 200 V260" marker-end="url(#vr-arrow)" />
+  <text x="192" y="234" class="d-sub">the salt is stored in the vault</text>
+
+  <rect class="d-node" x="60" y="264" width="240" height="64" rx="8" />
+  <text x="180" y="290" text-anchor="middle">Vault JSON</text>
+  <text x="180" y="309" text-anchor="middle" class="d-sub">
+    localStorage, a backend, a sync service
+  </text>
+
+  <path class="d-edge" d="M180 328 V388" marker-end="url(#vr-arrow)" />
+  <text x="192" y="352" class="d-sub">unlock: the same ceremony with the</text>
+  <text x="192" y="370" class="d-sub">stored salt reproduces the key</text>
+
+  <rect class="d-secret" x="60" y="392" width="240" height="56" rx="8" />
+  <text x="180" y="416" text-anchor="middle">Secret</text>
+  <text x="180" y="435" text-anchor="middle" class="d-sub">
+    only the ceremony recovers it
+  </text>
+
+  <text x="340" y="488" text-anchor="middle" class="d-note">
+    Tampering with the stored bytes makes decryption fail.
+  </text>
+</svg>

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -7,6 +7,8 @@ sidebar:
     variant: default
 ---
 
+import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
+
 A secret vault holds one secret, a recovery phrase, a private key, any bytes, encrypted so that only a passkey ceremony can decrypt it. Vaults cover the cases where key material must come from outside the passkey. The most important is migration: an existing account moves to passkey sign-in by encrypting its secret once. Apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
 
 ## How a vault works
@@ -14,6 +16,8 @@ A secret vault holds one secret, a recovery phrase, a private key, any bytes, en
 Vaults encrypt with AES-256-GCM, a symmetric cipher that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey against a fresh random salt for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
+
+<VaultRoundtrip />
 
 ## The secret exists on its own
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -3,6 +3,8 @@ title: Security model
 description: What mera protects, what it cannot, and the risks left to the app.
 ---
 
+import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
+
 mera has a narrow scope: it runs passkey ceremonies, returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/).
 
 ## What the library handles
@@ -18,6 +20,8 @@ WebAuthn challenges are generated internally. So are AES-GCM nonces: a nonce is 
 A compromised JavaScript runtime, whether an injected script, a malicious dependency, or an extension with page access, can observe key material during app-owned derivation or import. It can also sign with an active session until `session.lock()` is called.
 
 The mitigations are app-level: lock sessions when idle, keep derivation windows short, and treat everything that can run script on the page as inside the trust boundary.
+
+<TrustBoundary />
 
 ## rpId binding
 


### PR DESCRIPTION
Sixth PR in the docs diagram series (stacked on #167). "What a compromised runtime sees" describes a boundary without drawing it. This adds the diagram: the page runtime containing the app and mera with their respective guarantees, the authenticator outside it reachable only through WebAuthn ceremonies, and the compromise consequence as the caption.

## Screenshots

![security-plain-diagram-1.png](https://github.com/user-attachments/assets/7d041ffc-3566-4bcb-a807-4c1bff96ca37)
