### PR TITLE
Fund demo accounts automatically when a balance runs low

### DIFF
--- a/demo/src/chains/ethereum.ts
+++ b/demo/src/chains/ethereum.ts
@@ -1,5 +1,6 @@
 import {
   type Account,
+  type Address,
   type Chain,
   createPublicClient,
   createWalletClient as createViemTransactionClient,
@@ -46,6 +47,32 @@ async function resolveEthereumContext(): Promise<EthereumContext> {
 }
 
 /**
+ * Asks the network to fund `address` through the guard's demo_fundAccount
+ * method (see demo/network/evm/server.mts). The guard tops a balance below
+ * its threshold up by a fixed amount and is a no-op otherwise, so the call
+ * is idempotent; anvil's cheat methods themselves are not exposed.
+ */
+async function fundAccount(address: Address): Promise<void> {
+  const response = await fetch(RPC_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "demo_fundAccount",
+      params: [address],
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Funding failed with status ${response.status}.`);
+  }
+  const body = (await response.json()) as { error?: { message?: string } };
+  if (body.error) {
+    throw new Error(body.error.message ?? "Funding failed.");
+  }
+}
+
+/**
  * Creates a viem transaction client bound to a passkey-backed account and chain.
  */
 function createTransactionClient(
@@ -61,4 +88,4 @@ function createTransactionClient(
 }
 
 export type { EthereumContext };
-export { createTransactionClient, resolveEthereumContext };
+export { createTransactionClient, fundAccount, resolveEthereumContext };

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -35,6 +35,39 @@ async function getSolBalance(
   return BigInt(balance);
 }
 
+/**
+ * Requests an airdrop from the network's built-in faucet and waits for it to
+ * confirm by polling the signature status over HTTP. `Connection`'s own
+ * confirmation helpers subscribe over a websocket, which the demo network's
+ * single HTTP port doesn't carry, so this polls instead.
+ */
+async function airdropSol(
+  connection: Connection,
+  address: string,
+  lamports: bigint,
+): Promise<void> {
+  // requestAirdrop takes a number; demo amounts stay far below 2^53 lamports.
+  const signature = await connection.requestAirdrop(
+    new PublicKey(address),
+    Number(lamports),
+  );
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const status = (await connection.getSignatureStatuses([signature]))
+      .value[0];
+    if (status?.err) {
+      throw new Error(`The airdrop failed: ${JSON.stringify(status.err)}`);
+    }
+    if (
+      status?.confirmationStatus === "confirmed" ||
+      status?.confirmationStatus === "finalized"
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error("The airdrop was not confirmed in time.");
+}
+
 type SignSolTransferOptions = {
   connection: Connection;
   session: Ed25519SigningSession;
@@ -80,4 +113,4 @@ async function signSolTransfer({
   return transaction.serialize();
 }
 
-export { getSolBalance, resolveSolanaConnection, signSolTransfer };
+export { airdropSol, getSolBalance, resolveSolanaConnection, signSolTransfer };

--- a/demo/src/ethereumAdapter.ts
+++ b/demo/src/ethereumAdapter.ts
@@ -6,9 +6,15 @@ import type { ChainAdapter } from "./ChainAccountCard";
 import {
   createTransactionClient,
   type EthereumContext,
+  fundAccount,
 } from "./chains/ethereum";
+import { createFundingGate } from "./funding";
 
 const ETH_DECIMALS = 18;
+// Balances below this ask the network for funds. The top-up policy lives in
+// the network's guard (demo/network/evm/server.mts), which uses the same
+// threshold.
+const MIN_BALANCE_WEI = 10n * 10n ** 18n;
 
 /**
  * Builds the Ethereum `ChainAdapter` for one account: balance and gas-reserve
@@ -23,6 +29,11 @@ function createEthereumAdapter(
   const { chain, publicClient, rpcUrl } = ethereum;
   const account = toViemAccount(session);
   const symbol = chain.nativeCurrency.symbol;
+  const ensureFunded = createFundingGate({
+    minBalance: MIN_BALANCE_WEI,
+    fund: () => fundAccount(address),
+    readBalance: () => publicClient.getBalance({ address }),
+  });
   return {
     chainName: "Ethereum",
     badgeClassName: "badge",
@@ -38,7 +49,10 @@ function createEthereumAdapter(
         publicClient.estimateFeesPerGas(),
       ]);
       // 21000 gas is the base cost of a native transfer to an EOA.
-      return { balance, feeReserve: 21000n * fees.maxFeePerGas };
+      return {
+        balance: await ensureFunded(balance),
+        feeReserve: 21000n * fees.maxFeePerGas,
+      };
     },
     async signTransfer(to, valueWei) {
       const transactionClient = createTransactionClient(account, chain, rpcUrl);

--- a/demo/src/funding.ts
+++ b/demo/src/funding.ts
@@ -1,0 +1,38 @@
+type FundingGateOptions = {
+  /** Balance below which a top-up runs, in the chain's smallest unit. */
+  minBalance: bigint;
+  /** Funds the account, e.g. through a funding endpoint or an airdrop. */
+  fund: () => Promise<void>;
+  /** Re-reads the balance after a successful top-up. */
+  readBalance: () => Promise<bigint>;
+};
+
+/**
+ * Creates a funding gate for one account. The demo networks hold no real
+ * value, so accounts are funded on demand: pass each balance read through the
+ * gate, and a balance below `minBalance` is topped up and re-read. Only one
+ * top-up runs at a time; concurrent reads await the same one. A failed top-up
+ * or re-read (for example while a network restarts) returns the balance
+ * unchanged, so the caller's next poll retries.
+ */
+function createFundingGate({
+  minBalance,
+  fund,
+  readBalance,
+}: FundingGateOptions): (balance: bigint) => Promise<bigint> {
+  let inFlight: Promise<void> | null = null;
+  return async (balance) => {
+    if (balance >= minBalance) return balance;
+    inFlight ??= fund().finally(() => {
+      inFlight = null;
+    });
+    try {
+      await inFlight;
+      return await readBalance();
+    } catch {
+      return balance;
+    }
+  };
+}
+
+export { createFundingGate };

--- a/demo/src/solanaAdapter.ts
+++ b/demo/src/solanaAdapter.ts
@@ -5,12 +5,16 @@ import {
 import type { Connection } from "@solana/web3.js";
 import { formatDecimalAmount, parseDecimalAmount } from "./amount";
 import type { ChainAdapter } from "./ChainAccountCard";
-import { getSolBalance, signSolTransfer } from "./chains/solana";
+import { airdropSol, getSolBalance, signSolTransfer } from "./chains/solana";
+import { createFundingGate } from "./funding";
 import { bytesToBase64 } from "./ui";
 
 // Solana charges 5000 lamports per signature; a basic transfer needs one.
 const TRANSFER_FEE_LAMPORTS = 5000n;
 const SOL_DECIMALS = 9;
+// Balances below 10 DEMON are topped up with a 100 DEMON airdrop.
+const MIN_BALANCE_LAMPORTS = 10n * 10n ** 9n;
+const TOP_UP_LAMPORTS = 100n * 10n ** 9n;
 
 /**
  * Builds the Solana `ChainAdapter` for one account: balance reads from the
@@ -22,6 +26,11 @@ function createSolanaAdapter(
   address: string,
   connection: Connection,
 ): ChainAdapter {
+  const ensureFunded = createFundingGate({
+    minBalance: MIN_BALANCE_LAMPORTS,
+    fund: () => airdropSol(connection, address, TOP_UP_LAMPORTS),
+    readBalance: () => getSolBalance(connection, address),
+  });
   return {
     chainName: "Solana",
     badgeClassName: "badge chain-solana",
@@ -34,8 +43,9 @@ function createSolanaAdapter(
     parseAmount: (text) => parseDecimalAmount(text, SOL_DECIMALS),
     formatAmount: (amount) => formatDecimalAmount(amount, SOL_DECIMALS),
     async fetchBalance() {
+      const balance = await getSolBalance(connection, address);
       return {
-        balance: await getSolBalance(connection, address),
+        balance: await ensureFunded(balance),
         feeReserve: TRANSFER_FEE_LAMPORTS,
       };
     },


### PR DESCRIPTION
Second half of removing the faucet (#188): accounts need funds without the user doing anything.

Every balance read now passes through a funding gate: below 10 DEMON, the EVM adapter asks the network's guard for funds through its `demo_fundAccount` method, and the Solana adapter requests a 100 DEMON airdrop from the validator's built-in faucet; the balance is then re-read. Every refresh path (10-second poll, tab-focus refetch, post-send refetch) already funnels through `fetchBalance`, so a network restart re-funds a connected account within one poll cycle with no extra plumbing — the "restarts are fine" property the private networks rely on.

Non-obvious choices:

- The EVM funding policy (top up by 100 when below 10, no-op otherwise) lives in the network's guard (#187), not the client — anvil's cheat methods aren't publicly reachable, so the demo can't and doesn't set balances itself. The client keeps only the threshold that decides when to ask, matching the guard's. The guard adds to the current balance rather than setting a flat value, so an amount received while the account sat below the threshold survives — the demo's own send-to-Account-2 flow shows 100.01 instead of a flat 100.
- Airdrop confirmation polls `getSignatureStatuses` over HTTP. `connection.confirmTransaction` subscribes over a websocket that web3.js derives at rpc-port+1, which the Railway proxy's single HTTP port doesn't carry. Nothing in the demo uses websockets, and it needs to stay that way.
- While a top-up is in flight the card shows the existing "…" loading state and Send stays disabled through the existing covered-balance gate. A failed top-up shows the real balance and the next poll retries.

Verified end to end against the deployed networks with real Chrome and a virtual-authenticator passkey: both cards fund 0 → 100 DEMON on first load, sends broadcast, and each recipient shows 100.01.

<img src="https://github.com/user-attachments/assets/a7671e9f-df93-4c86-956b-3f4296efb9d7" width="420"> <img src="https://github.com/user-attachments/assets/6bf35308-2652-4bda-b0de-00cc67dadb64" width="420">