### PR TITLE
Compress the blockchain basics; move the foundations page last

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -130,12 +130,12 @@ export default defineConfig({
         {
           label: "Concepts",
           items: [
-            "concepts/entropy-keys-and-accounts",
             "concepts/passkeys-and-prf",
             "concepts/security-model",
             "concepts/passkey-accounts",
             "concepts/signing-sessions",
             "concepts/secret-vaults",
+            "concepts/entropy-keys-and-accounts",
           ],
         },
         {

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -16,7 +16,7 @@ Entropy is randomness an attacker cannot predict, and 32 random bytes carry 256 
 
 A private key is a 256-bit secret number. A one-way function computes the public key from it, so the public key is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
 
-A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key. Control of an account is the ability to sign, and there is no reset path: losing the private key loses the account, and anyone who obtains it controls the account.
+A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key.
 
 The docs use two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -10,25 +10,11 @@ The rest of the docs assume the blockchain background this page teaches: how 32 
 
 <DerivationPipeline />
 
-## Randomness and entropy
+## Keys, signatures, and accounts
 
-Entropy is randomness an attacker cannot predict, measured in bits. A fair coin flip carries one bit; 32 random bytes carry 256, and searching 2^256 values is infeasible for any computer.
+Entropy is randomness an attacker cannot predict; 32 random bytes carry 256 bits of it, and searching 2^256 values is infeasible for any computer. A private key is a 256-bit secret number, and a one-way function computes the public key from it, so the public key is safe to share. A signature, computed from a message and a private key and verified with the public key alone, proves the key's holder approved that exact message.
 
-Everything below starts from one such value and proceeds deterministically. The root secret is the only unpredictable input, so it is the only thing to protect; everything derived from it can be recomputed instead of stored.
-
-## Private keys, public keys, and signatures
-
-A private key is a 256-bit secret number. A one-way function computes the public key from it: cheap to run forward, infeasible to reverse, so the public key is safe to share.
-
-A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message, without revealing the key.
-
-The docs use two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
-
-## Accounts and addresses
-
-A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key, safe to publish.
-
-Control of an account is the ability to sign: a transaction is valid when its signature verifies against the account's public key. There is no reset path. Losing the private key loses the account, and anyone who obtains it controls the account.
+A blockchain account is the state a chain tracks for one key pair, a balance and a transaction history, at an address that is a short encoding of the public key. Control of an account is the ability to sign, and there is no reset path: losing the private key loses the account, and anyone who obtains it controls the account. The docs use two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
 
 ## Deterministic derivation
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -12,9 +12,13 @@ The rest of the docs assume the blockchain background this page teaches: how 32 
 
 ## Keys, signatures, and accounts
 
-Entropy is randomness an attacker cannot predict; 32 random bytes carry 256 bits of it, and searching 2^256 values is infeasible for any computer. A private key is a 256-bit secret number, and a one-way function computes the public key from it, so the public key is safe to share. A signature, computed from a message and a private key and verified with the public key alone, proves the key's holder approved that exact message.
+Entropy is randomness an attacker cannot predict, and 32 random bytes carry 256 bits of it. Searching 2^256 values is infeasible for any computer.
 
-A blockchain account is the state a chain tracks for one key pair, a balance and a transaction history, at an address that is a short encoding of the public key. Control of an account is the ability to sign, and there is no reset path: losing the private key loses the account, and anyone who obtains it controls the account. The docs use two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
+A private key is a 256-bit secret number. A one-way function computes the public key from it, so the public key is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
+
+A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key. Control of an account is the ability to sign, and there is no reset path: losing the private key loses the account, and anyone who obtains it controls the account.
+
+The docs use two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
 
 ## Deterministic derivation
 


### PR DESCRIPTION
External reviewer feedback: many Concepts items are not useful to the likely reader, singling out the blockchain-account background, and the section reads as the front door to the docs.

docs/AGENTS.md deliberately defines the audience as an engineer who may know none of blockchain and designates this page as the foundations page other glosses link into, so the background is compressed rather than cut: the three basics sections (randomness, keys and signatures, accounts and addresses) merge into one two-paragraph section, while the derivation, key-material, and seed-phrase content that other pages depend on is untouched and the #deterministic-derivation anchor keeps its name (the only anchor on this page targeted from elsewhere). The page also moves from first to last in the Concepts sidebar so mera-specific concepts lead.

Stacked on #209 (4/5).