### PR TITLE
Add a first versus returning visit diagram to the recipe

### DIFF
--- a/docs/src/assets/diagrams/first-vs-returning.svg
+++ b/docs/src/assets/diagrams/first-vs-returning.svg
@@ -1,0 +1,96 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 516"
+  width="680"
+  height="516"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    The recipe's two flows. On the first visit, createPasskeyWithPrfOutput
+    creates the passkey and the app stores the credential metadata, credentialId
+    and transports, which holds no key material. On a returning visit,
+    getPasskeyPrfOutput signs in using the stored metadata. The PRF output
+    becomes the master seed through BIP-39, held in memory for the session, and
+    HD derivation by index produces the EVM and Solana signing sessions, ended
+    by lock().
+  </title>
+  <defs>
+    <marker
+      id="fr-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <!-- first visit -->
+  <rect class="d-zone" x="24" y="24" width="296" height="246" rx="10" />
+  <text x="38" y="46" class="d-sub">first visit</text>
+
+  <rect class="d-node" x="48" y="56" width="248" height="56" rx="8" />
+  <text x="172" y="80" text-anchor="middle">Create the passkey</text>
+  <text x="172" y="99" text-anchor="middle" class="d-mono">
+    createPasskeyWithPrfOutput
+  </text>
+
+  <path class="d-edge" d="M172 112 V156" marker-end="url(#fr-arrow)" />
+
+  <rect class="d-node" x="48" y="160" width="248" height="80" rx="8" />
+  <text x="172" y="184" text-anchor="middle">Credential metadata</text>
+  <text x="172" y="203" text-anchor="middle" class="d-sub">
+    credentialId and transports
+  </text>
+  <text x="172" y="221" text-anchor="middle" class="d-sub">
+    no key material
+  </text>
+
+  <!-- the stored record feeds the later sign-in -->
+  <path
+    class="d-edge d-dashed"
+    d="M296 200 L378 92"
+    marker-end="url(#fr-arrow)"
+  />
+
+  <!-- returning visit -->
+  <rect class="d-zone" x="360" y="24" width="296" height="476" rx="10" />
+  <text x="374" y="46" class="d-sub">returning visit</text>
+
+  <rect class="d-node" x="384" y="56" width="248" height="56" rx="8" />
+  <text x="508" y="80" text-anchor="middle">Sign in</text>
+  <text x="508" y="99" text-anchor="middle" class="d-mono">
+    getPasskeyPrfOutput
+  </text>
+
+  <path class="d-edge" d="M508 112 V156" marker-end="url(#fr-arrow)" />
+
+  <rect class="d-secret" x="384" y="160" width="248" height="56" rx="8" />
+  <text x="508" y="184" text-anchor="middle">PRF output</text>
+  <text x="508" y="203" text-anchor="middle" class="d-sub">32 bytes</text>
+
+  <path class="d-edge" d="M508 216 V260" marker-end="url(#fr-arrow)" />
+  <text x="520" y="242" class="d-sub">BIP-39</text>
+
+  <rect class="d-secret" x="384" y="264" width="248" height="56" rx="8" />
+  <text x="508" y="288" text-anchor="middle">Master seed</text>
+  <text x="508" y="307" text-anchor="middle" class="d-sub">
+    held in memory for the session
+  </text>
+
+  <path class="d-edge" d="M508 320 V364" marker-end="url(#fr-arrow)" />
+  <text x="520" y="346" class="d-sub">HD derivation by index</text>
+
+  <rect class="d-secret" x="384" y="368" width="248" height="64" rx="8" />
+  <text x="508" y="394" text-anchor="middle">Signing sessions</text>
+  <text x="508" y="413" text-anchor="middle" class="d-sub">
+    EVM and Solana, numbered by index
+  </text>
+
+  <path class="d-edge" d="M508 432 V476" marker-end="url(#fr-arrow)" />
+  <text x="520" y="458" class="d-mono">lock()</text>
+</svg>

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -3,11 +3,15 @@ title: Create passkey accounts
 description: Numbered EVM and Solana accounts from a single ceremony, with credential pinning.
 ---
 
+import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
+
 This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM and Solana accounts, credential pinning, one passkey ceremony per session, and locking.
 
 Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
 Prerequisites: `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/concepts/authenticator-support/)).
+
+<FirstVsReturning />
 
 ## Create the passkey
 


### PR DESCRIPTION
Last PR in the docs diagram series. The recipe walks through two flows that read as one in prose: the first visit, which creates the passkey and stores credential metadata, and the returning visit, which turns a sign-in assertion into the seed and the numbered signing sessions. This adds a two-lane diagram at the top of the page showing both flows and the stored metadata connecting them.

## Screenshots

![recipe-seed-diagram-1.png](https://github.com/user-attachments/assets/7798ec26-42eb-43ed-84e0-22abb9903f28)
