### PR TITLE
Lead the security model with the trust statements

### DIFF
--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -11,7 +11,7 @@ When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deter
 
 ## No stored state
 
-There is no stored secret; all state lives in the passkey. Once the passkey has synced to a new device, sign-in there is the same ceremony and produces the same accounts. During use, the PRF output and the keys derived from it are values in the page's memory, readable by any script on the page ([security model](/concepts/security-model/#what-a-compromised-runtime-sees)).
+There is no stored secret; all state lives in the passkey. Once the passkey has synced to a new device, sign-in there is the same ceremony and produces the same accounts. During use, the PRF output and the keys derived from it are values in the page's memory, readable by any script on the page ([security model](/concepts/security-model/#the-page-is-trusted)).
 
 ## Losing the passkey
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -11,7 +11,7 @@ When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deter
 
 ## No stored state
 
-There is no stored secret; all state lives in the passkey. Once the passkey has synced to a new device, sign-in there is the same ceremony and produces the same accounts. During use, the PRF output and the keys derived from it are values in the page's memory, readable by any script on the page ([security model](/concepts/security-model/#the-page-is-trusted)).
+There is no stored secret; all state lives in the passkey. Once the passkey has synced to a new device, sign-in there is the same ceremony and produces the same accounts. During use, the PRF output and the keys derived from it are values in the page's memory, readable by any script on the page ([security model](/concepts/security-model/)).
 
 ## Losing the passkey
 
@@ -27,4 +27,4 @@ Passkey accounts are rooted in the passkey itself, so an account that predates t
 - [Create passkey accounts](/recipes/create-passkey-accounts/): the pattern in code, with numbered accounts and credential pinning.
 - [Secret vaults](/concepts/secret-vaults/): the advanced pattern for secrets that exist on their own.
 - [getDeterministicPrfSaltV1](/reference/get-deterministic-prf-salt-v1/): the fixed salt behind the stability.
