### PR TITLE
Restructure Getting started: install first, linear overview diagram

### DIFF
--- a/docs/src/assets/diagrams/getting-started-overview.svg
+++ b/docs/src/assets/diagrams/getting-started-overview.svg
@@ -9,9 +9,8 @@
   <title>
     The pipeline from a passkey to a signature. A sign-in ceremony returns 32
     secret bytes, the same bytes on every sign-in. The app derives a private key
-    from them. A signing session holds the key and produces signatures with no
-    further prompts. mera owns every step except the derivation, which belongs
-    to the app.
+    from them. A signing session holds the key and produces signatures. mera
+    owns every step except the derivation, which belongs to the app.
   </title>
   <defs>
     <marker
@@ -58,6 +57,5 @@
   <path class="d-edge" d="M620 44 H640" marker-end="url(#gs-arrow)" />
 
   <rect class="d-node" x="644" y="16" width="136" height="56" rx="8" />
-  <text x="712" y="40" text-anchor="middle">Signature</text>
-  <text x="712" y="59" text-anchor="middle" class="d-sub">no prompts</text>
+  <text x="712" y="49" text-anchor="middle">Signature</text>
 </svg>

--- a/docs/src/assets/diagrams/getting-started-overview.svg
+++ b/docs/src/assets/diagrams/getting-started-overview.svg
@@ -1,19 +1,17 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 680 612"
-  width="680"
-  height="612"
+  viewBox="0 0 784 104"
+  width="784"
+  height="104"
   role="img"
   class="mera-diagram"
 >
   <title>
-    The path from signing in with a passkey to a signature, split by ownership.
-    In mera, the user signs in with the passkey, which stays in the
-    authenticator, and receives 32 secret bytes, the same bytes on every
-    sign-in. The app turns those bytes into an account key. Back in mera, a
-    signing session signs with the key held in memory. A dashed return path
-    shows signing back in: the same passkey returns the same 32 bytes. No secret
-    is stored anywhere.
+    The pipeline from a passkey to a signature. A sign-in ceremony returns 32
+    secret bytes, the same bytes on every sign-in. The app derives a private key
+    from them. A signing session holds the key and produces signatures with no
+    further prompts. mera owns every step except the derivation, which belongs
+    to the app.
   </title>
   <defs>
     <marker
@@ -29,70 +27,37 @@
     </marker>
   </defs>
 
-  <!-- mera: the ceremony and its output -->
-  <rect class="d-zone" x="100" y="24" width="360" height="190" rx="10" />
-  <text x="114" y="46" class="d-sub">mera</text>
+  <rect class="d-node" x="4" y="16" width="136" height="56" rx="8" />
+  <text x="72" y="40" text-anchor="middle">Sign in</text>
+  <text x="72" y="59" text-anchor="middle" class="d-sub">passkey ceremony</text>
+  <text x="72" y="92" text-anchor="middle" class="d-sub">mera</text>
 
-  <rect class="d-node" x="130" y="56" width="300" height="56" rx="8" />
-  <text x="280" y="80" text-anchor="middle">Sign in with the passkey</text>
-  <text x="280" y="99" text-anchor="middle" class="d-sub">
-    the passkey stays in the authenticator
+  <path class="d-edge" d="M140 44 H160" marker-end="url(#gs-arrow)" />
+
+  <rect class="d-secret" x="164" y="16" width="136" height="56" rx="8" />
+  <text x="232" y="40" text-anchor="middle">32 secret bytes</text>
+  <text x="232" y="59" text-anchor="middle" class="d-sub">
+    same every sign-in
   </text>
+  <text x="232" y="92" text-anchor="middle" class="d-sub">mera</text>
 
-  <path class="d-edge" d="M280 112 V144" marker-end="url(#gs-arrow)" />
+  <path class="d-edge" d="M300 44 H320" marker-end="url(#gs-arrow)" />
 
-  <rect class="d-secret" x="130" y="148" width="300" height="56" rx="8" />
-  <text x="280" y="172" text-anchor="middle">32 secret bytes</text>
-  <text x="280" y="191" text-anchor="middle" class="d-sub">
-    the same bytes on every sign-in
-  </text>
+  <rect class="d-secret" x="324" y="16" width="136" height="56" rx="8" />
+  <text x="392" y="40" text-anchor="middle">Derive a key</text>
+  <text x="392" y="59" text-anchor="middle" class="d-sub">any scheme</text>
+  <text x="392" y="92" text-anchor="middle" class="d-sub">the app</text>
 
-  <!-- the app: derivation -->
-  <path class="d-edge" d="M280 204 V270" marker-end="url(#gs-arrow)" />
+  <path class="d-edge" d="M460 44 H480" marker-end="url(#gs-arrow)" />
 
