### PR TITLE
Restore separate create and sign-in buttons for passkey mode

### DIFF
--- a/demo/src/ConnectPanel.tsx
+++ b/demo/src/ConnectPanel.tsx
@@ -1,4 +1,3 @@
-import { isMeraError } from "@category-labs/mera";
 import { type ReactElement, useState } from "react";
 import {
   type AccountMode,
@@ -14,17 +13,15 @@ type ConnectPanelProps = {
 };
 
 /**
- * The connect area under the market data. Passkey mode is a single button:
- * it tries a discoverable sign-in and flips to offering a fresh account when
- * that fails, because WebAuthn reports "no passkey" and "cancelled" as the
- * same error. Vault mode imports or creates a phrase-backed account. Mount
- * with `key={mode}` so switching modes resets the local state.
+ * The connect area under the market data. Passkey mode offers explicit
+ * create and sign-in actions; new passkeys are created under a fixed default
+ * name. Vault mode imports or creates a phrase-backed account. Mount with
+ * `key={mode}` so switching modes resets the local state.
  */
 function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
   const [secret, setSecret] = useState("");
-  const [busy, setBusy] = useState(false);
+  const [busy, setBusy] = useState<"create" | "signin" | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [offerCreate, setOfferCreate] = useState(false);
 
   const trimmedSecret = secret.trim();
   const secretValid = isValidMnemonic(trimmedSecret);
@@ -35,23 +32,14 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
   }
 
   async function run(action: "create" | "signin") {
-    setBusy(true);
+    setBusy(action);
     setError(null);
     try {
       onConnected(await connect(mode, action, secret));
     } catch (caught) {
-      if (
-        mode === "passkey" &&
-        action === "signin" &&
-        isMeraError(caught) &&
-        caught.code === "PASSKEY_OPERATION_FAILED"
-      ) {
-        setOfferCreate(true);
-      } else {
-        setError(describeError(caught));
-      }
+      setError(describeError(caught));
     } finally {
-      setBusy(false);
+      setBusy(null);
     }
   }
 
@@ -69,7 +57,7 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
               type="button"
               className="link small"
               onClick={generate}
-              disabled={busy}
+              disabled={busy !== null}
             >
               Generate
             </button>
@@ -82,7 +70,7 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
             autoCapitalize="off"
             spellCheck={false}
             onChange={(event) => setSecret(event.target.value)}
-            disabled={busy}
+            disabled={busy !== null}
           />
         </label>
         {trimmedSecret.length > 0 && !secretValid && (
@@ -93,17 +81,17 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
             type="button"
             className="btn primary"
             onClick={() => void run("create")}
-            disabled={busy || !secretValid}
+            disabled={busy !== null || !secretValid}
           >
-            {busy ? "Waiting for passkey…" : "Open account"}
+            {busy === "create" ? "Waiting for passkey…" : "Open account"}
           </button>
           <button
             type="button"
             className="btn"
             onClick={() => void run("signin")}
-            disabled={busy}
+            disabled={busy !== null}
           >
-            Sign in
+            {busy === "signin" ? "Waiting for passkey…" : "Sign in"}
           </button>
         </div>
         {error && <p className="status error">{error}</p>}
@@ -113,36 +101,27 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
 
   return (
     <div className="connect-cta">
-      {offerCreate && (
-        <p className="hint">
-          No passkey for this demo on the device. Create a new one to start.
-        </p>
-      )}
-      <button
-        type="button"
-        className="btn primary"
-        onClick={() => void run(offerCreate ? "create" : "signin")}
-        disabled={busy}
-      >
-        {busy
-          ? "Waiting for passkey…"
-          : offerCreate
-            ? "Create account"
-            : "Sign in with a passkey"}
-      </button>
-      {offerCreate && (
+      <p className="hint">
+        Sign in with a passkey from before, or create a new account.
+      </p>
+      <div className="actions">
         <button
           type="button"
-          className="link"
-          onClick={() => {
-            setOfferCreate(false);
-            setError(null);
-          }}
-          disabled={busy}
+          className="btn primary"
+          onClick={() => void run("create")}
+          disabled={busy !== null}
         >
-          Try sign-in again
+          {busy === "create" ? "Waiting for passkey…" : "Create account"}
         </button>
-      )}
+        <button
+          type="button"
+          className="btn"
+          onClick={() => void run("signin")}
+          disabled={busy !== null}
+        >
+          {busy === "signin" ? "Waiting for passkey…" : "Sign in"}
+        </button>
+      </div>
       {error && <p className="status error">{error}</p>}
     </div>
   );

--- a/demo/src/ConnectPanel.tsx
+++ b/demo/src/ConnectPanel.tsx
@@ -101,9 +101,6 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
 
   return (
     <div className="connect-cta">
-      <p className="hint">
-        Sign in with a passkey from before, or create a new account.
-      </p>
       <div className="actions">
         <button
           type="button"


### PR DESCRIPTION
## Why

The single passkey button tried a discoverable sign-in and flipped to offering account creation when it failed, because WebAuthn reports "no passkey" and "cancelled" as the same error. Guessing intent from that ambiguous failure degraded the experience: cancelling a sign-in pushed the user toward creating an account, and a new user had to fail a sign-in before the create option appeared.

Explicit **Create account** and **Sign in** buttons remove the guess, so the `offerCreate` flip and its `PASSKEY_OPERATION_FAILED` special-casing go away; a failed or cancelled ceremony now just shows the error next to a visible Create button. The layout mirrors what vault mode already uses. The passkey-name input is deliberately not restored; passkeys keep the default label.

## Notes for reviewers

Manually validated in the running demo: both ceremonies dispatch the right action, buttons disable while one is pending with "Waiting for passkey…" only on the pressed button, and a failed ceremony surfaces the error and re-enables both. Vault mode is visually unchanged (its busy state is now per-button too).

## Screenshots

![The passkey connect card with separate Create account and Sign in buttons](https://github.com/user-attachments/assets/503598eb-fd21-4066-a295-35e1fa7c1397)

