### PR TITLE
Remove Railway publishing config for docs

### DIFF
--- a/docs/railway.json
+++ b/docs/railway.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://railway.com/railway.schema.json",
-  "build": {
-    "builder": "RAILPACK",
-    "watchPatterns": ["/docs/**"]
-  }
-}

--- a/docs/src/components/DemoEmbed.astro
+++ b/docs/src/components/DemoEmbed.astro
@@ -3,7 +3,7 @@
 // stacked layouts can show it without an inner scrollbar; wide layouts may
 // still constrain it to the viewport. The delegated permissions let passkey
 // ceremonies and clipboard writes run in-frame.
-const DEMO_ORIGIN = "https://demo-production-8ad3.up.railway.app";
+const DEMO_ORIGIN = "https://mera-demo.up.railway.app";
 const DEMO_PERMISSIONS = [
   "publickey-credentials-create",
   "publickey-credentials-get",


### PR DESCRIPTION
## Why

The docs site now publishes to GitHub Pages, so the Railway build config in `docs/railway.json` is dead configuration and misleads readers about where the site deploys. The demo embed also pointed at a stale Railway deployment URL; the demo still lives on Railway, now at `https://mera-demo.up.railway.app`.

## Notes for reviewers

The demo app itself still deploys to Railway (`demo/railway.json` is untouched); only the docs site's publishing moved to GitHub Pages.