### PR TITLE
Disable the Astro build cache in the docs Pages workflow

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           path: docs
           node-version: 24
+          # The action restores node_modules/.astro from any older commit's
+          # cache; a stale content-layer store makes the build emit module
+          # imports that no longer resolve. The cache only holds optimized
+          # remote images, which this site does not use.
+          cache: "false"
         env:
           DOCS_SITE: https://mera.category.xyz
 


### PR DESCRIPTION
## Motivation

The docs publish on main failed after #182 merged ([failing run](https://github.com/category-labs/mera/actions/runs/29432427559/job/87410511679)): Rolldown could not resolve the `astro:content-layer-deferred-module` imports in `docs/.astro/content-modules.mjs`.

The cause is the Astro cache inside `withastro/action`. It restores `node_modules/.astro` with a prefix restore key (`astro-cache-Linux-`), so every main build reuses the content-layer store saved at some older commit; the failing run restored the store from `c7eb3824`. When the checked-out content diverges enough from that store, Astro emits deferred-module imports that no longer resolve, and the build fails.

## Outcome

The workflow passes `cache: "false"` to the action, so each publish builds from a clean store and matches a local `npm run build`. The cache exists to speed up remote image optimization, which this site does not use; the docs build itself takes about one second.

## Validation

Merging this PR touches `.github/workflows/docs-pages.yml`, which triggers the docs Pages workflow on main, so the fix publishes the docs that #182's run failed to.