### PR TITLE
Rename Ethereum to EVM across the demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta
       name="description"
-      content="Create or unlock a passkey-backed account and use browser-held signing sessions for Ethereum and Solana."
+      content="Create or unlock a passkey-backed account and use browser-held signing sessions for EVM and Solana."
     >
     <meta name="theme-color" content="#f5f6f8">
     <meta property="og:type" content="website">
@@ -16,7 +16,7 @@
     >
     <meta
       property="og:description"
-      content="Create or unlock a passkey-backed account and use browser-held signing sessions for Ethereum and Solana."
+      content="Create or unlock a passkey-backed account and use browser-held signing sessions for EVM and Solana."
     >
     <meta property="og:image" content="/og-image.png">
     <meta property="og:image:type" content="image/png">
@@ -33,7 +33,7 @@
     >
     <meta
       name="twitter:description"
-      content="Create or unlock a passkey-backed account and use browser-held signing sessions for Ethereum and Solana."
+      content="Create or unlock a passkey-backed account and use browser-held signing sessions for EVM and Solana."
     >
     <meta name="twitter:image" content="/og-image.png">
     <meta

--- a/demo/src/AccountCard.tsx
+++ b/demo/src/AccountCard.tsx
@@ -1,21 +1,21 @@
 import type { Connection } from "@solana/web3.js";
 import { type ReactElement, useMemo, useState } from "react";
 import { ChainAccountCard, type RecipientSuggestion } from "./ChainAccountCard";
-import type { EthereumContext } from "./chains/ethereum";
+import type { EvmContext } from "./chains/evm";
 import {
   type AccountSlot,
   type ConnectedWallet,
   describeError,
   revealMnemonic,
 } from "./connect";
-import { createEthereumAdapter } from "./ethereumAdapter";
+import { createEvmAdapter } from "./evmAdapter";
 import { createSolanaAdapter } from "./solanaAdapter";
 import { WalletBackup } from "./WalletBackup";
 
-type ChainKind = "ethereum" | "solana";
+type ChainKind = "evm" | "solana";
 
 const CHAINS: { id: ChainKind; label: string }[] = [
-  { id: "ethereum", label: "Ethereum" },
+  { id: "evm", label: "EVM" },
   { id: "solana", label: "Solana" },
 ];
 
