### PR TITLE
Add private demo network services for Railway

### DIFF
--- a/demo/network/README.md
+++ b/demo/network/README.md
@@ -1,0 +1,26 @@
+# Demo networks
+
+Private, disposable networks the demo runs against, one Railway service per
+directory. Neither network holds real value: state is wiped on every restart,
+and the demo funds accounts automatically when a balance runs low.
+
+- `evm/` — anvil from the [monad-foundry fork](https://github.com/category-labs/foundry),
+  run with `--network monad` behind a guard server (`evm/server.mts`). The
+  guard forwards the `eth_*`, `net_*`, and `web3_*` namespaces, refuses
+  anvil's cheat methods, and funds accounts through one guarded method:
+  `demo_fundAccount(address)` tops a balance below 10 DEMON up by 100 and is
+  a no-op otherwise.
+- `solana/` — `solana-test-validator` from [Agave](https://github.com/anza-xyz/agave).
+  Accounts are funded with the validator's built-in `requestAirdrop`.
+
+Run them locally with Docker. Both images download amd64 binaries, so the
+platform flag keeps them working on other hosts, such as Apple Silicon:
+
+```sh
+docker build --platform linux/amd64 -t demo-evm demo/network/evm \
+  && docker run --rm --platform linux/amd64 -p 8545:8545 demo-evm
+docker build --platform linux/amd64 -t demo-solana demo/network/solana \
+  && docker run --rm --platform linux/amd64 -p 8899:8899 demo-solana
+```
+
+Then point the demo at them via `demo/.env` (see `demo/.env.example`).

--- a/demo/network/evm/Dockerfile
+++ b/demo/network/evm/Dockerfile
@@ -1,0 +1,20 @@
+# Private EVM network for the demo: anvil from the monad-foundry fork behind
+# a guard server. The guard owns the public port, forwards ordinary JSON-RPC,
+# refuses anvil's cheat methods, and funds accounts through demo_fundAccount
+# (see server.mts). State is in memory only; a restart resets every balance,
+# which the demo heals by asking for funds again on the next balance poll.
+FROM node:24-alpine
+
+# The alpine (musl) build must run on an alpine base; the linux build is glibc.
+RUN apk add --no-cache ca-certificates curl \
+  && curl -fsSL https://github.com/category-labs/foundry/releases/download/v1.7.1-monad-v1.0.0/foundry_v1.7.1-monad-v1.0.0_alpine_amd64.tar.gz \
+    | tar -xz -C /usr/local/bin anvil
+
+COPY server.mts /srv/server.mts
+
+EXPOSE 8545
+
+# The guard reads PORT itself and starts anvil on localhost, so anvil is
+# never reachable from outside the container. Node 24 runs the TypeScript
+# source directly by stripping the (erasable-only) type syntax.
+CMD ["node", "/srv/server.mts"]

--- a/demo/network/evm/server.mts
+++ b/demo/network/evm/server.mts
@@ -1,0 +1,287 @@
+// JSON-RPC guard in front of the demo network's anvil node.
+//
+// Anvil exposes cheat methods (anvil_*, evm_*, hardhat_*) that let any caller
+// rewrite chain state. This server owns the public port instead: anvil binds
+// to localhost inside the container, ordinary JSON-RPC namespaces are
+// forwarded, and everything else is refused. Funding happens through one
+// guarded method, demo_fundAccount, whose policy lives here on the server.
+//
+// The file runs directly under Node 24's type stripping, so it must stay
+// within erasable TypeScript syntax; tsconfig.json enforces that. The .mts
+// extension pins the module format to ESM: a plain .ts file's format depends
+// on the nearest package.json, and the container copies this file without
+// one.
+import { spawn } from "node:child_process";
+import http from "node:http";
+
+const PORT = Number(process.env.PORT ?? 8545);
+const ANVIL_URL = "http://127.0.0.1:8546";
+// Method namespaces the network exposes; every other method is refused.
+const ALLOWED_PREFIXES = ["eth_", "net_", "web3_"];
+// Methods within the allowed namespaces that sign or send with anvil's
+// unlocked dev accounts. Refused so the node never signs for a caller,
+// which would sidestep demo_fundAccount as a way to move funds; the demo
+// signs locally and broadcasts raw transactions.
+const REFUSED_METHODS = new Set([
+  "eth_sendTransaction",
+  "eth_signTransaction",
+  "eth_sign",
+  "eth_signTypedData",
+  "eth_signTypedData_v3",
+  "eth_signTypedData_v4",
+]);
+// Funding policy: balances below the threshold are raised by the top-up.
+// The demo's EVM adapter asks only when a balance is below the same
+// threshold (its MIN_BALANCE_WEI).
+const MIN_BALANCE_WEI = 10n * 10n ** 18n;
+const TOP_UP_WEI = 100n * 10n ** 18n;
+// Large enough for any raw transaction the demo produces; requests beyond
+// this are rejected with 413.
+const MAX_BODY_BYTES = 128 * 1024;
+
+// Anvil runs as a child on localhost, so the cheat methods are reachable
+// only from this process. The guard exits when anvil dies and the platform
+// restarts the container, which is the network's designed recovery path.
+const anvil = spawn(
+  "anvil",
+  ["--network", "monad", "--host", "127.0.0.1", "--port", "8546"],
+  { stdio: ["ignore", "inherit", "inherit"] },
+);
+anvil.on("exit", (code) => {
+  console.error(`anvil exited with code ${code}`);
+  process.exit(1);
+});
+
+// Stop anvil and exit on the platform's stop signals. As PID 1 in the
+// container the process has no default signal dispositions, so without
+// these handlers a stop would hang until the force-kill timeout. Killing
+// anvil also covers local runs, where it would otherwise outlive the guard
+// and keep its port.
+for (const signal of ["SIGTERM", "SIGINT"] as const) {
+  process.on(signal, () => {
+    anvil.kill(signal);
+    process.exit(0);
+  });
+}
+
+async function anvilRequest(
+  method: string,
+  params: unknown[],
+): Promise<unknown> {
+  const response = await fetch(ANVIL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const body = (await response.json()) as {
+    result?: unknown;
+    error?: { message?: string };
+  };
+  if (body.error) {
+    throw new Error(body.error.message ?? `anvil refused ${method}`);
+  }
+  return body.result;
+}
+
+// Raises `address`'s balance to current + TOP_UP_WEI when it sits below the
+// threshold, and is a no-op otherwise, so callers can invoke it idempotently.
+// Adding to the current balance (anvil_setBalance is absolute) preserves
+// amounts received while the account was below the threshold. Returns the
+// resulting balance as a hex quantity.
+async function fundAccount(address: string): Promise<string> {
+  const result = await anvilRequest("eth_getBalance", [address, "latest"]);
+  if (typeof result !== "string") {
+    throw new Error("eth_getBalance returned a non-string result");
+  }
+  const balance = BigInt(result);
+  if (balance < MIN_BALANCE_WEI) {
+    const funded = balance + TOP_UP_WEI;
+    await anvilRequest("anvil_setBalance", [
+      address,
+      `0x${funded.toString(16)}`,
+    ]);
+    return `0x${funded.toString(16)}`;
+  }
+  return `0x${balance.toString(16)}`;
+}
+
+// Permissive CORS on every response, since the demo calls the network
+// directly from the browser.
+const CORS_HEADERS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "POST, OPTIONS",
+  "access-control-allow-headers": "content-type",
+};
+
+// A JSON-RPC id is a string, a number, or null; anything else a caller
+// sends is replaced with null rather than echoed back.
+function rpcId(id: unknown): string | number | null {
+  return typeof id === "string" || typeof id === "number" ? id : null;
+}
+
+function rpcError(id: unknown, code: number, message: string): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: rpcId(id),
+    error: { code, message },
+  });
+}
+
+function rpcResult(id: unknown, result: unknown): string {
+  return JSON.stringify({ jsonrpc: "2.0", id: rpcId(id), result });
+}
+
+function respond(
+  response: http.ServerResponse,
+  status: number,
+  body: string | Buffer,
+): void {
+  response.writeHead(status, {
+    "content-type": "application/json",
+    ...CORS_HEADERS,
+  });
+  response.end(body);
+}
+
+async function handle(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+): Promise<void> {
+  if (request.method === "OPTIONS") {
+    // A preflight response carries no body, so 204 with the CORS headers
+    // alone.
+    response.writeHead(204, CORS_HEADERS);
+    response.end();
+    return;
+  }
+  if (request.method !== "POST") {
+    respond(response, 405, rpcError(null, -32600, "Only POST is supported."));
+    return;
+  }
+
+  const chunks: Buffer[] = [];
+  let received = 0;
+  for await (const chunk of request as AsyncIterable<Buffer>) {
+    received += chunk.length;
+    if (received > MAX_BODY_BYTES) {
+      respond(
+        response,
+        413,
+        rpcError(null, -32600, "The request body is too large."),
+      );
+      // Responding does not stop the caller from streaming the rest of the
+      // declared body into the open connection; drop the connection too.
+      request.destroy();
+      return;
+    }
+    chunks.push(chunk);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    respond(
+      response,
+      400,
+      rpcError(null, -32700, "The request body is not valid JSON."),
+    );
+    return;
+  }
+  if (Array.isArray(payload)) {
+    respond(
+      response,
+      400,
+      rpcError(null, -32600, "Batch requests are not supported."),
+    );
+    return;
+  }
+  const { id, method, params } = (payload ?? {}) as {
+    id?: unknown;
+    method?: unknown;
+    params?: unknown;
+  };
+  if (typeof method !== "string") {
+    respond(response, 400, rpcError(id, -32600, "The request has no method."));
+    return;
+  }
+
+  if (method === "demo_fundAccount") {
+    const address = Array.isArray(params) ? params[0] : undefined;
+    if (typeof address !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(address)) {
+      respond(
+        response,
+        200,
+        rpcError(id, -32602, "params must be a single 0x-prefixed address."),
+      );
+      return;
+    }
+    try {
+      respond(response, 200, rpcResult(id, await fundAccount(address)));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      respond(
+        response,
+        200,
+        rpcError(id, -32603, `Funding failed: ${message}`),
+      );
+    }
+    return;
+  }
+
+  if (
+    REFUSED_METHODS.has(method) ||
+    !ALLOWED_PREFIXES.some((prefix) => method.startsWith(prefix))
+  ) {
+    respond(
+      response,
+      200,
+      rpcError(id, -32601, `The demo network does not expose ${method}.`),
+    );
+    return;
+  }
+
+  try {
+    const upstream = await fetch(ANVIL_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    respond(
+      response,
+      upstream.status,
+      Buffer.from(await upstream.arrayBuffer()),
+    );
+  } catch {
+    respond(
+      response,
+      502,
+      rpcError(id, -32603, "The network node is not responding."),
+    );
+  }
+}
+
+// Serve only once anvil answers, so the platform's routing never sees a
+// listening guard with a dead node behind it during boot.
+for (let attempt = 0; ; attempt++) {
+  try {
+    await anvilRequest("eth_chainId", []);
+    break;
+  } catch {
+    if (attempt >= 100) {
+      console.error("anvil did not become ready");
+      process.exit(1);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+http
+  .createServer((request, response) => {
+    handle(request, response).catch(() => {
+      respond(response, 500, rpcError(null, -32603, "Internal error."));
+    });
+  })
+  .listen(PORT, "0.0.0.0", () => {
+    console.log(`guard listening on ${PORT}, anvil on ${ANVIL_URL}`);
+  });

--- a/demo/network/evm/tsconfig.json
+++ b/demo/network/evm/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["server.mts"]
+}

--- a/demo/network/solana/Dockerfile
+++ b/demo/network/solana/Dockerfile
@@ -1,0 +1,26 @@
+# Private Solana network for the demo: solana-test-validator from Agave.
+# The ledger lives in /tmp; a restart resets every balance, which the demo
+# heals by requesting an airdrop again on the next balance poll.
+FROM debian:bookworm-slim
+
+# Pinned to the v3.0 line: Agave v3.1+ and v4 require io_uring at startup
+# (a hard assertion in their filesystem helpers), and Railway's sandboxed
+# runtime doesn't implement io_uring. Agave publishes glibc binaries, so
+# this needs a debian base, not alpine.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl bzip2 \
+  && curl -fsSL https://github.com/anza-xyz/agave/releases/download/v3.0.14/solana-release-x86_64-unknown-linux-gnu.tar.bz2 \
+    | tar -xj -C /opt \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/solana-release/bin:${PATH}"
+
+EXPOSE 8899
+
+# A shell expands Railway's PORT; exec then makes the validator PID 1 so it
+# receives the platform's stop signals directly. The validator starts its own
+# faucet, so requestAirdrop works with no extra setup. The RPC service listens
+# on all interfaces by default, so no bind flag is needed. --quiet suppresses
+# the interactive dashboard, which would fill the deploy logs with escape
+# codes.
+CMD ["sh", "-c", "exec solana-test-validator --rpc-port ${PORT:-8899} --ledger /tmp/test-ledger --reset --limit-ledger-size 10000 --quiet"]

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -18,6 +18,7 @@
         "viem": "^2.55.2"
       },
       "devDependencies": {
+        "@types/node": "^24.13.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
@@ -666,12 +667,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -3829,9 +3830,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/url": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && tsc -p network/evm && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc"
+    "typecheck": "tsc && tsc -p network/evm"
   },
   "dependencies": {
     "@noble/hashes": "^2.2.0",
@@ -20,6 +20,7 @@
     "viem": "^2.55.2"
   },
   "devDependencies": {
+    "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",

--- a/demo/railway.json
+++ b/demo/railway.json
@@ -5,6 +5,7 @@
     "buildCommand": "npm ci && npm run build && npm --prefix demo ci && npm --prefix demo run build",
     "watchPatterns": [
       "/demo/**",
+      "!/demo/network/**",
       "/src/**",
       "/package.json",
       "/package-lock.json",


### PR DESCRIPTION
The demo depended on public networks: Monad testnet behind an external faucet, and Solana devnet. Which network the demo runs on doesn't matter to what it demonstrates, and the faucet step is pure onboarding friction. This is the infrastructure half of the fix: two private, disposable networks the demo switches to in the rest of this stack.

- `demo/network/evm` — anvil from the monad-foundry fork (run with `--network monad`; the release README documents `--monad`, but that flag doesn't exist in the v1.7.1 build) behind a small guard server (`server.ts`, zero dependencies, run directly by Node 24's type stripping and typechecked via `tsc -p network/evm` in the demo build). Anvil binds to localhost inside the container and the guard owns the public port: it forwards the `eth_*`/`net_*`/`web3_*` namespaces — except the node-side signing methods (`eth_sendTransaction`, `eth_signTransaction`, `eth_sign`, `eth_signTypedData*`), since anvil's unlocked dev accounts would sign for any caller — refuses everything else (`anvil_*`, `evm_*`, `hardhat_*`, …), and exposes one funding method: `demo_fundAccount(address)` tops a balance below 10 DEMON up by 100 and is a no-op otherwise, so the funding policy and amounts live server-side and are capped per account.
- `demo/network/solana` — `solana-test-validator` pinned to Agave v3.0.14. Newer Agave (v3.1+, v4) hard-asserts io_uring support during startup, and Railway's sandboxed runtime doesn't implement io_uring (ENOSYS); the resulting crash loop is nearly silent, visible only with the validator's `--log` flag. Separately, Agave v4's `--bind-address 0.0.0.0` panics (`UnspecifiedIpAddr`); the flag is omitted since the test validator's RPC binds all interfaces regardless. Funding uses the validator's built-in `requestAirdrop`, which stays open — the token is worthless and state wipes on every restart.

Deployed and verified: services `evm-network` and `solana-network` in the Mera Railway project. Over the public domains: ordinary reads and broadcasts forwarded, `anvil_setBalance`/`evm_mine`/`eth_sendTransaction` refused with a clear JSON-RPC error, `demo_fundAccount` funds a fresh address to exactly 100 DEMON and no-ops on repeat, CORS confirmed from a browser origin.

Both Railway services already track `main`, so nothing deploys from this branch anymore; the one `FAILED` build from `main` in the deploy history is the branch switch predating this directory and resolves when this merges.
