### PR TITLE
Describe the signing session by its custody, not by prompts

### DIFF
--- a/docs/src/assets/diagrams/getting-started-overview.svg
+++ b/docs/src/assets/diagrams/getting-started-overview.svg
@@ -9,9 +9,9 @@
   <title>
     The path from a passkey ceremony to a signature, split by ownership. In
     mera, a passkey ceremony produces 32 bytes of PRF output. The app derives
-    the private key from that output. Back in mera, a signing session signs
-    with the key held in memory. A dashed return path shows signing back in:
-    the same ceremony returns the same 32 bytes. No secret is stored anywhere.
+    the private key from that output. Back in mera, a signing session signs with
+    the key held in memory. A dashed return path shows signing back in: the same
+    ceremony returns the same 32 bytes. No secret is stored anywhere.
   </title>
   <defs>
     <marker
@@ -58,9 +58,7 @@
   </text>
 
   <path class="d-edge" d="M280 330 V410" marker-end="url(#gs-arrow)" />
-  <text x="292" y="368" class="d-sub">
-    the session consumes and zeroes the key
-  </text>
+  <text x="292" y="368" class="d-sub">the session consumes the key</text>
 
   <!-- mera: the signing session -->
   <rect class="d-zone" x="100" y="382" width="360" height="190" rx="10" />

--- a/docs/src/assets/diagrams/getting-started-overview.svg
+++ b/docs/src/assets/diagrams/getting-started-overview.svg
@@ -9,10 +9,9 @@
   <title>
     The path from a passkey ceremony to a signature, split by ownership. In
     mera, a passkey ceremony produces 32 bytes of PRF output. The app derives
-    the private key from that output. Back in mera, a signing session consumes
-    the key and produces signatures without prompts until it is locked. A dashed
-    return path shows signing back in: the same ceremony returns the same 32
-    bytes. No secret is stored anywhere.
+    the private key from that output. Back in mera, a signing session signs
+    with the key held in memory. A dashed return path shows signing back in:
+    the same ceremony returns the same 32 bytes. No secret is stored anywhere.
   </title>
   <defs>
     <marker
@@ -70,7 +69,7 @@
   <rect class="d-secret" x="130" y="414" width="300" height="56" rx="8" />
   <text x="280" y="438" text-anchor="middle">Signing session</text>
   <text x="280" y="457" text-anchor="middle" class="d-sub">
-    signs without prompts until lock()
+    signs with the key held in memory
   </text>
 
   <path class="d-edge" d="M280 470 V502" marker-end="url(#gs-arrow)" />


### PR DESCRIPTION
Follow-up to #165. The overview diagram's session node read "signs without prompts until lock()", which frames signing against an expectation that only exists on the ceremony side of a passkey integration; signing itself is local key math and no crypto library prompts. The node now states what the session is: "signs with the key held in memory". The prompt contrast stays where an integrator actually asks the question, in the PRF page's prose.

## Screenshots

![gs-label2-diagram-1.png](https://github.com/user-attachments/assets/c9d50b18-bf78-4b23-80a1-5326b8890808)
