### PR TITLE
Load Satoshi in the demo and drop the placeholder logo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,6 +40,15 @@
       name="twitter:image:alt"
       content="Mera browser demo: passkey onboarding and signing."
     >
+    <link rel="preconnect" href="https://api.fontshare.com">
+    <link rel="preconnect" href="https://cdn.fontshare.com" crossorigin>
+    <!-- no-referrer: Fontshare rejects requests bearing a localhost referer,
+         which would leave local dev on the fallback fonts -->
+    <link
+      rel="stylesheet"
+      referrerpolicy="no-referrer"
+      href="https://api.fontshare.com/v2/css?f[]=satoshi@1&display=swap"
+    >
     <title>Mera Demo | Passkey onboarding and signing</title>
   </head>
   <body>

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -58,17 +58,7 @@ function App(): ReactElement {
 
   return (
     <main className="app">
-      <header className="brand">
-        <div className="brand-lockup">
-          <div className="mark" aria-hidden="true">
-            ◈
-          </div>
-          <div>
-            <h1>Mera Demo</h1>
-          </div>
-        </div>
-      </header>
-
+      <h1>Mera Demo</h1>
       <TradingCard evm={evmContext} evmError={evmError} />
     </main>
   );

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -17,9 +17,7 @@
   --shadow:
     0 1px 2px rgba(15, 17, 21, 0.04), 0 12px 32px rgba(15, 17, 21, 0.06);
 
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, sans-serif;
+  font-family: "Satoshi", -apple-system, system-ui, sans-serif;
   font-synthesis: none;
   -webkit-font-smoothing: antialiased;
 }
@@ -56,36 +54,6 @@ body {
   flex-direction: column;
   flex: 1;
   gap: 18px;
-}
-
-/* Header */
-.brand {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.brand-lockup {
-  display: flex;
-  align-items: center;
-  min-width: 0;
-  gap: 12px;
-}
-
-.brand-lockup > div:last-child {
-  min-width: 0;
-}
-
-.mark {
-  display: grid;
-  place-items: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 11px;
-  background: linear-gradient(135deg, var(--accent), #8b5cf6);
-  color: #fff;
-  font-size: 20px;
 }
 
 h1 {


### PR DESCRIPTION
## Why

The docs render in Satoshi, but the demo declared Inter without ever loading it, so it silently fell back to system fonts and the two surfaces looked unrelated. The demo now loads Satoshi from the same Fontshare CDN as the docs and uses the docs' exact fallback stack.

Two deviations from the docs' setup, both deliberate:

- The demo loads the variable cut (`satoshi@1`, weight range 300-900) instead of the docs' static weights, because the demo styles use in-between weights (550, 650) that static 400/500/700 cuts would round up to bold under CSS font matching.
- The link carries `referrerpolicy="no-referrer"`: Fontshare rejects requests bearing a `localhost` referer (it returns a "temporarily restricted" comment instead of the `@font-face` CSS), which would leave local dev on the fallback fonts. Requests without a referer and requests from production domains both pass. The docs dev server has the same latent issue; fixing it there is left as a follow-up.

The header's gradient-tile brand lockup is also removed as a placeholder that added nothing; only the "Mera Demo" title remains above the card.

## Notes for reviewers

Verified in the browser: `document.fonts` reports the Satoshi face loaded, and rendered text measures distinctly from `-apple-system`, so the demo genuinely renders Satoshi rather than a fallback.

## Screenshots

![demo-satoshi.png](https://github.com/user-attachments/assets/53c833a0-eeb4-443a-bcfb-e18fa04570f5)
