### PR TITLE
Stop tracking demo/.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist/
 node_modules/
 demo/network/evm/out/
 demo/network/evm/cache/
+demo/.env
 .astro/
 playwright-report/
 test-results/

--- a/demo/.env
+++ b/demo/.env
@@ -1,1 +1,0 @@
-VITE_EVM_RPC_URL=http://127.0.0.1:18545


### PR DESCRIPTION
The hosted demo at mera-demo.up.railway.app stopped working: every visitor saw "The market is unavailable: Failed to fetch" because the app was posting to `http://127.0.0.1:18545`.

The cause is `demo/.env`, the local-network override, which slipped into f00a2ed because nothing gitignored it. Vite loads `demo/.env` at build time, so Railway's build baked the localhost URL into the deployed bundle (verified: the live `index-*.js` contains `127.0.0.1:18545` and no hosted URL). No Railway variable was involved — the hosted endpoint is the hardcoded fallback in `demo/src/chains/evm.ts`, and the network itself is healthy (`demo_market` answers correctly).

This removes the file and gitignores `demo/.env` so the override stays local. `demo/.env.example` already documents recreating it for local runs.

Verified by rebuilding the demo from this branch: the bundle now contains `evm-network-production.up.railway.app` and no `127.0.0.1:18545`. Merging will trigger a Railway redeploy that picks up the fix.

Note for local checkouts: pulling this deletes an unmodified `demo/.env`; copy `demo/.env.example` back if you run against a local network.