### PR TITLE
Conform the docs to the AGENTS.md writing rules

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -31,7 +31,7 @@ Fixed section order:
 2. A short lead with no heading: what the function does, plus only facts no later section carries. Visible side effects belong here; functions that run WebAuthn ceremonies say so, because a browser prompt is one. Anything stated in or inferable from Parameters, Returns, or Errors is not repeated in the lead.
 3. `## Import`: a single import statement.
 4. `## Usage`: one focused, compilable example.
-5. `## Parameters`: an intro line naming the options type, then one `### options.field` subheading per field (dotted for nested fields). Under each: a `- Type:` line, a `- Required` or `- Optional` line (with the default or omission behavior), then prose.
+5. `## Parameters`: an intro line naming the options type, then one `### options.field` subheading per field (dotted for nested fields). Under each: a `- Type:` line, a `- Required` or `- Optional` line (with the default or omission behavior), then prose. Functions without an options object use one `### name` subheading per positional parameter and omit the intro line.
 6. `## Returns`: the named result type and what it contains. When the return value has members of its own, each member is documented here.
 7. `## Errors`: one bullet per error code with its trigger condition, each code linked to its anchor on the errors page.
 8. `## Notes`: copy and zeroing semantics, determinism statements, caveats. Omit the section when there is nothing to say.

--- a/docs/src/content/docs/authenticator-support.md
+++ b/docs/src/content/docs/authenticator-support.md
@@ -3,7 +3,7 @@ title: Authenticator support
 description: Which authenticators deliver WebAuthn PRF, and since when.
 ---
 
-mera requires three things from the authenticator stack: the WebAuthn PRF extension, discoverable credentials, and user verification. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/) defines all three.
+mera requires three things from the authenticator stack: the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension, discoverable credentials, and user verification. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/) defines all three.
 
 In the table, `✓` means a live PRF create + get cycle has been confirmed end-to-end; `Not supported` means a live test did not return PRF.
 
@@ -29,7 +29,7 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 ## The desktop Chrome complication
 
-On desktop Chrome, only passkeys saved to Google Password Manager carry PRF; the local profile authenticator lacks the CTAP2 [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) extension.
+On desktop Chrome, only passkeys saved to Google Password Manager carry PRF; the local profile authenticator lacks [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) primitive behind PRF.
 
 Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but returns no PRF output, so mera cannot use it; [createPasskey](/reference/create-passkey/) documents the ordering caveat.
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -40,7 +40,7 @@ BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/mas
 
 ## Seed phrases
 
-BIP-39 maps entropy to a phrase of common words and back: 128 bits become 12 words, 256 bits become 24. The phrase is an encoding, adding no security of its own; whoever reads it holds the entropy.
+BIP-39 maps entropy to a phrase of common words and back: 128 bits become 12 words, 256 bits become 24. The phrase is an encoding, adding no security of its own: anyone who reads the phrase can recover the entropy.
 
 A wallet app that follows the same standards (MetaMask and Phantom are two) turns an imported phrase back into the same accounts, which gives accounts built this way an exit path independent of any one library.
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
 
-A secret vault holds one secret, a recovery phrase, a private key, any bytes, encrypted so that only a passkey ceremony can decrypt it. Vaults cover the cases where key material must come from outside the passkey. The most important is migration: an existing account moves to passkey sign-in by encrypting its secret once. Apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
+A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony can decrypt it. Vaults cover the cases where key material must come from outside the passkey; apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
 
 ## How a vault works
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -13,7 +13,7 @@ Input buffers are copied before any async work starts, so mutating a buffer afte
 
 Owned copies are zeroed where possible. A signing session zeroes the caller's private-key buffer when it consumes it, even when construction throws, and zeroes its own copy on `lock()`. [createSecretVault](/reference/create-secret-vault/) zeroes its internal secret and PRF-output copies. Secret-vault workflow functions also zero the transient secret and PRF-output copies they own before settling.
 
