### PR TITLE
Conform the docs pages to the docs/AGENTS.md writing rules

### DIFF
--- a/docs/src/content/docs/authenticator-support.md
+++ b/docs/src/content/docs/authenticator-support.md
@@ -31,7 +31,7 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 On desktop Chrome, only passkeys saved to Google Password Manager carry PRF; the local profile authenticator lacks [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) primitive behind PRF.
 
-Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but returns no PRF output, so mera cannot use it; [createPasskey](/reference/create-passkey/) documents the ordering caveat.
+Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but returns no PRF output, so mera cannot use it. [createPasskey](/reference/create-passkey/) fails only after the creation ceremony has completed, so the unusable passkey stays in the authenticator's passkey list.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -6,7 +6,7 @@ description: How random bytes become a private key, an address, and a reproducib
 import DerivationPipeline from "../../../assets/diagrams/derivation-pipeline.svg";
 import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
 
-The blockchain background the rest of the docs assume: how 32 random bytes become a private key, an account, and a reproducible family of accounts. Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
+The rest of the docs assume the blockchain background this page teaches: how 32 random bytes become a private key, an account, and a reproducible family of accounts. Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
 
 <DerivationPipeline />
 
@@ -46,7 +46,7 @@ A wallet app that follows the same standards (MetaMask and Phantom are two) turn
 
 ## Where mera fits
 
-mera supplies the root: a passkey ceremony returns 32 bytes of PRF output, and the app uses them as the entropy for this pipeline. Derivation, paths, and phrases are app-owned; the library returns entropy and signs.
+mera supplies the root: a passkey ceremony returns 32 bytes of PRF output, secret bytes the passkey recomputes deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains how), and the app uses them as the entropy for this pipeline. Derivation, paths, and phrases are app-owned; the library returns entropy and signs.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -3,7 +3,7 @@ title: Passkey accounts
 description: Accounts derived from a passkey's PRF output, with no stored secret.
 ---
 
-A passkey account is a blockchain account whose keys derive from a passkey's PRF output. No secret is stored anywhere; each ceremony recomputes the same accounts. This is the default way to use mera.
+A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). No secret is stored anywhere; each ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, recomputes the same accounts. This is the default way to use mera.
 
 ## One salt, one stable output
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -7,7 +7,7 @@ import PrfFunction from "../../../assets/diagrams/prf-function.svg";
 
 A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords; a credential is one such key pair, created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
-**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another. The [security model](/concepts/security-model/) covers what this means for domain migrations.
+**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, ceremonies under the new domain cannot reach the old credential, so everything derived from it becomes unreachable there. The [security model](/concepts/security-model/) covers migrations in depth.
 
 **Passkeys sync.** Platform authenticators replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -9,11 +9,11 @@ sidebar:
 
 import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
 
-A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony can decrypt it. Vaults cover the cases where key material must come from outside the passkey; apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
+A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, can decrypt it. Vaults cover the cases where key material must come from outside the passkey; apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey against a fresh random salt for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey's PRF, the extension that makes a passkey return deterministic secret bytes ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains it), against a fresh random salt for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -25,7 +25,7 @@ The mitigations are app-level: lock sessions when idle, keep derivation windows 
 
 ## rpId binding
 
-PRF output is a function of the credential, the relying party ID, and the salt. A passkey can be used only under the rpId it was created for, so after a domain migration the app cannot run assertions under the old one. That breaks both patterns: passkey accounts can no longer be reproduced, and secret vaults can no longer be decrypted.
+PRF output, the secret bytes a passkey returns through its [PRF extension](/concepts/passkeys-and-prf/), is a function of the credential, the relying party ID, and the salt. A passkey can be used only under the rpId it was created for, so after a domain migration the app cannot run assertions under the old one. That breaks both patterns: passkey accounts can no longer be reproduced, and secret vaults can no longer be decrypted.
 
 Treat the rpId as a long-lived choice. Before any planned migration, accounts need an export path.
 
@@ -33,7 +33,7 @@ Treat the rpId as a long-lived choice. Before any planned migration, accounts ne
 
 If one PRF output is reused for unrelated purposes, exposing it compromises them all. Use a different salt per purpose, or split one output with a purpose-labeled key-derivation function (KDF), a deterministic function that turns one secret into separate purpose-specific keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)).
 