-  <rect class="d-zone" x="100" y="242" width="360" height="112" rx="10" />
-  <text x="114" y="264" class="d-sub">the app</text>
+  <rect class="d-secret" x="484" y="16" width="136" height="56" rx="8" />
+  <text x="552" y="40" text-anchor="middle">Signing session</text>
+  <text x="552" y="59" text-anchor="middle" class="d-sub">holds the key</text>
+  <text x="552" y="92" text-anchor="middle" class="d-sub">mera</text>
 
-  <rect class="d-secret" x="130" y="274" width="300" height="56" rx="8" />
-  <text x="280" y="298" text-anchor="middle">Derive an account</text>
-  <text x="280" y="317" text-anchor="middle" class="d-sub">
-    the bytes become a private key
-  </text>
+  <path class="d-edge" d="M620 44 H640" marker-end="url(#gs-arrow)" />
 
-  <path class="d-edge" d="M280 330 V410" marker-end="url(#gs-arrow)" />
-  <text x="292" y="368" class="d-sub">
-    the session takes ownership of the key
-  </text>
-
-  <!-- mera: the signing session -->
-  <rect class="d-zone" x="100" y="382" width="360" height="190" rx="10" />
-  <text x="114" y="404" class="d-sub">mera</text>
-
-  <rect class="d-secret" x="130" y="414" width="300" height="56" rx="8" />
-  <text x="280" y="438" text-anchor="middle">Signing session</text>
-  <text x="280" y="457" text-anchor="middle" class="d-sub">
-    signs with the key held in memory
-  </text>
-
-  <path class="d-edge" d="M280 470 V502" marker-end="url(#gs-arrow)" />
-
-  <rect class="d-node" x="130" y="506" width="300" height="56" rx="8" />
-  <text x="280" y="530" text-anchor="middle">Signature</text>
-  <text x="280" y="549" text-anchor="middle" class="d-sub">
-    as many as the app asks
-  </text>
-
-  <!-- signing back in reruns the ceremony -->
-  <path
-    class="d-edge d-dashed"
-    d="M430 534 H560 V84 H438"
-    marker-end="url(#gs-arrow)"
-  />
-  <text x="572" y="290" class="d-sub">sign back in:</text>
-  <text x="572" y="310" class="d-sub">same passkey,</text>
-  <text x="572" y="330" class="d-sub">same 32 bytes</text>
-
-  <text x="280" y="600" text-anchor="middle" class="d-note">
-    No secret is stored anywhere.
-  </text>
+  <rect class="d-node" x="644" y="16" width="136" height="56" rx="8" />
+  <text x="712" y="40" text-anchor="middle">Signature</text>
+  <text x="712" y="59" text-anchor="middle" class="d-sub">no prompts</text>
 </svg>

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -5,30 +5,12 @@ description: Install the library, derive an account, and make a first signature.
 
 import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
+A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, and the app decides what those bytes become. A [signing session](/concepts/signing-sessions/) holds one private key derived from them and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory; the [security model](/concepts/security-model/) states what that trusts.
+
 Prerequisites:
 
-- A browser with [WebAuthn](https://www.w3.org/TR/webauthn-3/) (the browser standard for signing in with key pairs instead of passwords; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/) covers the background), in a secure context: HTTPS, or `localhost` during development.
-- A passkey authenticator that supports the WebAuthn PRF extension. [Authenticator support](/authenticator-support/) lists the combinations known to work; 1Password and iCloud Keychain are good first choices.
-
-<GettingStartedOverview />
-
-## How mera works
-
-mera separates passkey access, account policy, and signing. A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one WebAuthn call with user verification. The pseudorandom function (PRF) extension makes that ceremony return 32 secret bytes.
-
-The app decides what those bytes become. A signing session then holds one private key until it is locked.
-
-The PRF output and every key derived from it are ordinary values in the page's JavaScript memory. The passkey's own private key never leaves the authenticator; the derived account keys never enter it. mera signs in the page with software keys; the [security model](/concepts/security-model/) states what the library protects and what stays with the app.
-
-The application owns:
-
-- account derivation and paths;
-- credential metadata and [vault](/concepts/secret-vaults/) storage;
-- export and recovery formats;
-- signing-session lifetime;
-- transaction construction, transport, or chain interaction.
-
-Keeping these decisions in the app lets the same primitives support different chains and product flows.
+- A secure context: HTTPS, or `localhost` during development.
+- An authenticator that supports the PRF extension. [Authenticator support](/authenticator-support/) lists the combinations known to work; 1Password and iCloud Keychain are good first choices.
 
 ## Install
 
@@ -44,7 +26,7 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a discoverable passkey and evaluates its PRF in one call. The salt is a 32-byte input acting as a namespace: the passkey returns 32 bytes stable for that passkey and salt ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/)).
+`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call. The salt is a 32-byte input that acts as a namespace. For one passkey and salt, the returned 32 bytes are always the same.
 
 ```ts
 import { createPasskeyWithPrfOutput } from "@category-labs/mera";