-- [Security model](/concepts/security-model/#rpid-binding): what a domain migration breaks.
+- [Security model](/concepts/security-model/): what a domain migration breaks.

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -13,7 +13,7 @@ A secret vault holds one secret (a recovery phrase, a private key, any bytes), e
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher (one key both encrypts and decrypts) that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey's PRF, the extension that makes a passkey return deterministic secret bytes ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains it), against a fresh random salt, the PRF's 32-byte input, for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher (one key both encrypts and decrypts) that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey's PRF, the extension that makes a passkey return deterministic secret bytes ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains it), against a fresh random salt, the PRF's 32-byte input, for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -12,11 +12,7 @@ mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompt
 - Losing the passkey without a prior export loses the accounts derived from it; [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The secret-vault workflow functions generate a fresh random 32-byte salt per secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves the fresh salt to the caller.
-- Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, encrypted, or derived.
-- The library zeroes the copies it owns: a session's key copy on `lock()` or on construction failure, and the vault functions' transient copies even when they fail. Zeroing shortens how long a secret stays readable; it cannot promise no other copy exists, and any script on the page can read the secret while it lives.
-- [WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges and [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonces are generated internally, so a caller cannot reuse a nonce. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
-- A revealed recovery phrase is a JavaScript string, and strings cannot be zeroed in place. The app can only drop references, keep the lifetime short, and never log it.
-- Runtime dependencies are `@noble/*` and `@scure/*` only; build and test tooling, and the unpublished demo app, never ship to library consumers.
+- Dependencies are kept to a minimum: the only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.
 
 <TrustBoundary />
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -5,49 +5,20 @@ description: What mera protects, what it cannot, and the risks left to the app.
 
 import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
-mera runs in the page and trusts the page: any script in the page's JavaScript context can read the PRF output, read every key derived from it, and request signatures from an unlocked session. The passkey's own private key never leaves the authenticator. Its PRF output, the secret bytes returned through the [PRF extension](/concepts/passkeys-and-prf/), does leave it, and every derived key is an ordinary value in page memory while in use. The guarantees match a wallet app holding an imported seed phrase in the page.
+mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/). All of it runs in the page, with software keys; the guarantees match a wallet app holding an imported seed phrase in the page.
 
-Losing the passkey without a prior export loses the accounts derived from it; [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
-
-The library's scope is narrow: it runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/).
-
-## The page is trusted
-
-The trust boundary, the set of code trusted with key material, is the page itself. An injected script, a malicious dependency, and a browser extension with page access all run inside it; nothing separates them from the app.
-
-Code on the page can observe [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) during app-owned derivation or import, and it can sign with an active session until `session.lock()` is called. The app bounds the exposure: locking sessions when idle and keeping derivation windows short shrink the time a secret exists to be read.
+- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session until `session.lock()`. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary; locking sessions when idle and keeping derivation windows short shorten the exposure.
+- The passkey's own private key never leaves the authenticator. The PRF output does leave it, and every derived key is an ordinary value in page memory while in use.
+- Losing the passkey without a prior export loses the accounts derived from it; [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
+- A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
+- Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The secret-vault workflow functions generate a fresh random 32-byte salt per secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves the fresh salt to the caller.
+- Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, encrypted, or derived.
+- The library zeroes the copies it owns: a session's key copy on `lock()` or on construction failure, and the vault functions' transient copies even when they fail. Zeroing shortens how long a secret stays readable; it cannot promise no other copy exists, and any script on the page can read the secret while it lives.
+- [WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges and [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonces are generated internally, so a caller cannot reuse a nonce. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
+- A revealed recovery phrase is a JavaScript string, and strings cannot be zeroed in place. The app can only drop references, keep the lifetime short, and never log it.
+- Runtime dependencies are `@noble/*` and `@scure/*` only; build and test tooling, and the unpublished demo app, never ship to library consumers.
 
 <TrustBoundary />
-
-## rpId binding
-
-PRF output is a function of the credential, the relying party ID, and the salt. A passkey can be used only under the rpId it was created for, so after a domain migration the app cannot run ceremonies under the old one. That breaks both patterns: passkey accounts can no longer be reproduced, and secret vaults can no longer be decrypted.
-
-Treat the rpId as a long-lived choice. Before any planned migration, accounts need an export path.
-
-## One output, one purpose
-
-If one PRF output is reused for unrelated purposes, exposing it compromises them all. Use a different salt per purpose, or split one output with a purpose-labeled [key-derivation function](/concepts/entropy-keys-and-accounts/#deterministic-derivation) (KDF).
-
-A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and to anyone who can rewrite stored vault JSON their stored [ciphertexts](/concepts/secret-vaults/#how-a-vault-works) become interchangeable. The secret-vault workflow functions generate a fresh random 32-byte salt for each secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves supplying a fresh salt per secret to the caller.
-
-## Copies, zeroing, and nonces
-
-Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, encrypted, or derived.
-
-The library zeroes the copies it owns. A signing session zeroes its private-key copy on `lock()`, or on construction failure before the error is rethrown. The secret-vault functions zero the transient secret and PRF-output copies they own before they finish, even when they fail; [createSecretVault](/reference/create-secret-vault/) documents the per-function semantics.
-
-[WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges and [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonces are generated internally. A nonce is a value that must never repeat under one encryption key; the library generates 12 fresh bytes per encryption, so a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
-
-None of this defends against the page itself. Zeroing shortens how long a secret stays readable in memory; JavaScript cannot promise that no other copy exists, and any script on the page can read the secret while it lives.
-
-## Strings cannot be zeroed
-
-A revealed recovery phrase is a JavaScript string, and strings cannot be zeroed in place. The app can only drop references and keep the lifetime short: render the phrase as late as possible, discard it as soon as possible, and never log it.
-
-## Dependency scope
-
-Runtime dependencies are `@noble/*` and `@scure/*` only. Build and test tooling, and the unpublished demo app, never ship to library consumers.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -5,25 +5,19 @@ description: What mera protects, what it cannot, and the risks left to the app.
 
 import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
-mera derives accounts with software keys. The passkey's own private key never leaves the authenticator; the PRF output, the secret bytes a passkey returns through its [PRF extension](/concepts/passkeys-and-prf/), does leave it, and every key derived from that output lives in the page's JavaScript memory while in use. The guarantees match a wallet app holding an imported seed phrase in the page.
+mera runs in the page and trusts the page: any script in the page's JavaScript context can read the PRF output, read every key derived from it, and request signatures from an unlocked session. The passkey's own private key never leaves the authenticator. Its PRF output, the secret bytes returned through the [PRF extension](/concepts/passkeys-and-prf/), does leave it, and every derived key is an ordinary value in page memory while in use. The guarantees match a wallet app holding an imported seed phrase in the page.
+
+Losing the passkey without a prior export loses the accounts derived from it; [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
 
 The library's scope is narrow: it runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/).
 
-## What a compromised runtime sees
+## The page is trusted
 
-A compromised JavaScript runtime, whether an injected script, a malicious dependency, or an extension with page access, can observe [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) during app-owned derivation or import. It can also sign with an active session until `session.lock()` is called.
+The trust boundary, the set of code trusted with key material, is the page itself. An injected script, a malicious dependency, and a browser extension with page access all run inside it; nothing separates them from the app.
 
-The mitigations are app-level: lock sessions when idle, keep derivation windows short, and treat everything that can run script on the page as inside the trust boundary, the set of code trusted with key material. Anything that runs on the page can read what the library reads.
+Code on the page can observe [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) during app-owned derivation or import, and it can sign with an active session until `session.lock()` is called. The app bounds the exposure: locking sessions when idle and keeping derivation windows short shrink the time a secret exists to be read.
 
 <TrustBoundary />
-
-## What the library handles
-
-Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, encrypted, or derived.
-
-The library zeroes the copies it owns. A signing session zeroes its private-key copy on `lock()`, or on construction failure before the error is rethrown. [createSecretVault](/reference/create-secret-vault/) zeroes its internal secret and PRF-output copies, and the secret-vault workflow functions zero the transient copies they own before they finish, even when they fail. Zeroing shortens how long a secret stays readable in memory; JavaScript cannot promise that no other copy exists, so it is a mitigation, not an erasure guarantee.
-
-[WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges are generated internally. So are [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonces: a nonce is a value that must never repeat under one encryption key, so the library generates 12 fresh bytes per encryption and a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
 
 ## rpId binding
 
@@ -33,13 +27,23 @@ Treat the rpId as a long-lived choice. Before any planned migration, accounts ne
 
 ## One output, one purpose
 
-If one PRF output is reused for unrelated purposes, exposing it compromises them all. Use a different salt per purpose, or split one output with a purpose-labeled key-derivation function (KDF), a deterministic function that turns one secret into separate purpose-specific keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)).
+If one PRF output is reused for unrelated purposes, exposing it compromises them all. Use a different salt per purpose, or split one output with a purpose-labeled [key-derivation function](/concepts/entropy-keys-and-accounts/#deterministic-derivation) (KDF).
 
-A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and their pairs of nonce and ciphertext (the encrypted bytes) become interchangeable to anyone who can rewrite stored vault JSON. The secret-vault workflow functions generate a fresh random 32-byte salt for each secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves supplying a fresh salt per secret to the caller.
+A vault is bound to its PRF output only, never to the credential ID or salt. Secrets encrypted using one reused output share an encryption key, and to anyone who can rewrite stored vault JSON their stored [ciphertexts](/concepts/secret-vaults/#how-a-vault-works) become interchangeable. The secret-vault workflow functions generate a fresh random 32-byte salt for each secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves supplying a fresh salt per secret to the caller.
+
+## Copies, zeroing, and nonces
+
+Input buffers are copied before any async work starts, so mutating a buffer after a call cannot change what gets signed, encrypted, or derived.
+
+The library zeroes the copies it owns. A signing session zeroes its private-key copy on `lock()`, or on construction failure before the error is rethrown. The secret-vault functions zero the transient secret and PRF-output copies they own before they finish, even when they fail; [createSecretVault](/reference/create-secret-vault/) documents the per-function semantics.
+
+[WebAuthn](https://www.w3.org/TR/webauthn-3/) challenges and [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonces are generated internally. A nonce is a value that must never repeat under one encryption key; the library generates 12 fresh bytes per encryption, so a caller cannot reuse one. Every ceremony requires user verification, and the requirement is [not configurable](/concepts/passkeys-and-prf/#user-verification).
+
+None of this defends against the page itself. Zeroing shortens how long a secret stays readable in memory; JavaScript cannot promise that no other copy exists, and any script on the page can read the secret while it lives.
 
 ## Strings cannot be zeroed
 
-A revealed recovery phrase is a JavaScript string, and strings cannot be zeroed in place. The app can only drop references and keep the lifetime short. Treat a revealed phrase as high-risk UI state: render it late, discard it early, never log it.
+A revealed recovery phrase is a JavaScript string, and strings cannot be zeroed in place. The app can only drop references and keep the lifetime short: render the phrase as late as possible, discard it as soon as possible, and never log it.
 
 ## Dependency scope
 
@@ -48,4 +52,5 @@ Runtime dependencies are `@noble/*` and `@scure/*` only. Build and test tooling,
 ## See also
 
 - [Passkeys and the PRF extension](/concepts/passkeys-and-prf/)
+- [Signing sessions](/concepts/signing-sessions/): what an unlocked session exposes and when to lock it.
 - [Errors](/reference/errors/): every failure the library signals, by code.

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -17,7 +17,7 @@ Because a session never contacts an authenticator, signing never prompts: the on
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking [zeroes](/concepts/security-model/#copies-zeroing-and-nonces) the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking [zeroes](/concepts/security-model/) the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
@@ -25,7 +25,7 @@ Sessions also support `using` declarations: disposal calls `lock()` when the sco
 
 ## The open window
 
-Between construction and lock, a compromised runtime can request signatures without reading the key. The [security model](/concepts/security-model/#the-page-is-trusted) covers the runtime trust boundary in full.
+Between construction and lock, a compromised runtime can request signatures without reading the key. The [security model](/concepts/security-model/) covers the runtime trust boundary in full.
 
 ## How long to keep a session
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -17,7 +17,7 @@ Because a session never contacts an authenticator, signing never prompts: the on
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking [zeroes](/concepts/security-model/) the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -17,7 +17,7 @@ Because a session never contacts an authenticator, signing never prompts: the on
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking [zeroes](/concepts/security-model/#what-the-library-handles) the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking [zeroes](/concepts/security-model/#copies-zeroing-and-nonces) the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
@@ -25,7 +25,7 @@ Sessions also support `using` declarations: disposal calls `lock()` when the sco
 
 ## The open window
 
-Between construction and lock, a compromised runtime can request signatures without reading the key. The [security model](/concepts/security-model/#what-a-compromised-runtime-sees) covers the runtime trust boundary in full.
+Between construction and lock, a compromised runtime can request signatures without reading the key. The [security model](/concepts/security-model/#the-page-is-trusted) covers the runtime trust boundary in full.
 
 ## How long to keep a session
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -82,7 +82,7 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The digest is the 32-byte hash of the transaction or message to sign; this walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/security-model/#what-the-library-handles) the session's copy; a locked session throws on signing.
+The digest is the 32-byte hash of the transaction or message to sign; this walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/security-model/#copies-zeroing-and-nonces) the session's copy; a locked session throws on signing.
 
 ## Sign back in
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -82,7 +82,7 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The digest is the 32-byte hash of the transaction or message to sign; this walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/security-model/) the session's copy; a locked session throws on signing.
+The digest is the 32-byte hash of the transaction or message to sign; this walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) the session's copy; a locked session throws on signing.
 
 ## Sign back in
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -82,7 +82,7 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The digest is the 32-byte hash of the transaction or message to sign; this walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/security-model/#copies-zeroing-and-nonces) the session's copy; a locked session throws on signing.
+The digest is the 32-byte hash of the transaction or message to sign; this walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/security-model/) the session's copy; a locked session throws on signing.
 
 ## Sign back in
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -70,7 +70,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a seed for the session
 
-Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, [zero](/concepts/security-model/#copies-zeroing-and-nonces) the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, [zero](/concepts/security-model/) the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -80,7 +80,7 @@ const seed = mnemonicToSeedSync(entropyToMnemonic(prfOutput, wordlist));
 prfOutput.fill(0);
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)); the phrase stays in memory until garbage collection.
+`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/)); the phrase stays in memory until garbage collection.
 
 ## Derive numbered accounts
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -70,7 +70,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a seed for the session
 
-Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, [zero](/concepts/security-model/) the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, zero the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -80,7 +80,7 @@ const seed = mnemonicToSeedSync(entropyToMnemonic(prfOutput, wordlist));
 prfOutput.fill(0);
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/)); the phrase stays in memory until garbage collection.
+`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed; the phrase stays in memory until garbage collection.
 
 ## Derive numbered accounts
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -70,7 +70,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a seed for the session
 
-Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, [zero](/concepts/security-model/#what-the-library-handles) the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, [zero](/concepts/security-model/#copies-zeroing-and-nonces) the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -80,8 +80,6 @@ const seed = mnemonicToSeedSync(entropyToMnemonic(prfOutput, wordlist));
 prfOutput.fill(0);
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed; the phrase stays in memory until garbage collection.
-
 ## Derive numbered accounts
 
 EVM accounts follow [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) over the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -35,7 +35,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)); the buffers are [zeroed](/concepts/security-model/#copies-zeroing-and-nonces) as soon as each one has served its purpose.
+`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/)); the buffers are [zeroed](/concepts/security-model/) as soon as each one has served its purpose.
 
 ## Create the viem account
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -35,7 +35,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)); the buffers are [zeroed](/concepts/security-model/#what-the-library-handles) as soon as each one has served its purpose.
+`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)); the buffers are [zeroed](/concepts/security-model/#copies-zeroing-and-nonces) as soon as each one has served its purpose.
 
 ## Create the viem account
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -35,8 +35,6 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed; the buffers are zeroed as soon as each one has served its purpose.
-
 ## Create the viem account
 
 `toViemAccount` lives in the `@category-labs/mera/viem` entry point, which requires the optional `viem` peer dependency; the root entry point does not use viem.

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -35,7 +35,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed ([security model](/concepts/security-model/)); the buffers are [zeroed](/concepts/security-model/) as soon as each one has served its purpose.
+`entropyToMnemonic` creates a phrase string on the way to the seed, and strings cannot be zeroed; the buffers are zeroed as soon as each one has served its purpose.
 
 ## Create the viem account
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -79,5 +79,4 @@ The phrase is a standard BIP-39 mnemonic, so key derivation from here is the sam
 ## Pitfalls
 
 - **A second secret needs its own ceremony and vault.** [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/) generates the fresh salt and stores it in the new vault.
-- **The phrase is a string** while it transits the encryption and unlock code, and strings cannot be zeroed. Keep the lifetime short and never log it.
 - **The vault JSON is the only ciphertext copy.** Losing the storage loses the account unless the person still holds the phrase elsewhere.

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit [zeroing](/concepts/security-model/#copies-zeroing-and-nonces). It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit [zeroing](/concepts/security-model/). It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 
@@ -24,7 +24,7 @@ if (!validateMnemonic(phrase, wordlist)) {
 
 ## Create and persist the vault
 
-`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension), the PRF input that namespaces its output, creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault. A separate salt for each vault avoids shared encryption keys and interchangeable nonce/ciphertext pairs ([one output, one purpose](/concepts/security-model/#one-output-one-purpose)).
+`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension), the PRF input that namespaces its output, creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault. A separate salt for each vault avoids shared encryption keys and interchangeable nonce/ciphertext pairs ([one output, one purpose](/concepts/security-model/)).
 
 ```ts
 import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
@@ -79,5 +79,5 @@ The phrase is a standard BIP-39 mnemonic, so key derivation from here is the sam
 ## Pitfalls
 
 - **A second secret needs its own ceremony and vault.** [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/) generates the fresh salt and stores it in the new vault.
-- **The phrase is a string** while it transits the encryption and unlock code, and strings cannot be zeroed ([security model](/concepts/security-model/#strings-cannot-be-zeroed)). Keep the lifetime short and never log it.
+- **The phrase is a string** while it transits the encryption and unlock code, and strings cannot be zeroed ([security model](/concepts/security-model/)). Keep the lifetime short and never log it.
 - **The vault JSON is the only ciphertext copy.** Losing the storage loses the account unless the person still holds the phrase elsewhere.

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit [zeroing](/concepts/security-model/#what-the-library-handles). It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit [zeroing](/concepts/security-model/#copies-zeroing-and-nonces). It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit [zeroing](/concepts/security-model/). It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 
@@ -79,5 +79,5 @@ The phrase is a standard BIP-39 mnemonic, so key derivation from here is the sam
 ## Pitfalls
 
 - **A second secret needs its own ceremony and vault.** [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/) generates the fresh salt and stores it in the new vault.
-- **The phrase is a string** while it transits the encryption and unlock code, and strings cannot be zeroed ([security model](/concepts/security-model/)). Keep the lifetime short and never log it.
+- **The phrase is a string** while it transits the encryption and unlock code, and strings cannot be zeroed. Keep the lifetime short and never log it.
 - **The vault JSON is the only ciphertext copy.** Losing the storage loses the account unless the person still holds the phrase elsewhere.

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -84,4 +84,4 @@ A fresh random 32-byte PRF salt is generated for each call and stored in the vau
 
 - [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create the first vault together with a passkey.
 - [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/): perform the assertion and decrypt a stored vault.
-- [One output, one purpose](/concepts/security-model/#one-output-one-purpose): why each vault receives a fresh salt.
+- [One output, one purpose](/concepts/security-model/): why each vault receives a fresh salt.

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -80,4 +80,4 @@ Input byte buffers are copied before async cryptographic work starts; mutating t
 - [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): create a vault with an existing passkey.
 - [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/) and [decryptSecretVault](/reference/decrypt-secret-vault/): the [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) and decryption that recover the secret.
 - [Use an existing secret](/recipes/use-an-existing-secret/): the full flow with zeroing.
-- [Security model](/concepts/security-model/#one-output-one-purpose): why PRF outputs must not be reused across purposes.
+- [Security model](/concepts/security-model/): why PRF outputs must not be reused across purposes.


### PR DESCRIPTION
External reviewer feedback: the security model read as if it were convincing the reader the library is secure, and the plain consequences took work to extract. Follow-up review feedback on the first draft: the section prose was itself verbose.

The page is now a two-sentence lead (scope plus the imported-seed-phrase equivalence) and one flat list, one fact per bullet: what any script on the page can do, what leaves the authenticator, what losing the passkey means, the rpId and salt-reuse sharp edges, copy and zeroing behavior with what zeroing cannot do, internal challenge/nonce generation, the string limitation, and the dependency scope. The ciphertext-interchangeability and KDF-splitting details moved out to the pages that own them (the createSecretVault reference and the entropy page). The content reflects the current custody contract: sessions copy the key and zero only their own snapshot.

The list removes every section heading, so the seven inbound section links now point at the page root.

Stacked series 3/5; based on main.