### PR TITLE
Show the account and network in the demo header, rename cash to DEMOCASH

### DIFF
--- a/demo/src/AccountChip.tsx
+++ b/demo/src/AccountChip.tsx
@@ -4,7 +4,6 @@ import { truncateAddress } from "./ui";
 import { useCopyButton } from "./useCopyButton";
 
 type AccountChipProps = {
-  /** The active account's address; null when signed out. */
   address: `0x${string}` | null;
 };
 

--- a/demo/src/AccountChip.tsx
+++ b/demo/src/AccountChip.tsx
@@ -5,18 +5,19 @@ import { useCopyButton } from "./useCopyButton";
 
 type AccountChipProps = {
   address: `0x${string}` | null;
+  connected: boolean;
 };
 
 /**
- * Title-row account indicator: the network's name, plus the account's
- * truncated address as a copy button. The network pill renders even when
- * signed out, so the page always says where trades settle.
+ * Title-row account indicator: the account's truncated address as a copy
+ * button, over the network's name with a dot that turns green once the
+ * network context resolves. The network line renders even when signed out,
+ * so the page always says where trades settle.
  */
-function AccountChip({ address }: AccountChipProps): ReactElement {
+function AccountChip({ address, connected }: AccountChipProps): ReactElement {
   const { copied, copy } = useCopyButton();
   return (
     <div className="account-chip">
-      <span className="chip-network">{NETWORK_NAME}</span>
       {address !== null && (
         <button
           type="button"
@@ -27,6 +28,9 @@ function AccountChip({ address }: AccountChipProps): ReactElement {
           {copied ? "Copied" : truncateAddress(address)}
         </button>
       )}
+      <span className={connected ? "chip-network connected" : "chip-network"}>
+        {NETWORK_NAME}
+      </span>
     </div>
   );
 }

--- a/demo/src/AccountChip.tsx
+++ b/demo/src/AccountChip.tsx
@@ -1,0 +1,35 @@
+import type { ReactElement } from "react";
+import { NETWORK_NAME } from "./chains/evm";
+import { truncateAddress } from "./ui";
+import { useCopyButton } from "./useCopyButton";
+
+type AccountChipProps = {
+  /** The active account's address; null when signed out. */
+  address: `0x${string}` | null;
+};
+
+/**
+ * Title-row account indicator: the network's name, plus the account's
+ * truncated address as a copy button. The network pill renders even when
+ * signed out, so the page always says where trades settle.
+ */
+function AccountChip({ address }: AccountChipProps): ReactElement {
+  const { copied, copy } = useCopyButton();
+  return (
+    <div className="account-chip">
+      <span className="chip-network">{NETWORK_NAME}</span>
+      {address !== null && (
+        <button
+          type="button"
+          className="chip-address mono"
+          title={address}
+          onClick={() => void copy(address)}
+        >
+          {copied ? "Copied" : truncateAddress(address)}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export { AccountChip };

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement, useEffect, useState } from "react";
+import { AccountChip } from "./AccountChip";
 import { type EvmContext, resolveEvmContext } from "./chains/evm";
 import { describeError } from "./connect";
 import { TradingCard } from "./TradingCard";
@@ -40,6 +41,7 @@ function retryingResolve<T>(
 function App(): ReactElement {
   const [evmContext, setEvmContext] = useState<EvmContext | null>(null);
   const [evmError, setEvmError] = useState<string | null>(null);
+  const [address, setAddress] = useState<`0x${string}` | null>(null);
 
   useEffect(
     () =>
@@ -58,8 +60,15 @@ function App(): ReactElement {
 
   return (
     <main className="app">
-      <h1>Mera Demo</h1>
-      <TradingCard evm={evmContext} evmError={evmError} />
+      <header className="app-head">
+        <h1>Mera Demo</h1>
+        <AccountChip address={address} />
+      </header>
+      <TradingCard
+        evm={evmContext}
+        evmError={evmError}
+        onAddressChange={setAddress}
+      />
     </main>
   );
 }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,10 @@
 import { type ReactElement, useEffect, useState } from "react";
 import { AccountChip } from "./AccountChip";
+import {
+  type AccountState,
+  accountAddress,
+  loadCachedAccount,
+} from "./account";
 import { type EvmContext, resolveEvmContext } from "./chains/evm";
 import { describeError } from "./connect";
 import { TradingCard } from "./TradingCard";
@@ -41,7 +46,10 @@ function retryingResolve<T>(
 function App(): ReactElement {
   const [evmContext, setEvmContext] = useState<EvmContext | null>(null);
   const [evmError, setEvmError] = useState<string | null>(null);
-  const [address, setAddress] = useState<`0x${string}` | null>(null);
+  const [account, setAccount] = useState<AccountState>(() => {
+    const cached = loadCachedAccount();
+    return cached ? { status: "locked", ...cached } : { status: "none" };
+  });
 
   useEffect(
     () =>
@@ -62,12 +70,13 @@ function App(): ReactElement {
     <main className="app">
       <header className="app-head">
         <h1>Mera Demo</h1>
-        <AccountChip address={address} />
+        <AccountChip address={accountAddress(account)} />
       </header>
       <TradingCard
         evm={evmContext}
         evmError={evmError}
-        onAddressChange={setAddress}
+        account={account}
+        onAccountChange={setAccount}
       />
     </main>
   );

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -70,7 +70,10 @@ function App(): ReactElement {
     <main className="app">
       <header className="app-head">
         <h1>Mera Demo</h1>
-        <AccountChip address={accountAddress(account)} />
+        <AccountChip
+          address={accountAddress(account)}
+          connected={evmContext !== null}
+        />
       </header>
       <TradingCard
         evm={evmContext}

--- a/demo/src/TradingCard.tsx
+++ b/demo/src/TradingCard.tsx
@@ -5,7 +5,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { clearCachedAccount, loadCachedAccount } from "./account";
+import {
+  type AccountState,
+  accountAddress,
+  clearCachedAccount,
+} from "./account";
 import { parseDecimalAmount } from "./amount";
 import { ConnectPanel } from "./ConnectPanel";
 import { type EvmContext, fundAccount } from "./chains/evm";
@@ -52,21 +56,11 @@ const CENT_WEI = 10n ** 16n;
 
 type Side = "buy" | "sell";
 
-/**
- * The account behind the trading surface. "locked" is a reloaded page: the
- * cached public identity shows the portfolio, and the first trade runs a
- * passkey ceremony to restore the signing session.
- */
-type AccountState =
-  | { status: "none" }
-  | { status: "locked"; mode: AccountMode; address: `0x${string}` }
-  | { status: "unlocked"; wallet: ConnectedWallet };
-
 type TradingCardProps = {
   evm: EvmContext | null;
   evmError: string | null;
-  /** Reports the active account's address; null when signed out. */
-  onAddressChange: (address: `0x${string}` | null) => void;
+  account: AccountState;
+  onAccountChange: (next: AccountState) => void;
 };
 
 /**
@@ -79,12 +73,9 @@ type TradingCardProps = {
 function TradingCard({
   evm,
   evmError,
-  onAddressChange,
+  account,
+  onAccountChange,
 }: TradingCardProps): ReactElement {
-  const [account, setAccount] = useState<AccountState>(() => {
-    const cached = loadCachedAccount();
-    return cached ? { status: "locked", ...cached } : { status: "none" };
-  });
   const [connectMode, setConnectMode] = useState<AccountMode>("passkey");
 
   const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
@@ -106,19 +97,11 @@ function TradingCard({
   const [revealing, setRevealing] = useState(false);
   const [backupError, setBackupError] = useState<string | null>(null);
 
-  const address =
-    account.status === "none"
-      ? null
-      : account.status === "locked"
-        ? account.address
-        : account.wallet.account.address;
-
-  // Mirrors the address into the app-level account chip.
-  useEffect(() => onAddressChange(address), [address, onAddressChange]);
+  const address = accountAddress(account);
 
   // Switches to `next` and drops everything scoped to the previous account.
   function adoptAccount(next: AccountState): void {
-    setAccount(next);
+    onAccountChange(next);
     setPortfolio(null);
     setAmount("");
     setSellAll(false);
@@ -283,7 +266,7 @@ function TradingCard({
           );
           return;
         }
-        setAccount({ status: "unlocked", wallet });
+        onAccountChange({ status: "unlocked", wallet });
       } else {
         wallet = account.wallet;
       }

--- a/demo/src/TradingCard.tsx
+++ b/demo/src/TradingCard.tsx
@@ -36,15 +36,15 @@ import {
 import { NewsTicker } from "./NewsTicker";
 import { CHART_WINDOW_SECONDS, PriceChart } from "./PriceChart";
 import { currentPasskeyWallet } from "./passkeyWallet";
-import { formatShares, formatUsd } from "./ui";
+import { CASH_SYMBOL, formatCash, formatShares } from "./ui";
 import { WalletBackup } from "./WalletBackup";
 
 const REFRESH_MS = 5_000;
 // Cash kept out of Max buys so the account can always pay a trade's network
 // fee; at the demo network's gas prices this covers hundreds of trades.
 const FEE_RESERVE_WEI = 10n ** 16n;
-// Cash below this offers the $10,000 top-up; the guard enforces the same
-// threshold, so the button cannot inflate a healthy account.
+// Cash below this offers the 10,000 DEMOCASH top-up; the guard enforces the
+// same threshold, so the button cannot inflate a healthy account.
 const LOW_CASH_WEI = 100n * UNIT;
 // One cent, the display resolution: sells that would leave less than this
 // behind sell the whole position instead.
@@ -65,6 +65,8 @@ type AccountState =
 type TradingCardProps = {
   evm: EvmContext | null;
   evmError: string | null;
+  /** Reports the active account's address; null when signed out. */
+  onAddressChange: (address: `0x${string}` | null) => void;
 };
 
 /**
@@ -74,7 +76,11 @@ type TradingCardProps = {
  * trades sign silently; a passkey prompt appears only at connect, at the
  * first trade after a reload, and when exporting the recovery phrase.
  */
-function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
+function TradingCard({
+  evm,
+  evmError,
+  onAddressChange,
+}: TradingCardProps): ReactElement {
   const [account, setAccount] = useState<AccountState>(() => {
     const cached = loadCachedAccount();
     return cached ? { status: "locked", ...cached } : { status: "none" };
@@ -106,6 +112,9 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
       : account.status === "locked"
         ? account.address
         : account.wallet.account.address;
+
+  // Mirrors the address into the app-level account chip.
+  useEffect(() => onAddressChange(address), [address, onAddressChange]);
 
   // Switches to `next` and drops everything scoped to the previous account.
   function adoptAccount(next: AccountState): void {
@@ -226,8 +235,8 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
   const estimatedShares =
     amountWei !== null ? (amountWei * UNIT) / price : null;
 
-  // Wei to a plain decimal dollar string, floored to cents.
-  function usdInput(wei: bigint): string {
+  // Wei to a plain decimal cash string, floored to cents.
+  function cashInput(wei: bigint): string {
     const cents = wei / CENT_WEI;
     return `${cents / 100n}.${(cents % 100n).toString().padStart(2, "0")}`;
   }
@@ -241,9 +250,9 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
           ? portfolio.cash - FEE_RESERVE_WEI
           : 0n
         : (positionValue ?? 0n);
-    setAmount(usdInput(wei));
+    setAmount(cashInput(wei));
     // Max on the sell side means the whole position: converting its stale
-    // dollar figure back to shares at a moved price can strand dust.
+    // cash figure back to shares at a moved price can strand dust.
     setSellAll(side === "sell");
   }
 
@@ -286,7 +295,7 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
       } else {
         let shares = (amountWei * UNIT) / price;
         // A Max sell, or a typed amount within a cent of the whole position,
-        // sells all of it, so no dust the display would round to $0.00 is
+        // sells all of it, so no dust the display would round to 0.00 is
         // left behind.
         if (
           sellAll ||
@@ -369,12 +378,12 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
             <span className="stock-symbol">{TICKER}</span>
           </div>
           <div className="stock-quote">
-            <span className="stock-price">{formatUsd(price)}</span>
+            <span className="stock-price">{formatCash(price)}</span>
             <span
               className={delta < 0n ? "stock-delta down" : "stock-delta up"}
             >
               {delta < 0n ? "" : "+"}
-              {formatUsd(delta)} · 30m
+              {formatCash(delta)} · 30m
             </span>
           </div>
         </div>
@@ -398,9 +407,9 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
           <>
             <div className="holdings">
               <div className="holding-row">
-                <span className="holding-label">Cash</span>
+                <span className="holding-label">{CASH_SYMBOL}</span>
                 <span className="holding-value">
-                  {portfolio === null ? "…" : formatUsd(portfolio.cash)}
+                  {portfolio === null ? "…" : formatCash(portfolio.cash)}
                 </span>
               </div>
               <div className="holding-row">
@@ -408,7 +417,7 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
                 <span className="holding-value">
                   {portfolio === null || positionValue === null
                     ? "…"
-                    : `${formatShares(portfolio.shares)} · ${formatUsd(positionValue)}`}
+                    : `${formatShares(portfolio.shares)} · ${formatCash(positionValue)}`}
                 </span>
               </div>
               {pnl !== null && (
@@ -420,7 +429,7 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
                     }
                   >
                     {pnl < 0n ? "" : "+"}
-                    {formatUsd(pnl)}
+                    {formatCash(pnl)}
                     {pnlPercent !== null &&
                       ` · ${pnlPercent < 0 ? "" : "+"}${pnlPercent.toFixed(2)}%`}
                   </span>
@@ -457,7 +466,7 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
               <div className="send-row">
                 <label className="field grow">
                   <span className="field-head">
-                    Amount (USD)
+                    Amount ({CASH_SYMBOL})
                     <button
                       type="button"
                       className="link small"
@@ -498,12 +507,6 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
                 </button>
               </div>
 
-              {account.status === "locked" && (
-                <p className="hint">
-                  The first trade asks for the account's passkey.
-                </p>
-              )}
-
               {estimatedShares !== null && !fill && (
                 <p className="hint">
                   ≈ {formatShares(estimatedShares)} {TICKER} at the current
@@ -517,7 +520,7 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
                     ? `Bought ${formatShares(fill.shares)} ${TICKER}${
                         fill.spent === undefined
                           ? ""
-                          : ` for ${formatUsd(fill.spent)}`
+                          : ` for ${formatCash(fill.spent)} ${CASH_SYMBOL}`
                       }`
                     : `Sold ${formatShares(fill.shares)} ${TICKER}`}
                 </p>
@@ -540,7 +543,7 @@ function TradingCard({ evm, evmError }: TradingCardProps): ReactElement {
                 onClick={() => void addFunds()}
                 disabled={funding}
               >
-                {funding ? "Adding funds…" : "Add $10,000"}
+                {funding ? "Adding funds…" : `Add 10,000 ${CASH_SYMBOL}`}
               </button>
             )}
             <button

--- a/demo/src/account.ts
+++ b/demo/src/account.ts
@@ -1,4 +1,23 @@
-import type { AccountMode } from "./connect";
+import type { AccountMode, ConnectedWallet } from "./connect";
+
+/**
+ * The account behind the trading surface. "locked" is a reloaded page: the
+ * cached public identity shows the portfolio, and the first trade runs a
+ * passkey ceremony to restore the signing session.
+ */
+type AccountState =
+  | { status: "none" }
+  | { status: "locked"; mode: AccountMode; address: `0x${string}` }
+  | { status: "unlocked"; wallet: ConnectedWallet };
+
+/** The address behind an account state; null when signed out. */
+function accountAddress(account: AccountState): `0x${string}` | null {
+  return account.status === "none"
+    ? null
+    : account.status === "locked"
+      ? account.address
+      : account.wallet.account.address;
+}
 
 /**
  * The signed-in account's public identity, cached so a reload can show its
@@ -41,5 +60,10 @@ function isCachedAccount(value: unknown): value is CachedAccount {
   );
 }
 
-export type { CachedAccount };
-export { clearCachedAccount, loadCachedAccount, saveCachedAccount };
+export type { AccountState, CachedAccount };
+export {
+  accountAddress,
+  clearCachedAccount,
+  loadCachedAccount,
+  saveCachedAccount,
+};

--- a/demo/src/chains/evm.ts
+++ b/demo/src/chains/evm.ts
@@ -13,8 +13,6 @@ const RPC_URL =
   import.meta.env.VITE_EVM_RPC_URL ??
   "https://evm-network-production.up.railway.app";
 
-// Shown in the account chip before the async context resolves, so it lives
-// outside `resolveEvmContext`.
 const NETWORK_NAME = "Demo Network";
 
 type EvmContext = {

--- a/demo/src/chains/evm.ts
+++ b/demo/src/chains/evm.ts
@@ -13,6 +13,10 @@ const RPC_URL =
   import.meta.env.VITE_EVM_RPC_URL ??
   "https://evm-network-production.up.railway.app";
 
+// Shown in the account chip before the async context resolves, so it lives
+// outside `resolveEvmContext`.
+const NETWORK_NAME = "Demo Network";
+
 type EvmContext = {
   chain: Chain;
   publicClient: PublicClient;
@@ -76,7 +80,7 @@ async function resolveEvmContext(): Promise<EvmContext> {
   ]);
   const chain = defineChain({
     id,
-    name: "Demo Network",
+    name: NETWORK_NAME,
     nativeCurrency: { name: "Demon", symbol: "DEMON", decimals: 18 },
     rpcUrls: { default: { http: [RPC_URL] } },
   });
@@ -97,4 +101,4 @@ async function fundAccount(address: Address): Promise<void> {
 }
 
 export type { EvmContext };
-export { fundAccount, resolveEvmContext };
+export { fundAccount, NETWORK_NAME, resolveEvmContext };

--- a/demo/src/market.ts
+++ b/demo/src/market.ts
@@ -85,7 +85,7 @@ function noiseLayerAt(
 /**
  * Share price at Unix `timestamp` (seconds), in native wei per whole share.
  * A slow drift, a medium swing, and a fast wiggle layer on the base price,
- * so the result stays within $40 +/- $9.10 and is always positive.
+ * so the result stays within 40 +/- 9.10 DEMOCASH and is always positive.
  */
 function priceAt(timestamp: bigint): bigint {
   const slowDrift = noiseLayerAt(timestamp, 1n, 28800n, 6n * UNIT);
@@ -99,7 +99,7 @@ function priceAt(timestamp: bigint): bigint {
 
 /** One account's market state, all in wei-scale bigints. */
 type Portfolio = {
-  /** Native balance, presented as dollars. */
+  /** Native balance, presented as DEMOCASH. */
   cash: bigint;
   /** Share balance (18 decimals). */
   shares: bigint;

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -63,6 +63,41 @@ h1 {
   letter-spacing: -0.01em;
 }
 
+/* Title row: app name on the left, account chip on the right. */
+.app-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.account-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chip-network {
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--muted);
+}
+
+.chip-address {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+}
+
 input {
   width: 100%;
   padding: 10px 12px;

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -73,28 +73,40 @@ h1 {
 
 .account-chip {
   display: flex;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
 }
 
+/* Network line under the address: the dot turns green once the network
+   context resolves. */
 .chip-network {
-  font-size: 10px;
-  font-weight: 650;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 3px 8px;
-  border-radius: 999px;
-  background: var(--surface-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 550;
   color: var(--muted);
 }
 
+.chip-network::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.chip-network.connected::before {
+  background: var(--ok);
+}
+
 .chip-address {
-  padding: 3px 8px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface);
+  padding: 0;
+  border: none;
+  background: none;
   color: var(--text);
-  font-size: 12px;
+  font-size: 13px;
   cursor: pointer;
 }
 

--- a/demo/src/ui.ts
+++ b/demo/src/ui.ts
@@ -1,13 +1,21 @@
+/** The demo's currency name; every balance is play money. */
+const CASH_SYMBOL = "DEMOCASH";
+
 /**
- * Formats a wei-scale amount as dollars, e.g. "$10,000.00". Fractions of a
- * cent are floored away; negative amounts keep their sign.
+ * Formats a wei-scale cash amount as a bare number, e.g. "10,000.00".
+ * Fractions of a cent are floored away; negative amounts keep their sign.
  */
-function formatUsd(wei: bigint): string {
+function formatCash(wei: bigint): string {
   const cents = Number(wei / 10n ** 16n);
   return (cents / 100).toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   });
+}
+
+/** Shortens a 0x address for display, e.g. "0x1234…cdef". */
+function truncateAddress(address: string): string {
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
 /** Formats an 18-decimal share amount with at most four fraction digits. */
@@ -16,4 +24,4 @@ function formatShares(shares: bigint): string {
   return scaled.toLocaleString("en-US", { maximumFractionDigits: 4 });
 }
 
-export { formatShares, formatUsd };
+export { CASH_SYMBOL, formatCash, formatShares, truncateAddress };


### PR DESCRIPTION
## Why

Feedback on the demo: it feels almost too smooth — nothing on screen ties the buys and sells to an actual network, so they read as an in-browser simulation (Porto's demo surfaces the account for exactly this reason). And the fiat labels mix "Cash", "USD", and "$", implying real dollars.

The title row now carries a chip with the network name and, once an account exists, its truncated address as a copy button — the network pill also shows signed out, so the message lands before connecting. The currency is renamed to DEMOCASH, carried in labels ("DEMOCASH" holdings row, "Amount (DEMOCASH)") with bare numbers as values; `Intl` cannot emit a made-up currency code, so the formatter switches from `currency: "USD"` to plain fixed two-fraction formatting with identical flooring. The account state machine stays whole inside `TradingCard` — it reports the derived address up through a callback rather than lifting five mutation sites into `App`.

Also drops the "The first trade asks for the account's passkey." hint; the ceremony itself still runs on the first trade after a reload.

## Notes for reviewers

Manually verified against the live demo network: signed-out, cached-account reload (chip shows the address immediately, guard funds the account, balances render), sign-out, and mobile width. The copy button's "Copied" flip couldn't be exercised headless (clipboard needs document focus) — it reuses the same `useCopyButton` hook as the recovery-phrase screen. Screenshots below.

## Screenshots

| Signed out | Cached account |
| --- | --- |
| ![signed-out.png](https://github.com/user-attachments/assets/4829f2d5-b754-4fea-b408-38ccd6a6f217) | ![connected.png](https://github.com/user-attachments/assets/ba7e1232-4e63-4968-8f06-3949a5526f32) |