@@ -57,13 +39,13 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 });
 ```
 
-The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts), a second WebAuthn call that uses the new passkey, to evaluate PRF.
+The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF. An assertion is a second WebAuthn call, one that uses the new passkey.
 
 mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID; [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 
-The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), which encodes entropy as a phrase of common words, and [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), which derives numbered keys from one seed, a byte string computed from the phrase, so the account can be imported into wallet apps that follow those standards.
+The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), which encodes entropy as a phrase of common words. [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) then derives numbered keys from the [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation) computed from that phrase, so a wallet app that follows both standards can import the account.
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -78,7 +60,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`m/44'/60'/0'/0/0` is a [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) derivation path naming one key in the BIP-32 tree; this one selects the first Ethereum account, the key MetaMask derives first from an imported phrase.
+`m/44'/60'/0'/0/0` is a [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) derivation path, the name of one key in the BIP-32 tree. This path selects the first Ethereum account, the key MetaMask derives first from an imported phrase.
 
 ## Sign
 
@@ -94,13 +76,13 @@ const session = createSecp256k1SigningSession({
 
 const address = getEvmAddress(session.publicKey);
 
-const digest = new Uint8Array(32); // stand-in: a real app signs a transaction or message hash
+const digest = new Uint8Array(32); // the 32-byte hash of the transaction or message to sign
 const signature = await session.signDigest(digest);
 
 session.lock();
 ```
 
-The session copies the key, [zeroes](/concepts/security-model/#what-the-library-handles) the buffer it was given, and signs without further passkey prompts until `lock()` is called. Locking zeroes the session's copy too; after that, signing throws.
+The session copies the key and [zeroes](/concepts/security-model/#what-the-library-handles) the buffer it was given, then signs without further passkey prompts. `lock()` zeroes the session's copy; a locked session throws on signing.
 
 ## Sign back in
 
@@ -116,10 +98,17 @@ const { prfOutput } = await getPasskeyPrfOutput({
 
 Without `credential`, the browser offers any discoverable passkey it holds for the relying party; apps with returning users pin the stored credential ID instead.
 
+## From passkey to signature
+
+<GettingStartedOverview />
+
+Each sign-in repeats this pipeline: the same passkey and salt return the same 32 bytes, and no secret is stored anywhere.
+
 ## Where next
 
 - [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): the background behind the terms this page glosses.
 - [Create passkey accounts](/recipes/create-passkey-accounts/): numbered accounts, credential pinning, Solana keys.
+- [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): from sign-in to a sent transaction.
 - [Passkey accounts](/concepts/passkey-accounts/): why the same passkey reproduces the same accounts, and what losing it means.
 - [Secret vaults](/concepts/secret-vaults/): encrypting a secret that already exists behind the passkey.
 - [API reference](/reference/): every function used on this page.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -5,7 +5,7 @@ description: Install the library, derive an account, and make a first signature.
 
 import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
-A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one private key derived from them and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory; the [security model](/concepts/security-model/) states what that trusts.
+A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory; the [security model](/concepts/security-model/) states what that trusts.
 
 Prerequisites:
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -5,7 +5,7 @@ description: Install the library, derive an account, and make a first signature.
 
 import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
-A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, and the app decides what those bytes become. A [signing session](/concepts/signing-sessions/) holds one private key derived from them and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory; the [security model](/concepts/security-model/) states what that trusts.
+A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one private key derived from them and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory; the [security model](/concepts/security-model/) states what that trusts.
 
 Prerequisites:
 


### PR DESCRIPTION
External reviewer feedback: the install command and quickstart only appear after scrolling past prerequisites, a figure, and a "How mera works" section, and the figure itself misleads (mera appears as two disconnected regions, and the return arrow from the signature toward sign-in reads as the signature being required to sign back in).

This PR reorders the page so `npm install` sits on the first screen: a four-sentence lead carries the definitions the walkthrough needs, prerequisites shrink to two bullets, and the rest of the cut overview (the app-ownership list, the memory/trust statement) already lives on the concept pages the page links. The figure is redrawn as a single left-to-right pipeline with per-stage ownership labels and no return arrow, moved below the walkthrough as a recap; repeatability is now the caption sentence instead of an arrow.

This is the first of five stacked PRs addressing the docs feedback (phrasing density, concepts scope, security-model tone, example comments, and zeroing emphasis follow).

## Screenshots

First screen:

![gs-top.png](https://github.com/user-attachments/assets/ca39c524-0026-46c0-b949-ecee58f509f5)

Redrawn diagram in place:

![gs-diagram.png](https://github.com/user-attachments/assets/2e649452-c2b5-4a96-8023-7248796ebf2e)

