### PR TITLE
Say seed instead of master seed

### DIFF
--- a/demo/src/AccountCard.tsx
+++ b/demo/src/AccountCard.tsx
@@ -39,7 +39,7 @@ type AccountCardProps = {
  * then the chain-specific card for the active account.
  *
  * Switching accounts or chains never triggers a passkey ceremony because every
- * account was derived from the one master seed the wallet already holds.
+ * account was derived from the one seed the wallet already holds.
  */
 function AccountCard({
   wallet,

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -41,7 +41,7 @@ type AccountSlot = {
 /**
  * A connected wallet with one passkey ceremony's worth of authority.
  *
- * Passkey mode holds the BIP-39 master seed for the session and can mint more
+ * Passkey mode holds the BIP-39 seed for the session and can mint more
  * numbered HD accounts with no further passkey prompt. Vault mode exposes the
  * single decrypted account from its vault. Either way, `lock()` zeroes every
  * secret the wallet still holds.
@@ -52,7 +52,7 @@ type ConnectedWallet = {
   credentialId?: string;
   /** Returns the account at `index`, deriving and caching it on first use. */
   deriveAccount(index: number): AccountSlot;
-  /** Zeroes the master seed and every signing session handed out. */
+  /** Zeroes the seed and every signing session handed out. */
   lock(): void;
 };
 
@@ -65,10 +65,10 @@ const DEFAULT_USER = "nad";
 
 const rpId = location.hostname;
 
-/** Derives both chain sessions for one HD account index from the master seed. */
+/** Derives both chain sessions for one HD account index from the seed. */
 function deriveSlotFromSeed(seed: Uint8Array, index: number): AccountSlot {
   // Each derive* call returns a fresh buffer the session takes ownership of and
-  // zeroes; the master `seed` itself is never handed to a session.
+  // zeroes; the `seed` itself is never handed to a session.
   const secpSession = createSecp256k1SigningSession({
     consumePrivateKey: deriveEthereumPrivateKey(seed, index),
   });
@@ -88,12 +88,12 @@ function deriveSlotFromSeed(seed: Uint8Array, index: number): AccountSlot {
   };
 }
 
-// ----- Passkey mode: one PRF output is the HD master for every account -------
+// ----- Passkey mode: one PRF output is the HD root for every account ---------
 
 /**
  * Builds a passkey-mode wallet from a single PRF output.
  *
- * The PRF output becomes a BIP-39 master seed held in memory for the session,
+ * The PRF output becomes a BIP-39 seed held in memory for the session,
  * exactly like the signing keys are, and is zeroed alongside them on `lock()`.
  * Holding it lets "Add account" derive a new HD account without another
  * ceremony. The demo runs one ceremony per session rather than per account.
@@ -102,7 +102,7 @@ function buildPasskeyWallet(
   prfOutput: Uint8Array,
   credentialId: string,
 ): ConnectedWallet {
-  // PRF output -> BIP-39 mnemonic -> 64-byte master seed. The mnemonic string
+  // PRF output -> BIP-39 mnemonic -> 64-byte seed. The mnemonic string
   // is transient (re-derivable from a fresh ceremony for a future export flow);
   // only the zeroable seed bytes are retained.
   let seed: Uint8Array | undefined = mnemonicToSeed(

--- a/demo/src/hd.ts
+++ b/demo/src/hd.ts
@@ -31,7 +31,7 @@ function prfOutputToMnemonic(prfOutput: Uint8Array): string {
   return entropyToMnemonic(prfOutput, wordlist);
 }
 
-/** Derives the 64-byte BIP-39 master seed (PBKDF2, empty passphrase). */
+/** Derives the 64-byte BIP-39 seed (PBKDF2, empty passphrase). */
 function mnemonicToSeed(mnemonic: string): Uint8Array {
   return mnemonicToSeedSync(mnemonic);
 }

--- a/docs/src/assets/diagrams/bip32-tree.svg
+++ b/docs/src/assets/diagrams/bip32-tree.svg
@@ -7,8 +7,8 @@
   class="mera-diagram"
 >
   <title>
-    One master seed derives a tree of keys. The BIP-44 paths m/44'/60'/0'/0/0
-    and m/44'/60'/0'/0/1 name two EVM accounts, and the SLIP-0010 path
+    One seed derives a tree of keys. The BIP-44 paths m/44'/60'/0'/0/0 and
+    m/44'/60'/0'/0/1 name two EVM accounts, and the SLIP-0010 path
     m/44'/501'/0'/0' names a Solana account. The same seed and path produce the
     same key on any machine.
   </title>
@@ -27,7 +27,7 @@
   </defs>
 
   <rect class="d-secret" x="230" y="20" width="180" height="44" rx="8" />
-  <text x="320" y="48" text-anchor="middle">Master seed</text>
+  <text x="320" y="48" text-anchor="middle">Seed</text>
 
   <path class="d-edge" d="M320 64 L118 190" marker-end="url(#bt-arrow)" />
   <path class="d-edge" d="M320 64 V190" marker-end="url(#bt-arrow)" />

--- a/docs/src/assets/diagrams/derivation-pipeline.svg
+++ b/docs/src/assets/diagrams/derivation-pipeline.svg
@@ -8,10 +8,10 @@
 >
   <title>
     Pipeline from entropy to an address. Entropy, encoded as a seed phrase by
-    BIP-39, derives a master seed, then a private key via a derivation path,
-    then a public key via a one-way function, then an address. The entropy, seed
-    phrase, master seed, and private key are secret; the public key and address
-    are safe to share.
+    BIP-39, derives a seed, then a private key via a derivation path, then a
+    public key via a one-way function, then an address. The entropy, seed
+    phrase, seed, and private key are secret; the public key and address are
+    safe to share.
   </title>
   <defs>
     <marker
@@ -52,7 +52,7 @@
   <text x="152" y="107" class="d-note">key derivation (KDF)</text>
 
   <rect class="d-secret" x="30" y="132" width="220" height="56" rx="8" />
-  <text x="140" y="156" text-anchor="middle">Master seed</text>
+  <text x="140" y="156" text-anchor="middle">Seed</text>
   <text x="140" y="175" text-anchor="middle" class="d-sub">
     extends into a tree of keys
   </text>

--- a/docs/src/assets/diagrams/first-vs-returning.svg
+++ b/docs/src/assets/diagrams/first-vs-returning.svg
@@ -11,9 +11,9 @@
     creates the passkey and the app stores the credential metadata, credentialId
     and transports, which holds no key material. On a returning visit,
     getPasskeyPrfOutput signs in using the stored metadata. The PRF output
-    becomes the master seed through BIP-39, held in memory for the session, and
-    HD derivation by index produces the EVM and Solana signing sessions, ended
-    by lock().
+    becomes the seed through BIP-39, held in memory for the session, and HD
+    derivation by index produces the EVM and Solana signing sessions, ended by
+    lock().
   </title>
   <defs>
     <marker
@@ -77,7 +77,7 @@
   <text x="520" y="242" class="d-sub">BIP-39</text>
 
   <rect class="d-secret" x="384" y="264" width="248" height="56" rx="8" />
-  <text x="508" y="288" text-anchor="middle">Master seed</text>
+  <text x="508" y="288" text-anchor="middle">Seed</text>
   <text x="508" y="307" text-anchor="middle" class="d-sub">
     held in memory for the session
   </text>

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -34,7 +34,7 @@ Control of an account is the ability to sign: a transaction is valid when its si
 
 A key-derivation function (KDF) turns one secret into others: the output looks random, and the same input always produces the same output. A key that can be recomputed never needs to be stored.
 
-BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one master seed into a tree of child keys, where a derivation path such as `m/44'/60'/0'/0/0` names one key. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account. (BIP is a Bitcoin Improvement Proposal; several became standards beyond Bitcoin.)
+BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, where a derivation path such as `m/44'/60'/0'/0/0` names one key. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account. (BIP is a Bitcoin Improvement Proposal; several became standards beyond Bitcoin.)
 
 <Bip32Tree />
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -70,9 +70,9 @@ const record =
 localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 ```
 
-## Hold a master seed for the session
+## Hold a seed for the session
 
-Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) master seed once, zero the output, and keep the seed in memory for the session. The master seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, zero the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -152,7 +152,7 @@ for (const account of accounts) {
 seed.fill(0);
 ```
 
-Sessions zero their own key copies on `lock()`. The master seed is the app's buffer, so zeroing it is the app's job.
+Sessions zero their own key copies on `lock()`. The seed is the app's buffer, so zeroing it is the app's job.
 
 ## Pitfalls
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -77,7 +77,7 @@ async function unlockPhrase(): Promise<string> {
 
 ## Derive signing sessions
 
-The phrase is a standard BIP-39 mnemonic, so key derivation from here is the same derivation passkey accounts use: master seed, then per-index paths. [Create passkey accounts](/recipes/create-passkey-accounts/) has both curves; pass it `mnemonicToSeedSync(phrase)` instead of a PRF-derived seed and zero the seed after the sessions exist.
+The phrase is a standard BIP-39 mnemonic, so key derivation from here is the same derivation passkey accounts use: one seed, then per-index paths. [Create passkey accounts](/recipes/create-passkey-accounts/) has both curves; pass it `mnemonicToSeedSync(phrase)` instead of a PRF-derived seed and zero the seed after the sessions exist.
 
 ## Pitfalls
 


### PR DESCRIPTION
Replaces "master seed" with "seed" across the docs prose, the diagrams, and the demo's code comments, following the industry's move to neutral terminology. Touches the entropy concepts page, both recipes, and the three diagrams that named the node (derivation pipeline, BIP-32 tree, first versus returning visit). A repo-wide screen for other non-neutral terms (whitelist/blacklist, sanity, dummy, man-in-the-middle, and similar) found nothing else; the remaining matches are the demo comments fixed here. The `HDKey.fromMasterSeed` identifier in code examples is the @scure/bip32 API and stays as is; BIP spec URLs containing `/blob/master/` also stay.

One heading changed with its anchor (`#hold-a-master-seed-for-the-session` becomes `#hold-a-seed-for-the-session`); nothing in the repo links to the old anchor.

## Screenshots

![seed-entropy-diagram-1.png](https://github.com/user-attachments/assets/45f0be17-ee87-44db-974a-3a020c5d4d83)
![seed-entropy-diagram-2.png](https://github.com/user-attachments/assets/a1525e66-71ff-4fb8-9e11-ec448c85500a)
![seed-recipe-diagram-1.png](https://github.com/user-attachments/assets/0b9b5693-9d40-4bc5-9e9a-f7e3d7c77ab4)

