### PR TITLE
Define niche terminology at first use across the docs

### DIFF
--- a/docs/src/content/docs/authenticator-support.md
+++ b/docs/src/content/docs/authenticator-support.md
@@ -31,7 +31,7 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 On desktop Chrome, only passkeys saved to Google Password Manager carry PRF; the local profile authenticator lacks [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) primitive behind PRF.
 
-Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback ceremony. Either way the passkey exists but returns no PRF output, so mera cannot use it. [createPasskey](/reference/create-passkey/) fails only after the creation ceremony has completed, so the unusable passkey stays in the authenticator's passkey list.
+Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts). Either way the passkey exists but returns no PRF output, so mera cannot use it. [createPasskey](/reference/create-passkey/) fails only after the creation ceremony has completed, so the unusable passkey stays in the authenticator's passkey list.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -34,9 +34,11 @@ Control of an account is the ability to sign: a transaction is valid when its si
 
 A key-derivation function (KDF) turns one secret into others: the output looks random, and the same input always produces the same output. A key that can be recomputed never needs to be stored.
 
-BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, where a derivation path such as `m/44'/60'/0'/0/0` names one key. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account. (BIP is a Bitcoin Improvement Proposal; several became standards beyond Bitcoin.)
+A seed is the byte string a key tree starts from. BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, a scheme called hierarchical deterministic (HD) derivation, and a derivation path such as `m/44'/60'/0'/0/0` names one key in the tree. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account. (BIP is a Bitcoin Improvement Proposal; several became standards beyond Bitcoin.)
 
 <Bip32Tree />
+
+Key material is any secret bytes in this pipeline: root entropy, a seed, a private key. Exposing key material exposes every key derived from it.
 
 ## Seed phrases
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -7,7 +7,7 @@ A passkey account is a blockchain account whose keys derive from a passkey's PRF
 
 ## One salt, one stable output
 
-When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony. The app passes that output to a derivation scheme of its choosing, the deterministic computation that turns root entropy into per-account keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)); [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD standards.
+When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony. The app passes that output to a derivation scheme of its choosing, the deterministic computation that turns root entropy into per-account keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)); [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## No stored state
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -9,7 +9,7 @@ A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/T
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, ceremonies under the new domain cannot reach the old credential, so everything derived from it becomes unreachable there. The [security model](/concepts/security-model/) covers migrations in depth.
 
-**Passkeys sync.** Platform authenticators replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
+**Passkeys sync.** Platform authenticators, the credential stores built into an operating system or a password manager, replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
 
 ## User verification
 
@@ -29,11 +29,11 @@ PRF output is determined by the credential, relying party ID, and salt. Those in
 
 The output is suitable as the root secret for accounts. It is stable wherever the passkey syncs, it appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony.
 
-Passed to a key-derivation scheme, the deterministic computation that turns one root secret into per-account keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)), the output produces a hierarchy of accounts; used as key material, it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
+Passed to a key-derivation scheme, the deterministic computation that turns one root secret into per-account keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)), the output produces a hierarchy of accounts; used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
 
 ## Ceremonies and prompts
 
-A ceremony is one WebAuthn call and one user-verification prompt. mera runs three kinds:
+A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential or runs an assertion, the call that uses an existing credential: the authenticator proves possession of the key pair and can evaluate the PRF. mera runs three kinds:
 
 - [createPasskey](/reference/create-passkey/) makes the credential, and can evaluate the PRF in the same ceremony when the authenticator supports it.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -9,11 +9,11 @@ sidebar:
 
 import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
 
-A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, can decrypt it. Vaults cover the cases where key material must come from outside the passkey; apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
+A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey; apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey's PRF, the extension that makes a passkey return deterministic secret bytes ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains it), against a fresh random salt for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher (one key both encrypts and decrypts) that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey's PRF, the extension that makes a passkey return deterministic secret bytes ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains it), against a fresh random salt, the PRF's 32-byte input, for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 
@@ -21,7 +21,7 @@ The vault itself is ordinary JSON and can live in `localStorage`, on a backend, 
 
 ## The secret exists on its own
 