-A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. The secret-vault creation functions generate a fresh random 32-byte salt for each secret; the [createSecretVault](/reference/create-secret-vault/) page documents the low-level requirement.
+A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. The secret-vault workflow functions generate a fresh random 32-byte salt for each secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves supplying a fresh salt per secret to the caller.
 
 ## Strings cannot be zeroed
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,7 +5,7 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing.
+A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing. A ceremony is one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, and PRF output is the 32 secret bytes the passkey returns deterministically; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains both.
 
 Two constructors exist, one per signature scheme ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces both): [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests (a digest is the fixed-length hash of the content to sign) and [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 
@@ -17,7 +17,7 @@ Because a session never contacts an authenticator, signing never prompts: the on
 
 ## The lifecycle
 
-Construction consumes the key: the session keeps the only library-side copy and zeroes the caller's input buffer, even when construction throws. Locking zeroes the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`; permanence is what makes the lock meaningful.
+Construction consumes the key: the session keeps the only library-side copy and zeroes the caller's input buffer, even when construction throws. Locking zeroes the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import GettingStartedOverview from "../../assets/diagrams/getting-started-overvi
 
 Prerequisites:
 
-- A browser with [WebAuthn](https://www.w3.org/TR/webauthn-3/) (the browser standard for signing in with key pairs instead of passwords), in a secure context: HTTPS, or `localhost` during development.
+- A browser with [WebAuthn](https://www.w3.org/TR/webauthn-3/) (the browser standard for signing in with key pairs instead of passwords; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/) covers the background), in a secure context: HTTPS, or `localhost` during development.
 - A passkey authenticator that supports the WebAuthn PRF extension. [Authenticator support](/authenticator-support/) lists the combinations known to work; 1Password and iCloud Keychain are good first choices.
 
 <GettingStartedOverview />
@@ -39,7 +39,7 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 });
 ```
 
-The call prompts once or twice when the authenticator needs a follow-up assertion to evaluate PRF.
+The call prompts once, or twice when the authenticator needs a follow-up assertion to evaluate PRF.
 
 mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID; [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
@@ -71,8 +71,7 @@ import {
 } from "@category-labs/mera";
 
 const session = createSecp256k1SigningSession({
-  // Copy out of the HDKey so the session can own and later zero the buffer.
-  consumePrivateKey: new Uint8Array(node.privateKey),
+  consumePrivateKey: node.privateKey,
 });
 
 const address = getEvmAddress(session.publicKey);

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -1,9 +1,9 @@
 ---
 title: mera
-description: Accounts on any chain and platform, backed by a passkey.
+description: Derive accounts on any chain and platform from a passkey.
 template: splash
 hero:
-  tagline: Accounts on any chain and platform, backed by a passkey.
+  tagline: Derive accounts on any chain and platform from a passkey.
   actions:
     - text: Getting started
       link: /getting-started/

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -1,9 +1,9 @@
 ---
 title: mera
-description: Derive accounts on any chain and platform from a passkey.
+description: Accounts on any chain and platform, backed by a passkey.
 template: splash
 hero:
-  tagline: Derive accounts on any chain and platform from a passkey.
+  tagline: Accounts on any chain and platform, backed by a passkey.
   actions:
     - text: Getting started
       link: /getting-started/

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -1,11 +1,11 @@
 ---
 title: Create passkey accounts
-description: Numbered EVM and Solana accounts from a single ceremony, with credential pinning.
+description: Create numbered EVM and Solana accounts from one passkey ceremony, with credential pinning.
 ---
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM and Solana accounts, credential pinning, one passkey ceremony per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/authenticator-support/)).
+This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey ceremony per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/authenticator-support/)). PRF is the [WebAuthn](https://www.w3.org/TR/webauthn-3/) extension that makes a passkey return deterministic secret bytes; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism.
 
 Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
@@ -28,7 +28,7 @@ const created = await createPasskeyWithPrfOutput({
 created.prfOutput.fill(0);
 ```
 
-`user.id` is left to its default, a fresh 32-byte random handle, so every create call makes a distinct, parallel passkey rather than silently overwriting an existing one.
+`user.id` is left to its default, a fresh 32-byte random handle, so every create call makes a distinct, parallel passkey.
 
 ## Remember the credential
 
@@ -61,8 +61,8 @@ const { prfOutput, credentialId } = await getPasskeyPrfOutput({
   credential: known,
 });
 
-// The ceremony reports which credential was actually used; the person may
-// have picked a different passkey than the stored one.
+// The ceremony reports which credential was used; with no stored record,
+// the browser may have offered any discoverable passkey for the domain.
 const record =
   known?.credentialId === credentialId ? known : { credentialId };
 localStorage.setItem("app.derivedCredential", JSON.stringify(record));
@@ -97,8 +97,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
   const node = HDKey.fromMasterSeed(seed).derive(`m/44'/60'/0'/0/${index}`);
   if (node.privateKey === null) throw new Error("derivation produced no key");
   const session = createSecp256k1SigningSession({
-    // Copy out of the HDKey so the session can own and later zero the buffer.
-    consumePrivateKey: new Uint8Array(node.privateKey),
+    consumePrivateKey: node.privateKey,
   });
   return { session, address: getEvmAddress(session.publicKey) };
 }
@@ -134,7 +133,7 @@ function deriveSolanaAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-The derivation paths are an app choice; these two are the shared wallet conventions. A phrase imported into a wallet app that follows them (MetaMask and Phantom are two) reproduces the same addresses, so accounts keep an exit path that does not depend on mera.
+The derivation paths are an app choice; these two are the conventions wallet apps share. A phrase imported into a wallet app that follows them (MetaMask and Phantom are two) reproduces the same addresses, so accounts keep an exit path that does not depend on mera.
 
 Build the account list from these helpers:
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -3,11 +3,9 @@ title: Send a transaction with viem
 description: Sign in with a passkey, derive the first EVM account, and send a transaction through viem.
 ---
 
-This recipe turns a passkey sign-in into a sent transaction. [viem](https://viem.sh) is a TypeScript client library for EVM chains (chains that run the Ethereum Virtual Machine); [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session.
+This recipe turns a passkey sign-in into a sent transaction. Prerequisites: `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed, a PRF-capable authenticator ([authenticator support](/authenticator-support/)), an existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit), and test funds on the sending address. PRF is the [WebAuthn](https://www.w3.org/TR/webauthn-3/) extension that makes a passkey return deterministic secret bytes; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism.
 
-Derivation and client setup are app-owned; mera provides the ceremony, the session, and the adapter.
-
-Prerequisites: `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed, a PRF-capable authenticator ([authenticator support](/authenticator-support/)), an existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit), and test funds on the sending address.
+[viem](https://viem.sh) is a TypeScript client library for EVM chains (chains that run the Ethereum Virtual Machine); [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session. Derivation and client setup are app-owned; mera provides the ceremony, the session, and the adapter.
 
 ## Sign in
 
@@ -19,7 +17,7 @@ const rpId = location.hostname;
 const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 ```
 
-One ceremony, one user-verification prompt, and the only prompt on this page. Without `credential`, the browser offers every discoverable passkey for the domain; [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID.
+The call runs one ceremony with one user-verification prompt, the only prompt in this recipe. Without `credential`, the browser offers every discoverable passkey for the domain; [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID.
 
 ## Derive the key
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -45,11 +45,11 @@ try {
 }
 ```
 
-The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before settling. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
+The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before settling. PRF output is the deterministic secret bytes the passkey returns through the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension, and it keys the encryption; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
 
 ## Unlock
 
-One ceremony, pinned automatically to the credential stored in the vault:
+The unlock runs one ceremony, pinned automatically to the credential stored in the vault:
 
 ```ts
 import {

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -3,7 +3,7 @@ title: createPasskeyWithPrfOutput
 description: Creates a passkey and returns its deterministic PRF output in one call.
 ---
 
-Creates a passkey and returns its [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output, using mera's fixed v1 salt by default. If [createPasskey](/reference/create-passkey/) returns no `prfOutput`, the function runs [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt, which may show a second browser prompt.
+Creates a passkey and returns its [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output. It runs [createPasskey](/reference/create-passkey/)'s creation ceremony, which may show browser or authenticator UI; when that ceremony returns no `prfOutput`, it runs [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt, which may show a second prompt.
 
 ## Import
 
@@ -32,12 +32,26 @@ const result = await createPasskeyWithPrfOutput({
 
 Relying party identity, passed to WebAuthn.
 
-### options.user
+### options.user.name
 
-- Type: `{ id?: Uint8Array; name: string; displayName: string }`
+- Type: `string`
 - Required
 
-Same fields and constraints as on [createPasskey](/reference/create-passkey/#optionsusername): `name` and `displayName` are required, `id` is optional (1 to 64 bytes, fresh 32-byte random handle per call when omitted).
+User name displayed or stored by the authenticator.
+
+### options.user.displayName
+
+- Type: `string`
+- Required
+
+Human-readable display name for the authenticator UI.
+
+### options.user.id
+
+- Type: `Uint8Array`
+- Optional; a fresh 32-byte random handle is generated per call when omitted
+
+User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided, the same constraint as on [createPasskey](/reference/create-passkey/#optionsuserid). Copied before use.
 
 ### options.prfSalt
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -84,7 +84,7 @@ The credential is requested with fixed parameters: ES256 or RS256 key types, att
 
 The WebAuthn challenge is generated internally. The raw attestation response is not returned.
 
-A [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable) failure happens after the creation ceremony has completed: the passkey exists on the authenticator, but the thrown error does not carry its metadata. The credential still appears in the authenticator's passkey list.
+A [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable) failure happens after the creation ceremony has completed: the passkey exists on the authenticator and appears in its passkey list, but the thrown error does not carry its metadata.
 
 WebAuthn availability is checked before Web Crypto, so an environment missing both throws [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed).
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -3,7 +3,7 @@ title: createSecretVaultWithExistingPasskey
 description: Encrypts one secret into a vault using an existing passkey and a fresh random salt.
 ---
 
-Evaluates an existing passkey against a fresh random salt and encrypts one secret into a vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Evaluates an existing passkey and encrypts one secret into a vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
 
 ## Import
 
@@ -67,7 +67,7 @@ WebAuthn timeout in milliseconds.
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault containing the selected credential metadata, generated PRF salt, nonce, and ciphertext.
+`Promise<PasskeySecretVault>`: a JSON-safe vault containing the selected credential metadata, generated PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -61,7 +61,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault containing the new credential metadata, generated PRF salt, nonce, and ciphertext.
+`Promise<PasskeySecretVault>`: a JSON-safe vault containing the new credential metadata, generated PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -68,11 +68,11 @@ Secret bytes to encrypt. Any non-empty length; the library does not interpret th
 
 ## Notes
 
-**Use a fresh random salt per secret.** A vault is bound to its `prfOutput` only, never to the credential ID or salt. Secrets encrypted using one reused PRF output share an encryption key, so their nonce/ciphertext pairs are interchangeable by anyone who can rewrite stored vault JSON.
+A vault is bound to its `prfOutput` only, never to the credential ID or salt: secrets encrypted using one reused PRF output share an encryption key, so their nonce/ciphertext pairs are interchangeable by anyone who can rewrite stored vault JSON. A fresh random salt per secret produces unrelated PRF outputs and distinct keys.
 
 The GCM nonce (12 bytes) is generated internally for each encryption, so a caller cannot accidentally reuse one.
 
-Input byte buffers are copied before async cryptographic work starts; mutating them after the call does not change the vault being produced. Caller-owned buffers are not modified or zeroed by this function; the internal copies of the PRF output and secret are zeroed before it returns. Callers that are done with their own `prfOutput` and `secret` buffers should zero them.
+Input byte buffers are copied before async cryptographic work starts; mutating them after the call does not change the vault being produced. Caller-owned buffers are not modified or zeroed by this function; the internal copies of the PRF output and secret are zeroed before it returns, so the caller's `prfOutput` and `secret` buffers are the only copies left in memory.
 
 ## See also
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -47,7 +47,7 @@ Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion
 - Type: `PasskeySecretVault`
 - Required
 
-A parsed secret vault. Run untrusted stored data through [parseSecretVault](/reference/parse-secret-vault/) first. The assertion is restricted to the credential stored in the vault.
+A parsed secret vault; [parseSecretVault](/reference/parse-secret-vault/) produces one from untrusted stored data. The assertion is restricted to the credential stored in the vault.
 
 ### options.timeout
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault.md
@@ -43,24 +43,30 @@ try {
 - Type: `PasskeySecretVault`
 - Required
 
-A parsed secret vault. Run untrusted stored data through [parseSecretVault](/reference/parse-secret-vault/) first.
+A parsed secret vault; [parseSecretVault](/reference/parse-secret-vault/) produces one from untrusted stored data.
 
 ### options.prfOutput
 
 - Type: `Uint8Array`
 - Required
 
-The 32-byte [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output for the vault's stored salt. Copied before async cryptographic work starts; the caller-owned buffer is not modified or zeroed.
+The 32-byte [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output for the vault's stored salt.
 
 ## Returns
 
-`Promise<Uint8Array>`: the decrypted secret bytes, exactly as they were passed to [createSecretVault](/reference/create-secret-vault/). The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it. Zeroing it after use is the caller's job.
+`Promise<Uint8Array>`: the decrypted secret bytes, exactly as they were passed to [createSecretVault](/reference/create-secret-vault/).
 
 ## Errors
 
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
 - [`DECRYPT_FAILED`](/reference/errors/#decrypt_failed): AES-GCM authentication failed, meaning wrong key material or a tampered vault. The two are indistinguishable.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+
+## Notes
+
+The `prfOutput` buffer is copied before async cryptographic work starts; the caller-owned buffer is not modified or zeroed.
+
+The returned buffer is a fresh allocation; the library keeps no reference to it and never zeroes it. Zeroing it after use is the caller's job.
 
 ## See also
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -35,7 +35,7 @@ try {
 }
 ```
 
-A type guard: returns `true` when the value is a `MeraError` instance. Narrow with it first, then branch on `code`.
+`isMeraError` is a type guard that returns `true` when the value is a `MeraError` instance, narrowing the value so `code` can be branched on.
 
 ## Codes
 
@@ -49,11 +49,11 @@ Web Crypto is unavailable. In practice this means the page is running outside a 
 
 ### PRF_UNAVAILABLE
 
-The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path this fires after the creation ceremony has completed, so the passkey exists on the authenticator even though the error carries no metadata; [createPasskey](/reference/create-passkey/) documents the caveat. [Authenticator support](/authenticator-support/) lists tested compatible stacks.
+The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path this fires after the creation ceremony has completed, so the passkey exists on the authenticator even though the error carries no metadata ([createPasskey](/reference/create-passkey/) documents the create path). [Authenticator support](/authenticator-support/) lists tested compatible stacks.
 
 ### SESSION_LOCKED
 
-A signing call was made after the session's `lock()`. Locking is permanent; recover by building a new session from fresh key material.
+A signing call was made after the session's `lock()`. Locking is permanent; new signatures require a new session built from fresh key material.
 
 ### DECRYPT_FAILED
 

--- a/docs/src/content/docs/reference/get-secret-vault-prf-output.md
+++ b/docs/src/content/docs/reference/get-secret-vault-prf-output.md
@@ -39,14 +39,14 @@ const secret = await decryptSecretVault({ vault, prfOutput });
 - Type: `string`
 - Required
 
-Relying party ID for the WebAuthn assertion. Must match the rpId the passkey was created under.
+Relying party ID for the WebAuthn assertion. It must match the rpId the passkey was created under.
 
 ### options.vault
 
 - Type: `PasskeySecretVault`
 - Required
 
-A parsed secret vault. Run untrusted stored data through [parseSecretVault](/reference/parse-secret-vault/) first; this function trusts the vault's shape.
+A parsed secret vault; this function trusts its shape. [parseSecretVault](/reference/parse-secret-vault/) produces one from untrusted stored data.
 
 ### options.timeout
 

--- a/docs/src/content/docs/reference/is-solana-address.md
+++ b/docs/src/content/docs/reference/is-solana-address.md
@@ -32,7 +32,7 @@ The string to check.
 
 ## Returns
 
-`boolean`, and a type predicate for `SolanaAddress`. Decode failures are caught internally and return `false`.
+`boolean`, and a type predicate for `SolanaAddress`.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -39,7 +39,7 @@ A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The creden
 
 A vault that came through this function cannot trigger the [`INPUT_INVALID`](/reference/errors/#input_invalid) re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), [decryptSecretVault](/reference/decrypt-secret-vault/), or [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/). Cryptographic failure ([`DECRYPT_FAILED`](/reference/errors/#decrypt_failed)) and ceremony failure remain possible.
 
-A future vault format will use a higher version number. Rejecting an unknown version keeps an old library from misreading newer data.
+Rejecting an unknown version keeps an old library from misreading data written by a newer format.
 
 ## See also
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -34,7 +34,7 @@ Authenticator transports reported by the browser when the passkey was created. O
 
 ### prfSalt
 
-The PRF salt for this secret, 32 bytes as canonical unpadded base64url. Chosen by the app per vault, and typically generated fresh and randomly; storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
+The PRF salt for this secret, 32 bytes as canonical unpadded base64url. The workflow functions generate it fresh and randomly per vault; the low-level [createSecretVault](/reference/create-secret-vault/) path accepts an app-supplied salt, which must be fresh per secret. Storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
 
 ### nonce
 
@@ -48,7 +48,7 @@ The AES-GCM ciphertext including its 16-byte authentication tag, base64url. The 
 
 The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
 
-The credential ID and salt are stored but not authenticated: the AES-GCM additional authenticated data is a fixed constant (`mera.v1.secret.aad` plus the version), so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored JSON. [createSecretVault](/reference/create-secret-vault/) carries the same warning.
+The credential ID and salt are stored but not authenticated: the AES-GCM additional authenticated data is a fixed constant (`mera.v1.secret.aad` plus the version), so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored JSON.
 
 ## Portability
 

--- a/docs/src/content/docs/reference/to-viem-account.md
+++ b/docs/src/content/docs/reference/to-viem-account.md
@@ -3,7 +3,7 @@ title: toViemAccount
 description: Adapts a secp256k1 signing session into a viem local account.
 ---
 
-Adapts a secp256k1 signing session into a viem local account. Each signing method hashes its input with viem's own hashers and signs the resulting 32-byte digest with `session.signDigest`, so signing shows no passkey prompt. The function lives in the `@category-labs/mera/viem` entry point, which requires `viem` (`^2.28.0`) as an optional peer dependency; the root entry point does not use viem.
+Adapts a secp256k1 signing session into a viem local account. Every signing method signs through `session.signDigest`, so signing shows no passkey prompt. The function lives in the `@category-labs/mera/viem` entry point, which requires `viem` (`^2.28.0`) as an optional peer dependency; the root entry point does not use viem.
 
 ## Import
 


### PR DESCRIPTION
## Why

A conformance review of every page under `docs/src/content/docs/` against the rules in `docs/AGENTS.md` (and `site/WRITING.md`) surfaced two accuracy defects and a set of rule violations. The accuracy defects were the motivation:

- The create-passkey-accounts recipe copied the derived key with a comment claiming the copy lets the session "own and later zero the buffer". The `consumePrivateKey` contract already copies and zeroes the input; the extra copy actually *prevented* the HDKey's internal buffer from being zeroed, and the sibling viem recipe taught the opposite (correct) pattern for the same call. Getting started had the same comment; all three now pass the key directly, matching the contract in `src/types.ts`.
- The vault format page said the PRF salt is "chosen by the app per vault", but the workflow functions generate it internally; only the low-level `createSecretVault` path takes an app-supplied salt. The page now states both paths.

The rest applies the writing rules: consequences stated in place instead of deferred to links (rpId migration, the createPasskey ordering caveat), PRF/ceremony glossed with a link to the owning concept page on first mention, punch fragments and an editorializing clause rewritten, prerequisites moved to the recipe's first paragraph, imperative caller instructions on reference pages rephrased as observable behavior, a lead that repeated a Parameters default trimmed, dotted `options.user.*` subheadings on createPasskeyWithPrfOutput, and the splash index renamed to plain `.md` since it imports no component.

## Notes for review

- Findings that were judgment calls under the rules were applied in the direction the rules point; the two rewrites most worth checking are the security-model "one output, one purpose" paragraph and the createSecretVault Notes, which now state the fresh-salt requirement as facts rather than instructions.
- `docs npm run build` passes (34 pages, all sidebar slugs resolve) and root `npm run check` passes. The new `#optionsuserid` cross-page anchor was verified in the built HTML.
