### PR TITLE
Anchor the disclaimer to the bottom of the window or frame

### DIFF
--- a/demo/src/TradingCard.tsx
+++ b/demo/src/TradingCard.tsx
@@ -530,19 +530,7 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
         )}
       </section>
 
-      {account.status === "none" ? (
-        <button
-          type="button"
-          className="mode-switch"
-          onClick={() =>
-            setConnectMode(connectMode === "passkey" ? "vault" : "passkey")
-          }
-        >
-          {connectMode === "passkey"
-            ? "Import existing secret →"
-            : "← Back to passkey accounts"}
-        </button>
-      ) : (
+      {account.status !== "none" && (
         <>
           <div className="account-links">
             {portfolio !== null && portfolio.cash < LOW_CASH_WEI && (
@@ -571,9 +559,24 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
         </>
       )}
 
-      <p className="disclaimer">
-        Runs on a demo network. Everything traded is fictional.
-      </p>
+      <div className="shell-footer">
+        {account.status === "none" && (
+          <button
+            type="button"
+            className="mode-switch"
+            onClick={() =>
+              setConnectMode(connectMode === "passkey" ? "vault" : "passkey")
+            }
+          >
+            {connectMode === "passkey"
+              ? "Import existing secret →"
+              : "← Back to passkey accounts"}
+          </button>
+        )}
+        <p className="disclaimer">
+          Runs on a demo network. Everything traded is fictional.
+        </p>
+      </div>
     </div>
   );
 }

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -127,13 +127,25 @@ input:focus-visible {
   box-shadow: var(--shadow);
 }
 
-/* Trading surface shell: the card, its footer links, and the disclaimer.
-   Flexing lets the signed-out mode switch push itself to the page bottom
-   with `margin-top: auto`, like the old connect screen's footer did. */
+/* Trading surface shell: the card, its footer links, and the shell footer.
+   Flexing lets the footer push itself to the page bottom with
+   `margin-top: auto`, like the old connect screen's footer did. */
 .account-shell {
   display: flex;
   flex-direction: column;
   flex: 1;
+  gap: 14px;
+}
+
+/* Page-bottom footer: the connect mode switch (signed out) and the
+   disclaimer. `margin-top: auto` pushes it to the bottom of the
+   viewport-filling column; embedded, where the page hugs its content, the
+   auto margin collapses to the plain gap. */
+.shell-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: auto;
   gap: 14px;
 }
 
@@ -337,13 +349,9 @@ input:focus-visible {
   letter-spacing: normal;
 }
 
-/* Signed-out footer link that swaps passkey and vault connect modes:
-   `margin-top: auto` pushes it to the bottom of the viewport-filling column
-   (and collapses to the plain gap when embedded, where the page hugs its
-   content). Quiet by default, accent on hover. */
+/* Signed-out footer link that swaps passkey and vault connect modes.
+   Quiet by default, accent on hover. */
 .mode-switch {
-  align-self: center;
-  margin-top: auto;
   border: none;
   background: none;
   padding: 4px 8px;
@@ -559,21 +567,28 @@ html[data-embedded="true"] .app {
 
 /* Embedded in a frame taller than the content (embed.ts sets
    `data-footer-pinned`): the hugged column has no spare height for
-   `margin-top: auto` to distribute, so pin the mode switch just above the
-   frame's bottom edge instead. The column reserves the link's in-flow band so
-   the measured content height stays the same whether or not the link is in
-   the flow; small drift between the reserve and the real band is absorbed by
-   FOOTER_PIN_SLACK_PX in embed.ts. */
-html[data-footer-pinned="true"] .app:has(.mode-switch) {
-  /* The 18px `.app` column gap + the link's ~24px box. */
-  padding-bottom: 42px;
+   `margin-top: auto` to distribute, so pin the shell footer just above the
+   frame's bottom edge instead. The column reserves the footer's in-flow band
+   so the measured content height stays the same whether or not the footer is
+   in the flow; small drift between the reserve and the real band is absorbed
+   by FOOTER_PIN_SLACK_PX in embed.ts. */
+html[data-footer-pinned="true"] .app:has(.shell-footer) {
+  /* The 14px shell gap + the disclaimer's ~14px line. */
+  padding-bottom: 28px;
 }
 
-html[data-footer-pinned="true"] .mode-switch {
+html[data-footer-pinned="true"] .app:has(.mode-switch) {
+  /* + the mode switch's ~23px box and the footer's 14px gap. */
+  padding-bottom: 65px;
+}
+
+html[data-footer-pinned="true"] .shell-footer {
   position: fixed;
-  /* 16px embedded body padding + 8px `.app` margin: the same offset the
-     in-flow link gets in a content-sized frame. */
+  /* 16px embedded body padding + 8px `.app` margin: the same bottom offset
+     the in-flow footer gets in a content-sized frame. The side offsets mirror
+     the body padding so the pinned footer keeps the in-flow width and the
+     disclaimer wraps identically in both states. */
   bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 16px;
+  right: 16px;
 }


### PR DESCRIPTION
## Why

The disclaimer's position depended on which mode the demo ran in. Standalone and signed out it appeared at the viewport bottom, but only as a side effect of the mode switch's `margin-top: auto` dragging it down; signed in, or embedded in the post's iframe, it sat directly under the card. In a frame taller than the content (the docs hero before the first height report), the footer-pinned path pinned only the mode switch to the frame's bottom edge and left the disclaimer behind, stranded above the dead space.

This change makes the disclaimer read as a footer everywhere: the mode switch and the disclaimer now form one shell footer that is pushed to the viewport bottom standalone, sits at the frame's bottom in a content-sized frame, and is pinned above the frame's bottom edge as a unit when the frame is taller than the content.

## Notes for reviewers

The footer-pinned reserve now has two sizes (with and without the mode switch) so the measured content height stays stable when pinning toggles; I verified 0px drift in both states in the browser, well within `FOOTER_PIN_SLACK_PX`.

The pinned footer switched from `left: 50%` + translate centering to `left/right: 16px` offsets. Shrink-to-fit sizing of a fixed element capped the old approach at half the viewport width, which at mobile widths wrapped the disclaimer onto a second line only while pinned and would have broken that height invariant; the side offsets mirror the embedded body padding, so the pinned footer keeps the in-flow width.

## Screenshots

Embedded in a frame taller than the content (the docs hero before the first height report), signed out:

| Before | After |
| --- | --- |
| ![before.png](https://github.com/user-attachments/assets/d637313f-0963-4f57-addc-f33c138f0872) | ![after.png](https://github.com/user-attachments/assets/23ff2aab-d8b2-4b72-bf19-e6047ad72099) |