-The secret exists independently of the passkey: an account that predates it can be imported by encrypting its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext; decrypting it requires the passkey ceremony.
+The secret exists independently of the passkey: an account that predates it can be imported by encrypting its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext, the encrypted bytes; decrypting it requires the passkey ceremony.
 
 ## When to use a vault
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -5,27 +5,27 @@ description: What mera protects, what it cannot, and the risks left to the app.
 
 import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
-mera has a narrow scope: it runs passkey ceremonies, returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/).
+mera has a narrow scope: it runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/).
 
 ## What the library handles
 
 Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, encrypted, or derived.
 
-Owned copies are zeroed where possible. A signing session zeroes the caller's private-key buffer when it consumes it, even when construction throws, and zeroes its own copy on `lock()`. [createSecretVault](/reference/create-secret-vault/) zeroes its internal secret and PRF-output copies. Secret-vault workflow functions also zero the transient secret and PRF-output copies they own before settling.
+Owned copies are zeroed where possible: overwritten with zeros so the secret stops existing in memory instead of lingering until garbage collection. A signing session zeroes the caller's private-key buffer when it consumes it, even when construction throws, and zeroes its own copy on `lock()`. [createSecretVault](/reference/create-secret-vault/) zeroes its internal secret and PRF-output copies. Secret-vault workflow functions also zero the transient secret and PRF-output copies they own before they finish, even when they fail.
 