-WebAuthn challenges are generated internally. So are AES-GCM nonces: a nonce is a value that must never repeat under one encryption key, so the library generates 12 fresh bytes per encryption and a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
+[WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges are generated internally. So are AES-GCM nonces: a nonce is a value that must never repeat under one encryption key, so the library generates 12 fresh bytes per encryption and a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
 
 ## What a compromised runtime sees
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import GettingStartedOverview from "../../assets/diagrams/getting-started-overvi
 
 Prerequisites:
 
-- A browser with WebAuthn, in a secure context: HTTPS, or `localhost` during development.
+- A browser with [WebAuthn](https://www.w3.org/TR/webauthn-3/) (the browser standard for signing in with key pairs instead of passwords), in a secure context: HTTPS, or `localhost` during development.
 - A passkey authenticator that supports the WebAuthn PRF extension. [Authenticator support](/authenticator-support/) lists the combinations known to work; 1Password and iCloud Keychain are good first choices.
 
 <GettingStartedOverview />

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -5,11 +5,9 @@ description: Numbered EVM and Solana accounts from a single ceremony, with crede
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM and Solana accounts, credential pinning, one passkey ceremony per session, and locking.
+This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM and Solana accounts, credential pinning, one passkey ceremony per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/authenticator-support/)).
 
 Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
-
-Prerequisites: `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/authenticator-support/)).
 
 <FirstVsReturning />
 
@@ -99,7 +97,8 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
   const node = HDKey.fromMasterSeed(seed).derive(`m/44'/60'/0'/0/${index}`);
   if (node.privateKey === null) throw new Error("derivation produced no key");
   const session = createSecp256k1SigningSession({
-    consumePrivateKey: node.privateKey,
+    // Copy out of the HDKey so the session can own and later zero the buffer.
+    consumePrivateKey: new Uint8Array(node.privateKey),
   });
   return { session, address: getEvmAddress(session.publicKey) };
 }

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,11 +3,9 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
-
-Prerequisites: `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 ## Validate the phrase
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -57,7 +57,7 @@ Signs an arbitrary-length message and resolves to the 64-byte Ed25519 signature 
 
 ### lock()
 
-Zeroes the session-owned private-key copy and permanently locks the session; later signing throws `SESSION_LOCKED`.
+Zeroes the session-owned private-key copy and permanently locks the session; later signing throws [`SESSION_LOCKED`](/reference/errors/#session_locked).
 
 ### [Symbol.dispose]()
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -3,7 +3,7 @@ title: createPasskeyWithPrfOutput
 description: Creates a passkey and returns its deterministic PRF output in one call.
 ---
 
-Creates a passkey and returns its WebAuthn PRF output, using mera's fixed v1 salt by default. If [createPasskey](/reference/create-passkey/) returns no `prfOutput`, the function runs [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt, which may show a second browser prompt.
+Creates a passkey and returns its [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output, using mera's fixed v1 salt by default. If [createPasskey](/reference/create-passkey/) returns no `prfOutput`, the function runs [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt, which may show a second browser prompt.
 
 ## Import
 
@@ -14,8 +14,6 @@ import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 ## Usage
 
 ```ts
