### PR TITLE
Add Terms of Service and Privacy Policy links to the docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -119,6 +119,7 @@ export default defineConfig({
         "./src/styles/mera.css",
       ],
       components: {
+        Footer: "./src/components/Footer.astro",
         Header: "./src/components/Header.astro",
         Hero: "./src/components/Hero.astro",
         ThemeProvider: "./src/components/ThemeProvider.astro",

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -1,0 +1,19 @@
+---
+// Starlight's default footer followed by the legal links. The legal block
+// is a <footer> so the landing's hide rule in Hero.astro covers it too.
+import Default from "@astrojs/starlight/components/Footer.astro";
+import LegalLinks from "./LegalLinks.astro";
+---
+
+<Default />
+<footer class="legal">
+  <LegalLinks />
+</footer>
+
+<style>
+  .legal {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--sl-color-hairline);
+  }
+</style>

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -6,6 +6,7 @@
 import { LinkButton } from "@astrojs/starlight/components";
 import { withBasePath } from "../base-path";
 import DemoEmbed from "./DemoEmbed.astro";
+import LegalLinks from "./LegalLinks.astro";
 
 const { data } = Astro.locals.starlightRoute.entry;
 const { tagline, actions = [] } = data.hero || {};
@@ -86,6 +87,10 @@ const features = [
         </div>
       )
     }
+
+    <div class="legal">
+      <LegalLinks />
+    </div>
   </div>
 
   <div class="demo-column">
@@ -103,7 +108,8 @@ const features = [
       "code"
       "demo"
       "features"
-      "actions";
+      "actions"
+      "legal";
     grid-template-columns: minmax(0, 1fr);
     gap: 1.5rem;
     width: 100%;
@@ -263,6 +269,10 @@ const features = [
     color: var(--sl-color-white);
   }
 
+  .legal {
+    grid-area: legal;
+  }
+
   @media (min-width: 56rem) {
     .hero {
       grid-template-areas: none;
@@ -277,7 +287,13 @@ const features = [
       display: flex;
       flex-direction: column;
       gap: 1.25rem;
+      align-self: stretch;
       margin-inline-end: clamp(1rem, 3vw, 4rem);
+    }
+
+    /* Pin the legal links to the bottom of the viewport-sized column. */
+    .legal {
+      margin-top: auto;
     }
 
     .demo-column {

--- a/docs/src/components/LegalLinks.astro
+++ b/docs/src/components/LegalLinks.astro
@@ -1,0 +1,31 @@
+---
+// Legal links, shared by Footer.astro and Hero.astro.
+---
+
+<nav aria-label="Legal">
+  <a href="https://www.category.xyz/terms-of-service">Terms of Service</a>
+  <a href="https://www.category.xyz/privacy-policy">Privacy Policy</a>
+</nav>
+
+<style>
+  nav {
+    display: flex;
+    gap: 1.25rem;
+    font-size: 0.8125rem;
+    line-height: 1.6;
+  }
+
+  a {
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+
+  a:hover {
+    color: var(--sl-color-gray-1);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.16em;
+  }
+</style>


### PR DESCRIPTION
## Why

The docs site has no legal links, and Category Labs needs Terms of Service and Privacy Policy links reachable from every page. Doc pages get them through a Starlight `Footer` override, below the built-in pagination footer. The landing hides that footer to keep its viewport-fit layout, so it renders the same `LegalLinks` component itself, pinned to the bottom of the copy column so the links sit at the bottom edge on desktop rather than crowding the action buttons.

## Notes for reviewers

The override's legal block is a `<footer>` element rather than a `div` because Starlight mounts the override's output as siblings of its own `<footer>`, not inside it; the landing's existing `.sl-container > footer` hide rule then covers both, which is what prevents duplicate links on the landing. Verified in the browser at desktop and mobile widths: doc pages show the links under the pagination card, the landing shows exactly one set, and no console errors.