### PR TITLE
Auto-fund demo accounts only before their first transaction

### DIFF
--- a/demo/network/README.md
+++ b/demo/network/README.md
@@ -2,16 +2,19 @@
 
 Private, disposable networks the demo runs against, one Railway service per
 directory. Neither network holds real value: state is wiped on every restart,
-and the demo funds accounts automatically when a balance runs low.
+and the demo funds accounts automatically until they show on-chain activity,
+so an account emptied on purpose stays empty.
 
 - `evm/` — anvil from the [monad-foundry fork](https://github.com/category-labs/foundry),
   run with `--network monad` behind a guard server (`evm/server.mts`). The
   guard forwards the `eth_*`, `net_*`, and `web3_*` namespaces, refuses
   anvil's cheat methods, and funds accounts through one guarded method:
-  `demo_fundAccount(address)` tops a balance below 10 DEMON up by 100 and is
-  a no-op otherwise.
+  `demo_fundAccount(address)` tops a balance below 10 DEMON up by 100 for
+  accounts that have never sent a transaction, and is a no-op otherwise.
 - `solana/` — `solana-test-validator` from [Agave](https://github.com/anza-xyz/agave).
-  Accounts are funded with the validator's built-in `requestAirdrop`.
+  Accounts are funded with the validator's built-in `requestAirdrop`; the
+  demo airdrops only to addresses with no transaction history, and the
+  airdrop itself creates history, so an address is funded once per ledger.
 
 Run them locally with Docker. Both images download amd64 binaries, so the
 platform flag keeps them working on other hosts, such as Apple Silicon:

--- a/demo/network/evm/server.mts
+++ b/demo/network/evm/server.mts
@@ -30,9 +30,10 @@ const REFUSED_METHODS = new Set([
   "eth_signTypedData_v3",
   "eth_signTypedData_v4",
 ]);
-// Funding policy: balances below the threshold are raised by the top-up.
-// The demo's EVM adapter asks only when a balance is below the same
-// threshold (its MIN_BALANCE_WEI).
+// Funding policy: balances below the threshold are raised by the top-up,
+// but only for accounts that have never sent a transaction (nonce 0), so an
+// account emptied on purpose stays empty. The demo's EVM adapter applies the
+// same threshold and nonce check before asking.
 const MIN_BALANCE_WEI = 10n * 10n ** 18n;
 const TOP_UP_WEI = 100n * 10n ** 18n;
 // Large enough for any raw transaction the demo produces; requests beyond
@@ -83,18 +84,29 @@ async function anvilRequest(
   return body.result;
 }
 
-// Raises `address`'s balance to current + TOP_UP_WEI when it sits below the
-// threshold, and is a no-op otherwise, so callers can invoke it idempotently.
-// Adding to the current balance (anvil_setBalance is absolute) preserves
-// amounts received while the account was below the threshold. Returns the
-// resulting balance as a hex quantity.
-async function fundAccount(address: string): Promise<string> {
-  const result = await anvilRequest("eth_getBalance", [address, "latest"]);
+async function anvilQuantity(
+  method: string,
+  params: unknown[],
+): Promise<bigint> {
+  const result = await anvilRequest(method, params);
   if (typeof result !== "string") {
-    throw new Error("eth_getBalance returned a non-string result");
+    throw new Error(`${method} returned a non-string result`);
   }
-  const balance = BigInt(result);
-  if (balance < MIN_BALANCE_WEI) {
+  return BigInt(result);
+}
+
+// Raises `address`'s balance to current + TOP_UP_WEI when it sits below the
+// threshold and the account has never sent a transaction, and is a no-op
+// otherwise, so callers can invoke it idempotently. Adding to the current
+// balance (anvil_setBalance is absolute) preserves amounts received while
+// the account was below the threshold. Returns the resulting balance as a
+// hex quantity.
+async function fundAccount(address: string): Promise<string> {
+  const [balance, nonce] = await Promise.all([
+    anvilQuantity("eth_getBalance", [address, "latest"]),
+    anvilQuantity("eth_getTransactionCount", [address, "latest"]),
+  ]);
+  if (balance < MIN_BALANCE_WEI && nonce === 0n) {
     const funded = balance + TOP_UP_WEI;
     await anvilRequest("anvil_setBalance", [
       address,

--- a/demo/src/chains/solana.ts
+++ b/demo/src/chains/solana.ts
@@ -36,6 +36,22 @@ async function getSolBalance(
 }
 
 /**
+ * Reports whether any transaction on the current ledger mentions the address.
+ * The funding airdrop itself counts, so on Solana an address shows activity
+ * from its first top-up onward.
+ */
+async function hasSignatureHistory(
+  connection: Connection,
+  address: string,
+): Promise<boolean> {
+  const signatures = await connection.getSignaturesForAddress(
+    new PublicKey(address),
+    { limit: 1 },
+  );
+  return signatures.length > 0;
+}
+
+/**
  * Requests an airdrop from the network's built-in faucet and waits for it to
  * confirm by polling the signature status over HTTP. `Connection`'s own
  * confirmation helpers subscribe over a websocket, which the demo network's
@@ -113,4 +129,10 @@ async function signSolTransfer({
   return transaction.serialize();
 }
 
-export { airdropSol, getSolBalance, resolveSolanaConnection, signSolTransfer };
+export {
+  airdropSol,
+  getSolBalance,
+  hasSignatureHistory,
+  resolveSolanaConnection,
+  signSolTransfer,
+};

--- a/demo/src/evmAdapter.ts
+++ b/demo/src/evmAdapter.ts
@@ -11,9 +11,10 @@ import {
 import { createFundingGate } from "./funding";
 
 const EVM_DECIMALS = 18;
-// Balances below this ask the network for funds. The top-up policy lives in
-// the network's guard (demo/network/evm/server.mts), which uses the same
-// threshold.
+// Balances below this ask the network for funds, but only before the
+// account's first outgoing transaction (nonce 0). The top-up policy lives in
+// the network's guard (demo/network/evm/server.mts), which applies the same
+// threshold and nonce check.
 const MIN_BALANCE_WEI = 10n * 10n ** 18n;
 
 /**
@@ -31,6 +32,8 @@ function createEvmAdapter(
   const symbol = chain.nativeCurrency.symbol;
   const ensureFunded = createFundingGate({
     minBalance: MIN_BALANCE_WEI,
+    hasActivity: async () =>
+      (await publicClient.getTransactionCount({ address })) > 0,
     fund: () => fundAccount(address),
     readBalance: () => publicClient.getBalance({ address }),
   });

--- a/demo/src/funding.ts
+++ b/demo/src/funding.ts
@@ -1,6 +1,8 @@
 type FundingGateOptions = {
   /** Balance below which a top-up runs, in the chain's smallest unit. */
   minBalance: bigint;
+  /** Reports whether the account has prior on-chain activity. */
+  hasActivity: () => Promise<boolean>;
   /** Funds the account, e.g. through a funding endpoint or an airdrop. */
   fund: () => Promise<void>;
   /** Re-reads the balance after a successful top-up. */
@@ -9,24 +11,30 @@ type FundingGateOptions = {
 
 /**
  * Creates a funding gate for one account. The demo networks hold no real
- * value, so accounts are funded on demand: pass each balance read through the
- * gate, and a balance below `minBalance` is topped up and re-read. Only one
- * top-up runs at a time; concurrent reads await the same one. A failed top-up
- * or re-read (for example while a network restarts) returns the balance
- * unchanged, so the caller's next poll retries.
+ * value, so fresh accounts are funded on demand: pass each balance read
+ * through the gate, and a balance below `minBalance` is topped up and re-read.
+ * Accounts with prior on-chain activity are left alone, so an account emptied
+ * on purpose stays empty instead of silently refilling. Activity is re-read on
+ * each low-balance pass rather than cached, because a network reset wipes the
+ * activity and must re-arm funding. Only one top-up runs at a time; concurrent
+ * reads await the same one. A failed check, top-up, or re-read (for example
+ * while a network restarts) returns the balance unchanged, so the caller's
+ * next poll retries.
  */
 function createFundingGate({
   minBalance,
+  hasActivity,
   fund,
   readBalance,
 }: FundingGateOptions): (balance: bigint) => Promise<bigint> {
   let inFlight: Promise<void> | null = null;
   return async (balance) => {
     if (balance >= minBalance) return balance;
-    inFlight ??= fund().finally(() => {
-      inFlight = null;
-    });
     try {
+      if (await hasActivity()) return balance;
+      inFlight ??= fund().finally(() => {
+        inFlight = null;
+      });
       await inFlight;
       return await readBalance();
     } catch {

--- a/demo/src/solanaAdapter.ts
+++ b/demo/src/solanaAdapter.ts
@@ -5,14 +5,22 @@ import {
 import type { Connection } from "@solana/web3.js";
 import { formatDecimalAmount, parseDecimalAmount } from "./amount";
 import type { ChainAdapter } from "./ChainAccountCard";
-import { airdropSol, getSolBalance, signSolTransfer } from "./chains/solana";
+import {
+  airdropSol,
+  getSolBalance,
+  hasSignatureHistory,
+  signSolTransfer,
+} from "./chains/solana";
 import { createFundingGate } from "./funding";
 import { bytesToBase64 } from "./ui";
 
 // Solana charges 5000 lamports per signature; a basic transfer needs one.
 const TRANSFER_FEE_LAMPORTS = 5000n;
 const SOL_DECIMALS = 9;
-// Balances below 10 DEMON are topped up with a 100 DEMON airdrop.
+// Balances below 10 DEMON are topped up with a 100 DEMON airdrop, but only
+// while the address has no transaction history. The airdrop itself creates
+// history, so an address is funded at most once per ledger; validator
+// restarts reset the ledger and re-arm funding.
 const MIN_BALANCE_LAMPORTS = 10n * 10n ** 9n;
 const TOP_UP_LAMPORTS = 100n * 10n ** 9n;
 
@@ -28,6 +36,7 @@ function createSolanaAdapter(
 ): ChainAdapter {
   const ensureFunded = createFundingGate({
     minBalance: MIN_BALANCE_LAMPORTS,
+    hasActivity: () => hasSignatureHistory(connection, address),
     fund: () => airdropSol(connection, address, TOP_UP_LAMPORTS),
     readBalance: () => getSolBalance(connection, address),
   });


### PR DESCRIPTION
The demo's funding gate topped up any balance below 10 DEMON on every balance read, so a user who clicked "Max" and sent their whole balance out saw it snap straight back to ~100 DEMON on the next refresh. The refill made transfers look like they had no effect.

Funding now applies only to accounts with no prior on-chain activity, read from the chain itself so no funded state is stored anywhere: EVM uses the transaction count (a balance can only drop through the account's own transaction, so "low balance + nonce 0" precisely identifies a fresh account), and Solana uses signature history (the airdrop itself creates history, so an address funds at most once per ledger). The EVM guard's `demo_fundAccount` enforces the same nonce check server-side, keeping the policy authoritative where its header says it lives; the client check mirrors it the same way the threshold already did.

Trade-offs and behavior to know about:

- A deliberately drained account now stays empty. Recovery is receiving from the other demo account or adding a new account (fresh derivation index, funds automatically). A low-balance top-up button was considered and explicitly declined to keep the demo minimal.
- Network wipes still re-arm funding: the activity check is re-read on each low-balance pass rather than cached, so an anvil redeploy or the validator's `--reset` restores auto-funding. The check only runs when a balance is already below the threshold, so the healthy path costs no extra RPCs.
- The server half takes effect on Railway only after the EVM network service redeploys.

Manual validation, beyond `npm run check` and the demo typecheck:

- EVM, end-to-end against the updated guard running locally with anvil: a fresh account funds to exactly 100 DEMON; after a Max-style drain (nonce 1, balance below threshold) `demo_fundAccount` becomes a no-op returning the unchanged balance; a second fresh address still funds.
- Solana, against the hosted validator: a fresh keypair has no signature history, the airdrop confirms at 100 DEMON, and the resulting history means the gate refuses further funding.
- UI smoke: the demo loads in a browser preview with no console errors. The passkey ceremony itself was not driven headless; the funding logic is covered by the scripts above.