### PR TITLE
Remove redundant input copies from the signing sessions

### DIFF
--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -72,7 +72,7 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits. S
 
 Signing needs no passkey ceremony and shows no prompt; the session signs as often as the app asks until it is locked.
 
-The message is copied before signing; the original is not modified.
+The message is read before `signMessage` returns and is not modified; mutating the buffer after the call cannot change what was signed.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -81,7 +81,7 @@ Sessions bound with `const` or `let` are unaffected; disposal runs only where a 
 
 Signing needs no passkey ceremony and shows no prompt; the session signs as often as the app asks until it is locked.
 
-The digest is copied before signing; the original is not modified.
+The digest is read before `signDigest` returns and is not modified; mutating the buffer after the call cannot change what was signed.
 
 The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA, the signature algorithm secp256k1 uses, but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
 

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -1,5 +1,4 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
-import { copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
 import { createSigningKey } from "./session.js";
 import type {
@@ -49,10 +48,7 @@ function createEd25519SigningSession({
   return {
     publicKey,
     async signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
-      // Give the signer a standalone message snapshot even if a future backend
-      // reads its input asynchronously.
-      const messageCopy = copyBytes(message);
-      return new Uint8Array(ed25519.sign(messageCopy, key.use()));
+      return new Uint8Array(ed25519.sign(message, key.use()));
     },
     lock,
     [Symbol.dispose]: lock,

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -1,5 +1,4 @@
 import { secp256k1 } from "@noble/curves/secp256k1.js";
-import { copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
 import { createSigningKey } from "./session.js";
 import type {
@@ -78,11 +77,8 @@ function createSecp256k1SigningSession({
         throw new MeraError("INPUT_INVALID", "Digest must be 32 bytes");
       }
 
-      // Give the signer a standalone digest snapshot even if a future backend
-      // reads its input asynchronously.
-      const digest = copyBytes(digest32);
       const unlockedKey = key.use();
-      const signature = secp256k1.sign(digest, unlockedKey, {
+      const signature = secp256k1.sign(digest32, unlockedKey, {
         format: "recovered",
         lowS: true,
         prehash: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,7 +114,7 @@ type Secp256k1SigningSession = {
   /**
    * Signs a 32-byte digest without prehashing it.
    *
-   * @param digest32 - Exactly 32 bytes to sign; copied before use, the original buffer is not modified.
+   * @param digest32 - Exactly 32 bytes to sign; read before the call returns and not modified, so later mutation cannot change what is signed.
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
    * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
@@ -139,7 +139,7 @@ type Ed25519SigningSession = {
   /**
    * Signs an arbitrary-length message with Ed25519.
    *
-   * @param message - Message bytes to sign; copied before use, the original buffer is not modified. Hashing happens inside Ed25519 itself.
+   * @param message - Message bytes to sign; read before the call returns and not modified, so later mutation cannot change what is signed. Hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */

--- a/test/ed25519-session.test.ts
+++ b/test/ed25519-session.test.ts
@@ -58,7 +58,7 @@ test("a using declaration locks the session when its scope exits", async () => {
   ).rejects.toMatchObject({ code: "SESSION_LOCKED" });
 });
 
-test("signs the message snapshot taken at call time, not later mutations", async () => {
+test("signs the message bytes read at call time, not later mutations", async () => {
   const session = createEd25519SigningSession({
     consumePrivateKey: new Uint8Array(RFC_SECRET),
   });
@@ -66,7 +66,7 @@ test("signs the message snapshot taken at call time, not later mutations", async
   const original = new TextEncoder().encode("mera demo");
   const message = new Uint8Array(original); // caller-owned buffer we will mutate
   const pending = session.signMessage(message); // not awaited
-  message.fill(0); // mutate before noble reads the buffer (it reads after its await)
+  message.fill(0);
   const signature = await pending;
 
   // The signature is over the bytes at call time, not the later mutation.

--- a/test/secp256k1-session.test.ts
+++ b/test/secp256k1-session.test.ts
@@ -72,7 +72,7 @@ test("a using declaration locks the session when its scope exits", async () => {
   ).rejects.toMatchObject({ code: "SESSION_LOCKED" });
 });
 
-test("signs the digest snapshot taken at call time, not later mutations", async () => {
+test("signs the digest bytes read at call time, not later mutations", async () => {
   const session = createSecp256k1SigningSession({
     consumePrivateKey: new Uint8Array(PRIVATE_KEY_ONE),
   });
@@ -80,7 +80,7 @@ test("signs the digest snapshot taken at call time, not later mutations", async 
   const original = new Uint8Array(32).fill(1);
   const digest = new Uint8Array(original); // caller-owned buffer we will mutate
   const pending = session.signDigest(digest); // not awaited
-  digest.fill(2); // mutate before noble reads the buffer (it reads after its await)
+  digest.fill(2);
   const signature = await pending;
 
   // The signature is over the bytes at call time, not the later mutation.


### PR DESCRIPTION
## Why

`signDigest` and `signMessage` copied their input before signing to guard against a backend that reads the buffer after an `await`. Neither method contains an `await` and noble's `sign` reads its input synchronously, so the copy guarded a window that does not exist; the session tests' comments claiming noble "reads the buffer after its await" were wrong for the same reason. The copies also kept the documented contract ("copied before use") tied to a mechanism rather than to observable behavior.

The caller-facing guarantee is unchanged: the input is read before the call returns and is never modified, so mutating the buffer after the call cannot change what was signed. The JSDoc, reference pages, and the two call-time-bytes session tests now state and pin that contract directly. If a future backend (for example WebCrypto Ed25519) defers reading past an `await`, reintroducing the copy is what preserves the contract, invisibly behind the existing `Promise` return type.

## Notes for reviewers

This came out of a broader discussion about the library's zeroing and copy-before-await discipline. The entry-point copies in the vault and session-construction flows are untouched — those guard real `await` windows (WebAuthn ceremonies) and remain load-bearing.

Validated with `npm run check`, `npm test` (79 passed), `npm run check:pack`, and a docs build.