-import { createPasskeyWithPrfOutput } from "@category-labs/mera";
-
 const result = await createPasskeyWithPrfOutput({
   rp: { id: "account.example.com", name: "Example" },
   user: { name: "account@example.com", displayName: "Example account" },

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -3,7 +3,7 @@ title: createPasskey
 description: Creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled.
 ---
 
-Creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
+Creates a discoverable, user-verified passkey with the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension enabled. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
 
 ## Import
 
@@ -84,9 +84,9 @@ The credential is requested with fixed parameters: ES256 or RS256 key types, att
 
 The WebAuthn challenge is generated internally. The raw attestation response is not returned.
 
-A `PRF_UNAVAILABLE` failure happens after the creation ceremony has completed: the passkey exists on the authenticator, but the thrown error does not carry its metadata. The credential still appears in the authenticator's passkey list.
+A [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable) failure happens after the creation ceremony has completed: the passkey exists on the authenticator, but the thrown error does not carry its metadata. The credential still appears in the authenticator's passkey list.
 
-WebAuthn availability is checked before Web Crypto, so an environment missing both throws `PASSKEY_OPERATION_FAILED`.
+WebAuthn availability is checked before Web Crypto, so an environment missing both throws [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed).
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -57,7 +57,7 @@ Signs a 32-byte digest without prehashing it and resolves to a `Secp256k1Signatu
 
 ### lock()
 
-Zeroes the session-owned private-key copy and permanently locks the session; later signing throws `SESSION_LOCKED`.
+Zeroes the session-owned private-key copy and permanently locks the session; later signing throws [`SESSION_LOCKED`](/reference/errors/#session_locked).
 
 ### [Symbol.dispose]()
 
@@ -83,7 +83,7 @@ Signing needs no passkey ceremony and shows no prompt; the session signs as ofte
 
 The digest is copied before signing; the original is not modified.
 
-The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with `INPUT_INVALID` rather than return a signature that cannot be address-recovered.
+The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -42,7 +42,7 @@ try {
 - Type: `string`
 - Required
 
-Relying party ID for the WebAuthn assertion. It must match the ID under which the passkey was created.
+Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion. It must match the ID under which the passkey was created.
 
 ### options.credential
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -14,8 +14,6 @@ import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
 ## Usage
 
 ```ts
-import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
-
 const secret = new TextEncoder().encode("the secret to protect");
 try {
   const vault = await createSecretVaultWithNewPasskey({
@@ -38,7 +36,7 @@ try {
 - Type: `PublicKeyCredentialRpEntity & { id: string }`
 - Required, including `rp.id`
 
-Relying party identity passed to WebAuthn. The required ID is reused by the fallback assertion.
+Relying party identity passed to [WebAuthn](https://www.w3.org/TR/webauthn-3/). The required ID is reused by the fallback assertion.
 
 ### options.user
 

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -30,9 +30,13 @@ const credential = await createPasskeyWithPrfOutput({
 });
 
 const secret = new TextEncoder().encode("the secret to protect");
-
-const vault = await createSecretVault({ credential, secret });
-localStorage.setItem("vault", JSON.stringify(vault));
+try {
+  const vault = await createSecretVault({ credential, secret });
+  localStorage.setItem("vault", JSON.stringify(vault));
+} finally {
+  secret.fill(0);
+  credential.prfOutput.fill(0);
+}
 ```
 
 ## Parameters

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -40,7 +40,7 @@ try {
 - Type: `string`
 - Required
 
-Relying party ID for the WebAuthn assertion. It must match the ID under which the vault's passkey was created.
+Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion. It must match the ID under which the vault's passkey was created.
 
 ### options.vault
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault.md
@@ -50,7 +50,7 @@ A parsed secret vault. Run untrusted stored data through [parseSecretVault](/ref
 - Type: `Uint8Array`
 - Required
 
-The 32-byte WebAuthn PRF output for the vault's stored salt. Copied before async cryptographic work starts; the caller-owned buffer is not modified or zeroed.
+The 32-byte [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output for the vault's stored salt. Copied before async cryptographic work starts; the caller-owned buffer is not modified or zeroed.
 
 ## Returns
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -13,7 +13,7 @@ class MeraError extends Error {
 }
 ```
 
-`name` is always `"MeraError"`. When a lower-level failure triggered the error (a WebAuthn rejection, a Web Crypto failure), it is attached as `cause`.
+`name` is always `"MeraError"`. When a lower-level failure triggered the error (a [WebAuthn](https://www.w3.org/TR/webauthn-3/) rejection, a Web Crypto failure), it is attached as `cause`.
 
 ## isMeraError
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -14,8 +14,6 @@ import { getPasskeyPrfOutput } from "@category-labs/mera";
 ## Usage
 
 ```ts
-import { getPasskeyPrfOutput } from "@category-labs/mera";
-
 const { credentialId, prfOutput } = await getPasskeyPrfOutput({
   rpId: "account.example.com",
 });
@@ -30,7 +28,7 @@ const { credentialId, prfOutput } = await getPasskeyPrfOutput({
 - Type: `string`
 - Required
 
-Relying party ID for the WebAuthn assertion.
+Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion.
 
 ### options.credential
 
@@ -72,7 +70,7 @@ The assertion requires user verification, and the requirement is not configurabl
 
 The WebAuthn challenge is generated internally. The raw assertion response is not returned.
 
-WebAuthn availability is checked before Web Crypto, so an environment missing both throws `PASSKEY_OPERATION_FAILED`.
+WebAuthn availability is checked before Web Crypto, so an environment missing both throws [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed).
 
 ## See also
 

--- a/docs/src/content/docs/reference/get-secret-vault-prf-output.md
+++ b/docs/src/content/docs/reference/get-secret-vault-prf-output.md
@@ -3,7 +3,7 @@ title: getSecretVaultPrfOutput
 description: Performs the WebAuthn assertion needed to unlock a secret vault.
 ---
 
-Performs the WebAuthn assertion needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Performs the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
 
 Reads the credential metadata and PRF salt out of a parsed vault and delegates to [getPasskeyPrfOutput](/reference/get-passkey-prf-output/), so the assertion is automatically pinned to the credential that encrypted the secret.
 

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -7,7 +7,7 @@ Each exported function has its own page. Types are documented on the pages of th
 
 ## Passkeys
 
-- [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled.
+- [createPasskey](/reference/create-passkey/): creates a discoverable, user-verified passkey with the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension enabled.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns its deterministic PRF output in one call.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the deterministic output.
 - [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): returns the default salt explicitly for interoperability and custom composition.

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -37,7 +37,7 @@ A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The creden
 
 ## Notes
 
-A vault that came through this function cannot trigger the `INPUT_INVALID` re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), [decryptSecretVault](/reference/decrypt-secret-vault/), or [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/). Cryptographic failure (`DECRYPT_FAILED`) and ceremony failure remain possible.
+A vault that came through this function cannot trigger the [`INPUT_INVALID`](/reference/errors/#input_invalid) re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), [decryptSecretVault](/reference/decrypt-secret-vault/), or [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/). Cryptographic failure ([`DECRYPT_FAILED`](/reference/errors/#decrypt_failed)) and ceremony failure remain possible.
 
 A future vault format will use a higher version number. Rejecting an unknown version keeps an old library from misreading newer data.
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -35,6 +35,7 @@ Authenticator transports reported by the browser when the passkey was created. O
 ### prfSalt
 
 The PRF salt for this secret, 32 bytes as canonical unpadded base64url. Chosen by the app per vault, and typically generated fresh and randomly; storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
+
 ### nonce
 
 The 12-byte AES-GCM nonce, base64url. Generated internally by [createSecretVault](/reference/create-secret-vault/) for each encryption.


### PR DESCRIPTION
A conformance review of `docs/src/content/docs/` against `docs/AGENTS.md` found the pages drifting from several rules as written: per-page spec-link coverage for WebAuthn and CTAP, error-code links outside `## Errors` sections, recipe prerequisites placed after the first paragraph, one aphorism-shaped sentence, a migration point stated twice on the secret-vaults page, and two examples that contradicted guidance stated elsewhere (the recipe handed an HDKey's live private-key buffer to a signing session against the reference page's advice, and the `createSecretVault` example skipped the zeroing its own Notes require).

The fixes conform the pages to the rules rather than relaxing them, with one deliberate exception: the reference Parameters rule only described options-bag functions, while five positional-parameter pages had already settled on a consistent shape, so the rule now covers that shape instead of churning the pages.

Validation beyond CI: `npm run build` passes, and the mechanical sweeps over the content tree run clean (W3C/FIDO link coverage on every mentioning page, no bare error codes, no em dashes, no banned vocabulary, neutral possessives).