### PR TITLE
Sample the chart history on the absolute 5-second grid

### DIFF
--- a/demo/src/PriceChart.tsx
+++ b/demo/src/PriceChart.tsx
@@ -27,7 +27,12 @@ type PriceChartProps = {
 function PriceChart({ livePrice, now }: PriceChartProps): ReactElement {
   const { line, area, openY, up, high, low } = useMemo(() => {
     const points: { t: number; price: bigint }[] = [];
-    for (let t = now - CHART_WINDOW_SECONDS; t < now; t += SAMPLE_SECONDS) {
+    // Sample on the absolute SAMPLE_SECONDS grid, not relative to `now`:
+    // anchoring to `now` would shift every sample time each tick, re-rolling
+    // the price noise across the whole line and making it visibly shimmer.
+    const start =
+      Math.ceil((now - CHART_WINDOW_SECONDS) / SAMPLE_SECONDS) * SAMPLE_SECONDS;
+    for (let t = start; t < now; t += SAMPLE_SECONDS) {
       points.push({ t, price: priceAt(BigInt(t)) });
     }
     points.push({ t: now, price: livePrice });


### PR DESCRIPTION
## Why

The demo chart's line visibly shimmered, and its fuzz swelled thicker and thinner on a five-second cycle. The history sample grid was anchored to `now`, which advances one second per tick while the sample step is five seconds, so every tick shifted all 360 history sample times and re-sampled the price mirror's noise across the whole line. And because the mirror's fast jitter layer has the same 5-second period as the sample step, the sampled jitter's variance cycled with `now mod 5` (full variance at bucket boundaries, half at mid-bucket), which is what made the line's apparent thickness breathe.

Snapping the grid to absolute `SAMPLE_SECONDS` boundaries gives every history point a stable timestamp, so a tick just slides the window and appends the live point.

## Notes for reviewers

Verified in the running demo by sampling the rendered path across consecutive ticks: before, the jaggedness metric (mean |Δy| between neighboring points) cycled 3.0 → 3.6 → 4.5 → 3.6 → 3.0 with period 5 and every history point's value changed each tick; after, history points are bit-identical between ticks and the metric is flat.

The line keeps a constant level of wiggle after the fix. That is real signal — the mirrored price moves ±0.15 every 5 seconds, which spans about one pixel of chart width — not a rendering artifact.

## Before and after

One frame per second, six seconds each. Before, the line re-rolls every tick and its fuzz swells and shrinks on a five-second cycle; after, only the newest point moves.

**Before**

![before.gif](https://github.com/user-attachments/assets/0b5dd9ed-e59b-46b5-b1ed-4630d27834c3)

**After**

![after.gif](https://github.com/user-attachments/assets/14101032-f81b-4e70-870d-7d9da59432bf)