-[WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges are generated internally. So are AES-GCM nonces: a nonce is a value that must never repeat under one encryption key, so the library generates 12 fresh bytes per encryption and a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
+[WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges are generated internally. So are [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonces: a nonce is a value that must never repeat under one encryption key, so the library generates 12 fresh bytes per encryption and a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
 
 ## What a compromised runtime sees
 
-A compromised JavaScript runtime, whether an injected script, a malicious dependency, or an extension with page access, can observe key material during app-owned derivation or import. It can also sign with an active session until `session.lock()` is called.
+A compromised JavaScript runtime, whether an injected script, a malicious dependency, or an extension with page access, can observe [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) during app-owned derivation or import. It can also sign with an active session until `session.lock()` is called.
 
-The mitigations are app-level: lock sessions when idle, keep derivation windows short, and treat everything that can run script on the page as inside the trust boundary.
+The mitigations are app-level: lock sessions when idle, keep derivation windows short, and treat everything that can run script on the page as inside the trust boundary, the set of code trusted with key material. Anything that runs on the page can read what the library reads.
 
 <TrustBoundary />
 
 ## rpId binding
 
-PRF output, the secret bytes a passkey returns through its [PRF extension](/concepts/passkeys-and-prf/), is a function of the credential, the relying party ID, and the salt. A passkey can be used only under the rpId it was created for, so after a domain migration the app cannot run assertions under the old one. That breaks both patterns: passkey accounts can no longer be reproduced, and secret vaults can no longer be decrypted.
+PRF output, the secret bytes a passkey returns through its [PRF extension](/concepts/passkeys-and-prf/), is a function of the credential, the relying party ID, and the salt. A passkey can be used only under the rpId it was created for, so after a domain migration the app cannot run ceremonies under the old one. That breaks both patterns: passkey accounts can no longer be reproduced, and secret vaults can no longer be decrypted.
 
 Treat the rpId as a long-lived choice. Before any planned migration, accounts need an export path.
 
@@ -33,7 +33,7 @@ Treat the rpId as a long-lived choice. Before any planned migration, accounts ne
 
 If one PRF output is reused for unrelated purposes, exposing it compromises them all. Use a different salt per purpose, or split one output with a purpose-labeled key-derivation function (KDF), a deterministic function that turns one secret into separate purpose-specific keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)).
 
-A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored vault JSON. The secret-vault workflow functions generate a fresh random 32-byte salt for each secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves supplying a fresh salt per secret to the caller.
+A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and their pairs of nonce and ciphertext (the encrypted bytes) become interchangeable to anyone who can rewrite stored vault JSON. The secret-vault workflow functions generate a fresh random 32-byte salt for each secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves supplying a fresh salt per secret to the caller.
 
 ## Strings cannot be zeroed
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -11,13 +11,13 @@ Two constructors exist, one per signature scheme ([Entropy, keys, and accounts](
 
 ## Independent of passkeys
 
-A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design; [passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of key material.
+A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design; [passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
 
 Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the ceremony that produced the entropy, and it covers any number of signatures.
 
 ## The lifecycle
 
-Construction consumes the key: the session keeps the only library-side copy and zeroes the caller's input buffer, even when construction throws. Locking zeroes the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction consumes the key: the session keeps the only library-side copy and [zeroes](/concepts/security-model/#what-the-library-handles) the caller's input buffer, even when construction throws. Locking zeroes the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -39,13 +39,13 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 });
 ```
 
-The call prompts once, or twice when the authenticator needs a follow-up assertion to evaluate PRF.
+The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts), a second WebAuthn call that uses the new passkey, to evaluate PRF.
 
 mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID; [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 
-The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), which encodes entropy as a phrase of common words, and [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), which derives numbered keys from one seed, so the account can be imported into wallet apps that follow those standards.
+The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), which encodes entropy as a phrase of common words, and [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), which derives numbered keys from one seed, a byte string computed from the phrase, so the account can be imported into wallet apps that follow those standards.
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -82,7 +82,7 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The session copies the key, zeroes the buffer it was given, and signs without further passkey prompts until `lock()` is called. Locking zeroes the session's copy too; after that, signing throws.
+The session copies the key, [zeroes](/concepts/security-model/#what-the-library-handles) the buffer it was given, and signs without further passkey prompts until `lock()` is called. Locking zeroes the session's copy too; after that, signing throws.
 
 ## Sign back in
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -5,7 +5,7 @@ description: Create numbered EVM and Solana accounts from one passkey ceremony, 
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey ceremony per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/authenticator-support/)). PRF is the [WebAuthn](https://www.w3.org/TR/webauthn-3/) extension that makes a passkey return deterministic secret bytes; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism.
+This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/authenticator-support/)). PRF is the [WebAuthn](https://www.w3.org/TR/webauthn-3/) extension that makes a passkey return deterministic secret bytes; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism.
 
 Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
@@ -23,7 +23,7 @@ const created = await createPasskeyWithPrfOutput({
   user: { name: "account@example.com", displayName: "Example account" },
 });
 
-// The seed comes from the sign-in assertion below, so this flow never uses
+// The seed comes from the sign-in ceremony below, so this flow never uses
 // the create-time PRF output; zero it right away.
 created.prfOutput.fill(0);
 ```
@@ -32,7 +32,7 @@ created.prfOutput.fill(0);
 
 ## Remember the credential
 
-Store the credential metadata. It holds no key material; its only job is letting the next sign-in pin the exact passkey instead of showing every discoverable credential for the domain.
+Store the credential metadata. It holds no key material; its only job is letting the next sign-in pin the exact passkey instead of showing every [discoverable credential](/concepts/passkeys-and-prf/) the authenticator holds for the domain.
 
 ```ts
 localStorage.setItem(
@@ -70,7 +70,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a seed for the session
 
-Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, zero the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, [zero](/concepts/security-model/#what-the-library-handles) the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -103,7 +103,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the Ed25519 counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
+Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {
@@ -156,4 +156,4 @@ Sessions zero their own key copies on `lock()`. The seed is the app's buffer, so
 
 - **Do not change the derivation after launch.** Changing the mnemonic mapping or either path changes every account address.
 - **Zero the PRF output as soon as the seed exists**, and the seed on lock. Between those two moments a compromised runtime can read them ([security model](/concepts/security-model/)).
-- **Accounts reproduce only under the same rpId.** A domain migration leaves them unreachable, with no error until someone tries to sign in; give accounts an export path first. The phrase to show is `entropyToMnemonic` over the PRF output from a fresh assertion, the same mapping the seed step uses ([Passkey accounts](/concepts/passkey-accounts/)).
+- **Accounts reproduce only under the same [rpId](/concepts/passkeys-and-prf/)**, the domain the passkey is bound to. A domain migration leaves them unreachable, with no error until someone tries to sign in; give accounts an export path first. The phrase to show is `entropyToMnemonic` over the PRF output from a fresh sign-in ceremony, the same mapping the seed step uses ([Passkey accounts](/concepts/passkey-accounts/)).

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -35,7 +35,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)); the buffers are zeroed as soon as each one has served its purpose.
+`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)); the buffers are [zeroed](/concepts/security-model/#what-the-library-handles) as soon as each one has served its purpose.
 
 ## Create the viem account
 
@@ -75,7 +75,7 @@ const hash = await client.sendTransaction({
 session.lock();
 ```
 
-`sepolia` is Ethereum's Sepolia test network, and `http()` with no URL uses the chain's default public RPC endpoint; production apps pass a dedicated RPC URL. Signing shows no passkey prompt: the one prompt happened at sign-in, and the session covers every signature until it is locked.
+`sepolia` is Ethereum's Sepolia test network, and `http()` with no URL uses the chain's default public RPC endpoint (RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions); production apps pass a dedicated RPC URL. Signing shows no passkey prompt: the one prompt happened at sign-in, and the session covers every signature until it is locked.
 
 `sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query; viem's `waitForTransactionReceipt` on a public client covers it.
 
@@ -83,7 +83,7 @@ session.lock();
 
 - **The derivation must match the app's other sign-in paths.** This recipe repeats the mapping and path from [Create passkey accounts](/recipes/create-passkey-accounts/); a different mapping or path reaches a different address.
 - **A locked session rejects every viem signing method** with [`SESSION_LOCKED`](/reference/errors/#session_locked), and the account has no key of its own. Keep the session for the active burst of work, lock it when the burst ends, and build a new session from a fresh ceremony for the next one ([Signing sessions](/concepts/signing-sessions/)).
-- **Concurrent transactions can be assigned the same nonce**, and the chain accepts only one of them. viem's nonce manager assigns nonces in sequence; pass it through [toViemAccount](/reference/to-viem-account/) options.
+- **Concurrent transactions can be assigned the same nonce**, the per-account counter that orders transactions, and the chain accepts only one of them. viem's nonce manager assigns nonces in sequence; pass it through [toViemAccount](/reference/to-viem-account/) options.
 
 ## See also
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit [zeroing](/concepts/security-model/#what-the-library-handles). It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 
@@ -25,7 +25,7 @@ if (!validateMnemonic(phrase, wordlist)) {
 
 ## Create and persist the vault
 
-`createSecretVaultWithNewPasskey` generates a fresh 32-byte salt, creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault. A separate salt for each vault avoids shared encryption keys and interchangeable nonce/ciphertext pairs.
+`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension), the PRF input that namespaces its output, creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault. A separate salt for each vault avoids shared encryption keys and interchangeable nonce/ciphertext pairs ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
 
 ```ts
 import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
@@ -45,7 +45,7 @@ try {
 }
 ```
 
-The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before settling. PRF output is the deterministic secret bytes the passkey returns through the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension, and it keys the encryption; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
+The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before it finishes, even when it fails. PRF output is the deterministic secret bytes the passkey returns through the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension, and it keys the encryption; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
 
 ## Unlock
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -58,7 +58,7 @@ User handle stored with the discoverable credential. Must be 1 to 64 bytes when 
 - Type: `Uint8Array`
 - Optional; defaults to mera's fixed v1 deterministic salt
 
-32-byte PRF salt evaluated during creation or by the fallback assertion. An explicit value supports custom PRF namespaces and low-level composition. It is copied before async WebAuthn work starts, so post-call mutation changes neither the fallback ceremony nor the returned salt.
+32-byte PRF salt evaluated during creation or by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts). An explicit value supports custom PRF namespaces and low-level composition. It is copied before async WebAuthn work starts, so post-call mutation changes neither the fallback ceremony nor the returned salt.
 
 ### options.timeout
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -3,7 +3,7 @@ title: createPasskey
 description: Creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled.
 ---
 
-Creates a discoverable, user-verified passkey with the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension enabled. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
+Creates a [discoverable](/concepts/passkeys-and-prf/), user-verified passkey with the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension enabled. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
 
 ## Import
 
@@ -80,7 +80,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"`, a required resident key, and required user verification. The user-verification requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the PRF output nor remove the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
+The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key (the WebAuthn term for a discoverable credential), and required user verification. The user-verification requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the PRF output nor remove the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
 The WebAuthn challenge is generated internally. The raw attestation response is not returned.
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -3,7 +3,7 @@ title: createSecp256k1SigningSession
 description: Creates an explicitly lockable signing session from a secp256k1 private key.
 ---
 
-Creates an explicitly lockable signing session from a secp256k1 private key.
+Creates an explicitly lockable signing session from a [secp256k1](/concepts/entropy-keys-and-accounts/) private key.
 
 ## Import
 
@@ -41,7 +41,7 @@ session.lock();
 - Type: `Uint8Array`
 - Required
 
-secp256k1 private key. Must be exactly 32 bytes and a valid scalar. Copied into one session-owned snapshot; the input buffer is zeroed before the call returns or throws. Callers holding the key inside another structure (an `HDKey`, for example) should pass a copy.
+secp256k1 private key. Must be exactly 32 bytes and a valid scalar, an integer inside the curve's private-key range. Copied into one session-owned snapshot; the input buffer is zeroed before the call returns or throws. Callers holding the key inside another structure (an `HDKey`, for example) should pass a copy.
 
 ## Returns
 
@@ -53,7 +53,7 @@ A `Secp256k1SigningSession`, unlocked.
 
 ### signDigest(digest32)
 
-Signs a 32-byte digest without prehashing it and resolves to a `Secp256k1Signature`: `compact` (64 bytes, `r || s`, low-S) plus `recovery` (0 or 1).
+Signs a 32-byte digest without prehashing it and resolves to a `Secp256k1Signature`: `compact` (64 bytes, `r || s`, low-S: `s` lies in the lower half of the curve order) plus `recovery` (0 or 1).
 
 ### lock()
 
@@ -83,7 +83,7 @@ Signing needs no passkey ceremony and shows no prompt; the session signs as ofte
 
 The digest is copied before signing; the original is not modified.
 
-The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
+The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA, the signature algorithm secp256k1 uses, but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -42,7 +42,7 @@ try {
 - Type: `string`
 - Required
 
-Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion. It must match the ID under which the passkey was created.
+Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts). It must match the ID under which the passkey was created.
 
 ### options.credential
 
@@ -78,7 +78,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-A fresh random 32-byte PRF salt is generated for each call and stored in the vault. The secret and supplied credential metadata are copied before the ceremony begins. Caller-owned inputs are not modified or zeroed; internal secret and PRF-output copies are zeroed before the function settles.
+A fresh random 32-byte PRF salt is generated for each call and stored in the vault. The secret and supplied credential metadata are copied before the ceremony begins. Caller-owned inputs are not modified or zeroed; internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -36,7 +36,7 @@ try {
 - Type: `PublicKeyCredentialRpEntity & { id: string }`
 - Required, including `rp.id`
 
-Relying party identity passed to [WebAuthn](https://www.w3.org/TR/webauthn-3/). The required ID is reused by the fallback assertion.
+Relying party identity passed to [WebAuthn](https://www.w3.org/TR/webauthn-3/). The required ID is reused by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts).
 
 ### options.user
 
@@ -72,7 +72,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Notes
 
-A fresh random 32-byte PRF salt is generated for the vault and stored in it. The secret is copied before either ceremony begins. The caller-owned buffer is not modified or zeroed; internal secret and PRF-output copies are zeroed before the function settles.
+A fresh random 32-byte PRF salt is generated for the vault and stored in it. The secret is copied before either ceremony begins. The caller-owned buffer is not modified or zeroed; internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
 
 If the fallback ceremony or vault encryption fails after creation, the passkey remains on the authenticator and the error does not contain its metadata.
 

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -78,6 +78,6 @@ Input byte buffers are copied before async cryptographic work starts; mutating t
 
 - [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create a passkey and vault in one workflow.
 - [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): create a vault with an existing passkey.
-- [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) and [decryptSecretVault](/reference/decrypt-secret-vault/): the assertion and decryption that recover the secret.
+- [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) and [decryptSecretVault](/reference/decrypt-secret-vault/): the [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) and decryption that recover the secret.
 - [Use an existing secret](/recipes/use-an-existing-secret/): the full flow with zeroing.
 - [Security model](/concepts/security-model/#one-output-one-purpose): why PRF outputs must not be reused across purposes.

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -3,7 +3,7 @@ title: decryptSecretVaultWithPasskey
 description: Performs a passkey assertion and decrypts one secret vault.
 ---
 
-Performs the passkey assertion for a parsed vault and decrypts its secret. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Performs the passkey [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) for a parsed vault and decrypts its secret. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
 
 ## Import
 
@@ -64,13 +64,13 @@ WebAuthn timeout in milliseconds.
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
-- [`DECRYPT_FAILED`](/reference/errors/#decrypt_failed): AES-GCM authentication failed because the PRF output was wrong or the vault was modified.
+- [`DECRYPT_FAILED`](/reference/errors/#decrypt_failed): [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed because the PRF output was wrong or the vault was modified.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes
 
-The vault is copied before the assertion starts, so post-call mutation changes neither the credential restriction nor the ciphertext being decrypted. The transient PRF output is zeroed before the function settles, including when decryption fails.
+The vault is copied before the assertion starts, so post-call mutation changes neither the credential restriction nor the ciphertext being decrypted. The transient PRF output is zeroed before the function finishes, even when decryption fails.
 
 The WebAuthn challenge is generated internally, and the raw assertion response is not returned.
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault.md
@@ -70,6 +70,6 @@ The returned buffer is a fresh allocation; the library keeps no reference to it 
 
 ## See also
 
-- [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/): perform the assertion and decryption in one call.
+- [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/): perform the [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) and decryption in one call.
 - [Use an existing secret](/recipes/use-an-existing-secret/): create, store, and decrypt with the zeroing pattern.
 - [Secret vault format](/reference/secret-vault-format/): what the ciphertext actually contains.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -45,7 +45,7 @@ WebAuthn failed, was cancelled, returned an unexpected credential, or the creden
 
 ### CRYPTO_UNAVAILABLE
 
-Web Crypto is unavailable. In practice this means the page is running outside a secure context, or in a runtime without `globalThis.crypto`.
+Web Crypto is unavailable. In practice this means the page is running outside a secure context (HTTPS, or `localhost` during development), or in a runtime without `globalThis.crypto`.
 
 ### PRF_UNAVAILABLE
 
@@ -57,11 +57,11 @@ A signing call was made after the session's `lock()`. Locking is permanent; new 
 
 ### DECRYPT_FAILED
 
-AES-GCM authentication failed while decrypting a vault: wrong key material, or tampered ciphertext or additional authenticated data. The two cases are indistinguishable by design; GCM authenticates before it decrypts.
+[AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed while decrypting a vault: wrong key material, or tampered ciphertext or [additional authenticated data](/reference/secret-vault-format/#what-is-deliberately-absent). The two cases are indistinguishable by design; GCM authenticates before it decrypts.
 
 ### INPUT_INVALID
 
-A caller-supplied value at a public boundary did not satisfy a length, range, encoding, or curve (scalar or point) constraint. Each function's Errors section lists its specific conditions.
+A caller-supplied value at a public boundary did not satisfy a length, range, encoding, or curve constraint (a private key that is not a valid scalar, a public key that is not a valid point). Each function's Errors section lists its specific conditions.
 
 ### VAULT_FORMAT_INVALID
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -5,7 +5,7 @@ description: Returns mera's fixed v1 deterministic PRF salt.
 
 Returns mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`. The PRF output functions use this value internally when `prfSalt` is omitted; this helper supports explicit protocol interoperability and custom composition.
 
-The salt will not change across library versions, so one passkey assertion against it produces one stable 32-byte PRF output per credential and relying party. [Passkey accounts](/concepts/passkey-accounts/) are built on that stability.
+The salt will not change across library versions, so one passkey [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) against it produces one stable 32-byte PRF output per credential and relying party. [Passkey accounts](/concepts/passkey-accounts/) are built on that stability.
 
 ## Import
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -28,7 +28,7 @@ const { credentialId, prfOutput } = await getPasskeyPrfOutput({
 - Type: `string`
 - Required
 
-Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion.
+Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts).
 
 ### options.credential
 

--- a/docs/src/content/docs/reference/get-secret-vault-prf-output.md
+++ b/docs/src/content/docs/reference/get-secret-vault-prf-output.md
@@ -3,7 +3,7 @@ title: getSecretVaultPrfOutput
 description: Performs the WebAuthn assertion needed to unlock a secret vault.
 ---
 
-Performs the [WebAuthn](https://www.w3.org/TR/webauthn-3/) assertion needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Performs the [WebAuthn](https://www.w3.org/TR/webauthn-3/) [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
 
 Reads the credential metadata and PRF salt out of a parsed vault and delegates to [getPasskeyPrfOutput](/reference/get-passkey-prf-output/), so the assertion is automatically pinned to the credential that encrypted the secret.
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -26,7 +26,7 @@ Always `1`. [parseSecretVault](/reference/parse-secret-vault/) rejects anything 
 
 ### credential.credentialId
 
-The passkey credential that unlocks this vault, as canonical unpadded base64url. Stored so the unlock assertion can pin itself to the right passkey instead of letting the browser offer every discoverable credential.
+The passkey credential that unlocks this vault, as canonical unpadded [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5). Stored so the unlock [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can pin itself to the right passkey instead of letting the browser offer every discoverable credential.
 
 ### credential.transports
 
@@ -38,11 +38,11 @@ The PRF salt for this secret, 32 bytes as canonical unpadded base64url. The work
 
 ### nonce
 
-The 12-byte AES-GCM nonce, base64url. Generated internally by [createSecretVault](/reference/create-secret-vault/) for each encryption.
+The 12-byte [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonce, base64url. Generated internally by [createSecretVault](/reference/create-secret-vault/) for each encryption.
 
 ### ciphertext
 
-The AES-GCM ciphertext including its 16-byte authentication tag, base64url. The plaintext is the secret exactly as it was passed in; the library never interprets it.
+The AES-GCM ciphertext including its 16-byte authentication tag, the value decryption checks to detect tampering, base64url. The plaintext is the secret exactly as it was passed in; the library never interprets it.
 
 ## What is deliberately absent
 

--- a/docs/src/content/docs/reference/to-viem-account.md
+++ b/docs/src/content/docs/reference/to-viem-account.md
@@ -62,7 +62,7 @@ A viem `LocalAccount` with `source: "mera"`, accepted anywhere viem takes an acc
 
 ### address
 
-The EIP-55 checksummed address of the session key, the same value [getEvmAddress](/reference/get-evm-address/) returns for `session.publicKey`.
+The [EIP-55](https://eips.ethereum.org/EIPS/eip-55) checksummed address of the session key, the same value [getEvmAddress](/reference/get-evm-address/) returns for `session.publicKey`.
 
 ### publicKey
 
@@ -70,19 +70,19 @@ The 65-byte uncompressed secp256k1 public key as hex: the `0x04` prefix, then 12
 
 ### signTransaction(transaction, options?)
 
-Serializes the transaction, signs its keccak-256 digest, and resolves to the signed serialized transaction. `options.serializer` replaces viem's `serializeTransaction` for both steps. EIP-4844 transactions are hashed without their sidecars and serialized with them.
+Serializes the transaction, signs its keccak-256 digest, and resolves to the signed serialized transaction. `options.serializer` replaces viem's `serializeTransaction` for both steps. [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) transactions are hashed without their sidecars and serialized with them.
 
 ### signMessage({ message })
 
-Resolves to the EIP-191 personal-message signature for `message`, 65 bytes as hex.
+Resolves to the [EIP-191](https://eips.ethereum.org/EIPS/eip-191) personal-message signature for `message`, 65 bytes as hex.
 
 ### signTypedData(typedData)
 
-Resolves to the EIP-712 signature for the typed data, 65 bytes as hex.
+Resolves to the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature for the typed data, 65 bytes as hex.
 
 ### signAuthorization(authorization)
 
-Signs an EIP-7702 authorization and resolves to the signed authorization object: the contract address, chain ID, and nonce together with the signature fields.
+Signs an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) authorization and resolves to the signed authorization object: the contract address, chain ID, and nonce together with the signature fields.
 
 ### sign({ hash })
 
@@ -95,7 +95,7 @@ Signs a 32-byte hash directly, with no additional hashing, and resolves to the 6
 
 ## Notes
 
-Signatures are low-S, which EVM chains require since EIP-2; `signDigest` enforces this, so the adapter adds no normalization.
+Signatures are low-S (the signature's `s` value lies in the lower half of the curve order), which EVM chains require since [EIP-2](https://eips.ethereum.org/EIPS/eip-2); `signDigest` enforces this, so the adapter adds no normalization.
 
 ## See also
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -369,7 +369,7 @@ function getRandomVaultPrfSalt(): Uint8Array<ArrayBuffer> {
  * `secret` is copied and validated before either ceremony starts. Post-call
  * mutation does not change the encrypted secret, and the caller-owned buffer
  * is not modified or zeroed. The internal secret and PRF output are zeroed
- * before the function settles, including on failure.
+ * before the function finishes, even when it fails.
  *
  * If the fallback ceremony or vault encryption fails, the passkey from the
  * completed creation ceremony still exists on the authenticator, but the
@@ -419,7 +419,7 @@ async function createSecretVaultWithNewPasskey({
  * vault. `secret` and `credential` are copied before the ceremony starts, so
  * post-call mutation does not change the operation. Caller-owned inputs are
  * not modified or zeroed. The internal secret and PRF output are zeroed before
- * the function settles, including on failure.
+ * the function finishes, even when it fails.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `secret` is empty, or `credential.credentialId` is empty or not canonical base64url.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -661,7 +661,7 @@ type DecryptSecretVaultWithPasskeyInput = {
  *
  * The vault is copied before the ceremony starts, so post-call mutation does
  * not change the assertion or ciphertext being decrypted. The internal PRF
- * output is zeroed before the function settles, including when decryption
+ * output is zeroed before the function finishes, even when decryption
  * fails. The returned secret is not zeroed; its lifetime belongs to the
  * caller.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.


### PR DESCRIPTION
A reader reviewing the security-model page asked what "zeroing" means and noted the terminology is niche. An audit of every docs page confirmed the gap is systemic rather than local: zeroing, key material, assertion, HD, and seed were defined nowhere in the doc set, "settling" leaned on promise jargon, and several terms that do have definitions (AES-GCM, salt, ciphertext, discoverable credential) were used on other pages with neither a gloss nor a link.

The fix applies the convention docs/AGENTS.md already prescribes: each term gets a one-clause definition on the page that owns it (crypto terms on the entropy page, WebAuthn terms on the passkeys page, memory semantics on the security model), and every other page links or re-glosses at first mention. Reference pages get links to the teaching page plus external spec links for EIPs and base64url, staying within their state-facts-and-link rule. "Settling" is removed everywhere in favor of plain wording, including the three JSDoc sites in src/secret.ts, so the reference pages that mirror that JSDoc stay word-identical with it.

Not touched: the index tagline, and spec-level jargon on API pages where the surrounding sentence already explains the behavior.

Validation beyond CI: the docs build passes, every new anchor fragment was checked against the rendered HTML, and the diff was reviewed against the docs voice rules (no em dashes, no banned vocabulary, links root-relative with trailing slash). npm test currently fails on this branch with pre-existing @noble/curves typing errors in src/secp256k1.ts, unrelated to this change and reproducible with the change stashed.