@@ -25,8 +25,8 @@ type AccountCardProps = {
   activeIndex: number;
   onSwitch: (index: number) => void;
   onAddAccount: () => void;
-  ethereum: EthereumContext | null;
-  ethereumError: string | null;
+  evm: EvmContext | null;
+  evmError: string | null;
   solana: Connection | null;
   solanaError: string | null;
   onLock: () => void;
@@ -45,13 +45,13 @@ function AccountCard({
   activeIndex,
   onSwitch,
   onAddAccount,
-  ethereum,
-  ethereumError,
+  evm,
+  evmError,
   solana,
   solanaError,
   onLock,
 }: AccountCardProps): ReactElement {
-  const [chain, setChain] = useState<ChainKind>("ethereum");
+  const [chain, setChain] = useState<ChainKind>("evm");
   const active = accounts[activeIndex] ?? accounts[0];
 
   // Recovery phrase, revealed on demand by a fresh passkey ceremony. It lives
@@ -103,16 +103,12 @@ function AccountCard({
     };
   }
 
-  const ethereumAdapter = useMemo(
+  const evmAdapter = useMemo(
     () =>
-      ethereum
-        ? createEthereumAdapter(
-            active.ethereum.session,
-            active.ethereum.address,
-            ethereum,
-          )
+      evm
+        ? createEvmAdapter(active.evm.session, active.evm.address, evm)
         : null,
-    [active, ethereum],
+    [active, evm],
   );
   const solanaAdapter = useMemo(
     () =>
@@ -183,22 +179,20 @@ function AccountCard({
         ))}
       </div>
 
-      {chain === "ethereum" ? (
-        ethereumAdapter ? (
+      {chain === "evm" ? (
+        evmAdapter ? (
           <ChainAccountCard
-            key={`eth-${active.index}`}
-            adapter={ethereumAdapter}
-            address={active.ethereum.address}
+            key={`evm-${active.index}`}
+            adapter={evmAdapter}
+            address={active.evm.address}
             mode={wallet.mode}
-            suggestion={suggestionFor("ethereum")}
+            suggestion={suggestionFor("evm")}
             onLock={onLock}
           />
-        ) : ethereumError ? (
-          <p className="status error">
-            Ethereum is unavailable: {ethereumError}
-          </p>
+        ) : evmError ? (
+          <p className="status error">EVM is unavailable: {evmError}</p>
         ) : (
-          <p className="status">The demo is connecting to Ethereum…</p>
+          <p className="status">The demo is connecting to EVM…</p>
         )
       ) : solanaAdapter ? (
         <ChainAccountCard

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -2,10 +2,7 @@ import type { Connection } from "@solana/web3.js";
 import { type ReactElement, useEffect, useState } from "react";
 import { AccountCard } from "./AccountCard";
 import { ConnectCard } from "./ConnectCard";
-import {
-  type EthereumContext,
-  resolveEthereumContext,
-} from "./chains/ethereum";
+import { type EvmContext, resolveEvmContext } from "./chains/evm";
 import { resolveSolanaConnection } from "./chains/solana";
 import {
   type AccountSlot,
@@ -51,9 +48,8 @@ function retryingResolve<T>(
 
 /** Root component: holds the connected wallet + accounts, fetches network info. */
 function App(): ReactElement {
-  const [ethereumContext, setEthereumContext] =
-    useState<EthereumContext | null>(null);
-  const [ethereumError, setEthereumError] = useState<string | null>(null);
+  const [evmContext, setEvmContext] = useState<EvmContext | null>(null);
+  const [evmError, setEvmError] = useState<string | null>(null);
 
   const [solanaConnection, setSolanaConnection] = useState<Connection | null>(
     null,
@@ -65,10 +61,10 @@ function App(): ReactElement {
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
-    const stopEthereum = retryingResolve(
-      resolveEthereumContext,
-      setEthereumContext,
-      setEthereumError,
+    const stopEvm = retryingResolve(
+      resolveEvmContext,
+      setEvmContext,
+      setEvmError,
     );
     const stopSolana = retryingResolve(
       resolveSolanaConnection,
@@ -76,7 +72,7 @@ function App(): ReactElement {
       setSolanaError,
     );
     return () => {
-      stopEthereum();
+      stopEvm();
       stopSolana();
     };
   }, []);
@@ -137,8 +133,8 @@ function App(): ReactElement {
           activeIndex={activeIndex}
           onSwitch={setActiveIndex}
           onAddAccount={handleAddAccount}
-          ethereum={ethereumContext}
-          ethereumError={ethereumError}
+          evm={evmContext}
+          evmError={evmError}
           solana={solanaConnection}
           solanaError={solanaError}
           onLock={handleLock}

--- a/demo/src/ChainAccountCard.tsx
+++ b/demo/src/ChainAccountCard.tsx
@@ -14,7 +14,7 @@ const DEMO_SEND_AMOUNT = "0.01";
  * convert to and from the decimal strings shown in the UI.
  */
 type ChainAdapter = {
-  /** Chain label for the card badge, e.g. "Ethereum". */
+  /** Chain label for the card badge, e.g. "EVM". */
   chainName: string;
   badgeClassName: string;
   symbol: string;

--- a/demo/src/WalletBackup.tsx
+++ b/demo/src/WalletBackup.tsx
@@ -36,7 +36,7 @@ function WalletBackup({ phrase, onHide }: WalletBackupProps): ReactElement {
       </div>
       <p className="hint">
         Anyone with these {words.length} words controls the funds. Compatible
-        wallet apps, such as MetaMask for Ethereum and Phantom for Solana, can
+        wallet apps, such as MetaMask for EVM chains and Phantom for Solana, can
         recover the same addresses.
       </p>
       <ol className="mnemonic-grid">

--- a/demo/src/chains/evm.ts
+++ b/demo/src/chains/evm.ts
@@ -18,7 +18,7 @@ const RPC_URL =
   "https://evm-network-production.up.railway.app";
 
 /** The resolved chain paired with a public client bound to it. */
-type EthereumContext = {
+type EvmContext = {
   chain: Chain;
   publicClient: PublicClient;
   rpcUrl: string;
@@ -30,7 +30,7 @@ type EthereumContext = {
  * also probes connectivity, so an unreachable endpoint fails here (and shows
  * on the card) rather than in the first balance read.
  */
-async function resolveEthereumContext(): Promise<EthereumContext> {
+async function resolveEvmContext(): Promise<EvmContext> {
   const bootstrap = createPublicClient({ transport: http(RPC_URL) });
   const id = await bootstrap.getChainId();
   const chain = defineChain({
@@ -87,5 +87,5 @@ function createTransactionClient(
   });
 }
 
-export type { EthereumContext };
-export { createTransactionClient, fundAccount, resolveEthereumContext };
+export type { EvmContext };
+export { createTransactionClient, fundAccount, resolveEvmContext };

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -14,7 +14,7 @@ import {
   type Secp256k1SigningSession,
 } from "@category-labs/mera";
 import {
-  deriveEthereumPrivateKey,
+  deriveEvmPrivateKey,
   deriveSolanaSeed,
   isValidMnemonic,
   mnemonicToSeed,
@@ -28,7 +28,7 @@ type AccountMode = "vault" | "passkey";
 /** One numbered account with a signing session per chain. */
 type AccountSlot = {
   index: number;
-  ethereum: {
+  evm: {
     session: Secp256k1SigningSession;
     address: EvmAddress;
   };
@@ -70,14 +70,14 @@ function deriveSlotFromSeed(seed: Uint8Array, index: number): AccountSlot {
   // Each derive* call returns a fresh buffer the session takes ownership of and
   // zeroes; the `seed` itself is never handed to a session.
   const secpSession = createSecp256k1SigningSession({
-    consumePrivateKey: deriveEthereumPrivateKey(seed, index),
+    consumePrivateKey: deriveEvmPrivateKey(seed, index),
   });
   const ed25519Session = createEd25519SigningSession({
     consumePrivateKey: deriveSolanaSeed(seed, index),
   });
   return {
     index,
-    ethereum: {
+    evm: {
       session: secpSession,
       address: getEvmAddress(secpSession.publicKey),
     },
@@ -125,7 +125,7 @@ function buildPasskeyWallet(
     },
     lock(): void {
       for (const slot of cache.values()) {
-        slot.ethereum.session.lock();
+        slot.evm.session.lock();
         slot.solana.session.lock();
       }
       cache.clear();
@@ -270,7 +270,7 @@ function buildVaultWallet(slot: AccountSlot): ConnectedWallet {
       return slot;
     },
     lock(): void {
-      slot.ethereum.session.lock();
+      slot.evm.session.lock();
       slot.solana.session.lock();
     },
   };

--- a/demo/src/evmAdapter.ts
+++ b/demo/src/evmAdapter.ts
@@ -5,28 +5,28 @@ import { formatDecimalAmount, parseDecimalAmount } from "./amount";
 import type { ChainAdapter } from "./ChainAccountCard";
 import {
   createTransactionClient,
-  type EthereumContext,
+  type EvmContext,
   fundAccount,
-} from "./chains/ethereum";
+} from "./chains/evm";
 import { createFundingGate } from "./funding";
 
-const ETH_DECIMALS = 18;
+const EVM_DECIMALS = 18;
 // Balances below this ask the network for funds. The top-up policy lives in
 // the network's guard (demo/network/evm/server.mts), which uses the same
 // threshold.
 const MIN_BALANCE_WEI = 10n * 10n ** 18n;
 
 /**
- * Builds the Ethereum `ChainAdapter` for one account: balance and gas-reserve
+ * Builds the EVM `ChainAdapter` for one account: balance and gas-reserve
  * reads from the context's public client, passkey signing, and raw-transaction
  * broadcast.
  */
-function createEthereumAdapter(
+function createEvmAdapter(
   session: Secp256k1SigningSession,
   address: EvmAddress,
-  ethereum: EthereumContext,
+  evm: EvmContext,
 ): ChainAdapter {
-  const { chain, publicClient, rpcUrl } = ethereum;
+  const { chain, publicClient, rpcUrl } = evm;
   const account = toViemAccount(session);
   const symbol = chain.nativeCurrency.symbol;
   const ensureFunded = createFundingGate({
@@ -35,14 +35,14 @@ function createEthereumAdapter(
     readBalance: () => publicClient.getBalance({ address }),
   });
   return {
-    chainName: "Ethereum",
+    chainName: "EVM",
     badgeClassName: "badge",
     symbol,
     recipientPlaceholder: "0x…",
     balanceTooLowError: "Balance is too low to cover gas.",
     isValidRecipient: isAddress,
-    parseAmount: (text) => parseDecimalAmount(text, ETH_DECIMALS),
-    formatAmount: (amount) => formatDecimalAmount(amount, ETH_DECIMALS),
+    parseAmount: (text) => parseDecimalAmount(text, EVM_DECIMALS),
+    formatAmount: (amount) => formatDecimalAmount(amount, EVM_DECIMALS),
     async fetchBalance() {
       const [balance, fees] = await Promise.all([
         publicClient.getBalance({ address }),
@@ -71,4 +71,4 @@ function createEthereumAdapter(
   };
 }
 
-export { createEthereumAdapter };
+export { createEvmAdapter };

--- a/demo/src/hd.ts
+++ b/demo/src/hd.ts
@@ -12,9 +12,10 @@ import { wordlist } from "@scure/bip39/wordlists/english.js";
 
 const PRF_OUTPUT_LENGTH = 32;
 
-// BIP-44 Ethereum path: the address index varies on the external chain
-// (the MetaMask convention).
-const ethereumPath = (index: number): string => `m/44'/60'/0'/0/${index}`;
+// BIP-44 path on coin type 60, Ethereum's registered type, which EVM accounts
+// share; the address index varies on the external chain (the MetaMask
+// convention).
+const evmPath = (index: number): string => `m/44'/60'/0'/0/${index}`;
 
 /**
  * Converts a 32-byte WebAuthn PRF output into the BIP-39 mnemonic that every
@@ -46,9 +47,9 @@ function isValidMnemonic(mnemonic: string): boolean {
   return validateMnemonic(mnemonic, wordlist);
 }
 
-/** secp256k1 private key for Ethereum account `index` (BIP-32 over BIP-44). */
-function deriveEthereumPrivateKey(seed: Uint8Array, index: number): Uint8Array {
-  const node = HDKey.fromMasterSeed(seed).derive(ethereumPath(index));
+/** secp256k1 private key for EVM account `index` (BIP-32 over BIP-44). */
+function deriveEvmPrivateKey(seed: Uint8Array, index: number): Uint8Array {
+  const node = HDKey.fromMasterSeed(seed).derive(evmPath(index));
   if (!node.privateKey) {
     throw new Error("BIP-32 derivation produced no private key");
   }
@@ -97,7 +98,7 @@ function slip10ChildHardened(node: Slip10Node, index: number): Slip10Node {
 
 export {
   createMnemonic,
-  deriveEthereumPrivateKey,
+  deriveEvmPrivateKey,
   deriveSolanaSeed,
   isValidMnemonic,
   mnemonicToSeed,

--- a/site/index.html
+++ b/site/index.html
@@ -989,10 +989,9 @@ const address = getEvmAddress(session.publicKey)</code></pre>
 
         <p>
           The demo below runs both patterns. It opens with passkey accounts;
-          create a passkey or sign in with an existing one, see Ethereum and
-          Solana addresses, and reveal the recovery phrase. The link under the
-          card switches to the secret-vault flow for importing an existing
-          phrase.
+          create a passkey or sign in with an existing one, see EVM and Solana
+          addresses, and reveal the recovery phrase. The link under the card
+          switches to the secret-vault flow for importing an existing phrase.
         </p>
 
         <figure class="demo">


### PR DESCRIPTION
The demo no longer touches the Ethereum network (#188), so calling its EVM side "Ethereum" is wrong. The chain tab, card badge, status copy, meta descriptions, file names, identifiers, and the account-slot key now say EVM.

"Ethereum" intentionally survives where the standard itself is meant: BIP-44 coin type 60 in `hd.ts` (Ethereum's registered coin type, which EVM accounts share), the MetaMask/Phantom portability notes, and the EIP and secp256k1 discussion in the site article.

<img src="https://github.com/user-attachments/assets/882d12ae-aceb-49db-abad-a807f0880ce4" width="420">