### PR TITLE
Keep demo send errors short and wrapped

### DIFF
--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -10,6 +10,7 @@ import {
   parseSecretVault,
   type Secp256k1SigningSession,
 } from "@category-labs/mera";
+import { BaseError as ViemError } from "viem";
 import {
   deriveEvmPrivateKey,
   isValidMnemonic,
@@ -340,6 +341,9 @@ function describeError(error: unknown): string {
         return error.message;
     }
   }
+  // A viem error's `message` appends the request URL, body, and hex payload;
+  // `shortMessage` is its one-line summary, e.g. "Transaction creation failed."
+  if (error instanceof ViemError) return error.shortMessage;
   return error instanceof Error ? error.message : String(error);
 }
 

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -408,6 +408,10 @@ input:focus-visible {
   margin: 0;
   font-size: 13px;
   line-height: 1.4;
+  /* Error text can embed long unbroken tokens (URLs, hex payloads), which
+     would widen the card's grid track and force horizontal scrolling; see
+     `.break` for the same fix on the signed-transaction display. */
+  overflow-wrap: anywhere;
 }
 
 .status.error {


### PR DESCRIPTION
## Why

A failed send surfaced viem's full error text, which embeds long unbroken tokens (the RPC URL, the request body with the hex-encoded transaction, and the library version). This broke the demo in two ways: `.status` had no wrapping rule, so the tokens inflated the min-content width of the card's grid column, widening the page and adding a horizontal scrollbar in the docs embed; and the dump itself is noise for a status line.

Two commits, one per fix:

1. Wrap status text with `overflow-wrap: anywhere` — the same failure mode the signed-transaction display already guards against with `.break`. Kept even with shorter messages, so no future status string can widen the card.
2. Show viem errors as their one-line `shortMessage` (e.g. "Transaction creation failed.") instead of the full `message` dump. Non-viem errors are unchanged.

## Notes for reviewers

Manually validated in the running demo:

- Wrapping: injected the raw viem error text; with the rule, the text wraps inside the 420px card and the page scroll width equals the viewport at 1280px and 375px; with the rule toggled off, the page scroll width grows to 2253px at a 1280px viewport, reproducing the bug.
- Short message: exercised `describeError` through the dev server's real module graph with the errors viem throws on an underfunded broadcast (`TransactionRejectedRpcError`) and a transport failure (`HttpRequestError`); they render as "Transaction creation failed." and "HTTP request failed." respectively, and plain `Error` messages pass through unchanged.

| Before | After wrapping (commit 1) | After short message (commit 2) |
| --- | --- | --- |
| ![before.png](https://github.com/user-attachments/assets/8eb694b2-ca39-42b8-ae37-a0c5c874bbdf) | ![after.png](https://github.com/user-attachments/assets/17525854-d40b-4ace-8c16-cd2391e840be) | ![final.png](https://github.com/user-attachments/assets/e3fb8cdc-a1db-448f-b847-5015dba6a0ec) |