### PR TITLE
Sitewide prose pass: one definition per sentence

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -67,6 +67,7 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 ## Sentence mechanics
 
 - No em dashes. Use a comma, a period, a colon, or parentheses.
+- A sentence defines at most one term. A second definition moves to its own sentence or becomes a link to the owning page.
 - No "not X, but Y" constructions, including "isn't just X" and "It's not about X". Rewrite the thought.
 - Complete sentences, plainly shaped. Fragments for punch ("Same three, same 32 bytes.") and aphorisms ("whoever holds it holds ciphertext") get rewritten as plain statements.
 - The library takes plain verbs: mera requires, returns, throws. "mera asks", "hands over", "stops there" are narration.
@@ -81,6 +82,7 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 - Implementation details live only on the page that owns them: error codes and library internals on the reference, demo internals (derivation schemes, storage, UI) in the recipes that adapt its code. Every other page links to the owning page instead of restating the detail, so a demo or library change touches one page.
 - Examples import only the public API plus explicitly declared app-side dependencies.
 - Examples define every identifier they use. Values the app supplies enter through a placeholder with realistic shape and provenance: `crypto.getRandomValues(new Uint8Array(32))` for key material, `new TextEncoder().encode(...)` for secret text, a literal for addresses and rpIds. Never use an all-zero buffer where the library validates the value; an all-zero secp256k1 key throws.
+- A placeholder value carries its meaning in a descriptive variable name (`recipient`, `privateKey`), not in a comment. A comment that restates the variable name is deleted; provenance worth stating moves to prose.
 - Security-sensitive behavior is stated plainly on the page where the risk is acted on: key material lifetimes, zeroing, nonce handling, prompt counts, and what the library cannot protect against.
 - Support claims are date-stamped. The authenticator matrix lives on the authenticator-support page and is maintained there only.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -68,6 +68,7 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 
 - No em dashes. Use a comma, a period, a colon, or parentheses.
 - A sentence defines at most one term. A second definition moves to its own sentence or becomes a link to the owning page.
+- Use a period between independent statements. Reserve the semicolon for two clauses that form one thought, such as a contrast pair ("derivation is app-owned; mera provides the ceremonies").
 - No "not X, but Y" constructions, including "isn't just X" and "It's not about X". Rewrite the thought.
 - Complete sentences, plainly shaped. Fragments for punch ("Same three, same 32 bytes.") and aphorisms ("whoever holds it holds ciphertext") get rewritten as plain statements.
 - The library takes plain verbs: mera requires, returns, throws. "mera asks", "hands over", "stops there" are narration.

--- a/docs/src/content/docs/authenticator-support.md
+++ b/docs/src/content/docs/authenticator-support.md
@@ -29,7 +29,7 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 ## The desktop Chrome complication
 
-On desktop Chrome, only passkeys saved to Google Password Manager carry PRF; the local profile authenticator lacks [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) primitive behind PRF.
+On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local profile authenticator lacks [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) primitive behind PRF.
 
 Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts). Either way the passkey exists but returns no PRF output, so mera cannot use it. [createPasskey](/reference/create-passkey/) fails only after the creation ceremony has completed, so the unusable passkey stays in the authenticator's passkey list.
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -22,7 +22,7 @@ The docs use two signature schemes, named for their curves: secp256k1 on Ethereu
 
 ## Deterministic derivation
 
-A key-derivation function (KDF) turns one secret into others: the output looks random, and the same input always produces the same output. A key that can be recomputed never needs to be stored.
+A key-derivation function (KDF) turns one secret into others: the output looks random, and the same input always produces the same output. Because a KDF recomputes its outputs on demand, derived keys need no storage.
 
 A seed is the byte string a key tree starts from. BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, a scheme called hierarchical deterministic (HD) derivation, and a derivation path such as `m/44'/60'/0'/0/0` names one key in the tree. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account. (BIP is a Bitcoin Improvement Proposal; several became standards beyond Bitcoin.)
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -7,7 +7,7 @@ A passkey account is a blockchain account whose keys derive from a passkey's PRF
 
 ## One salt, one stable output
 
-When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony. The app passes that output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing; [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
+When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony. The app passes that output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## No stored state
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -3,11 +3,11 @@ title: Passkey accounts
 description: Accounts derived from a passkey's PRF output, with no stored secret.
 ---
 
-A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). No secret is stored anywhere; each ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, recomputes the same accounts. This is the default way to use mera.
+A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). No secret is stored anywhere: each ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, recomputes the same accounts. This is the default way to use mera.
 
 ## One salt, one stable output
 
-When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony. The app passes that output to a derivation scheme of its choosing, the deterministic computation that turns root entropy into per-account keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)); [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
+When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony. The app passes that output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing; [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## No stored state
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -15,7 +15,7 @@ A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/T
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
 
-The requirement is not configurable. PRF is built on the [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) primitive of [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the protocol browsers use to talk to authenticators. An authenticator keeps two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a setting could neither change the output nor skip the check; mera does not offer one.
+The requirement is not configurable. PRF is built on the [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) primitive of [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the protocol browsers use to talk to authenticators. An authenticator keeps two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a setting could neither change the output nor skip the check. mera does not offer one.
 
 ## The PRF extension
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -5,7 +5,7 @@ description: What a passkey is, what the PRF extension adds, and why its output 
 
 import PrfFunction from "../../../assets/diagrams/prf-function.svg";
 
-A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords; a credential is one such key pair, created at a website's request by an authenticator (a phone, a password manager, a hardware key). The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
+A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords. A credential is one such key pair, created at a website's request by an authenticator: a phone, a password manager, or a hardware key. The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
 **Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, ceremonies under the new domain cannot reach the old credential, so everything derived from it becomes unreachable there. The [security model](/concepts/security-model/) covers migrations in depth.
 
@@ -15,7 +15,7 @@ A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/T
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
 
-The requirement is not configurable. Authenticators built on [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the CTAP primitive behind PRF ([CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) is the protocol browsers use to talk to authenticators), keep two PRFs per credential, one for user-verified requests and one for the rest; WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it. A setting could neither change the output nor skip the check, so mera does not offer one.
+The requirement is not configurable. PRF is built on the [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) primitive of [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the protocol browsers use to talk to authenticators. An authenticator keeps two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a setting could neither change the output nor skip the check; mera does not offer one.
 
 ## The PRF extension
 
@@ -29,11 +29,11 @@ PRF output is determined by the credential, relying party ID, and salt. Those in
 
 The output is suitable as the root secret for accounts. It is stable wherever the passkey syncs, it appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony. The output, unlike the credential's private key, leaves the authenticator: it returns to the page, and every key derived from it lives in the page's memory ([security model](/concepts/security-model/)).
 
-Passed to a key-derivation scheme, the deterministic computation that turns one root secret into per-account keys ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)), the output produces a hierarchy of accounts; used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
+Passed to a [key-derivation scheme](/concepts/entropy-keys-and-accounts/), the output produces a hierarchy of accounts. Used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
 
 ## Ceremonies and prompts
 
-A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential or runs an assertion, the call that uses an existing credential: the authenticator proves possession of the key pair and can evaluate the PRF. mera runs three kinds:
+A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential or runs an assertion, the call that uses an existing credential. In both, the authenticator proves possession of the key pair and can evaluate the PRF. mera runs three kinds:
 
 - [createPasskey](/reference/create-passkey/) makes the credential, and can evaluate the PRF in the same ceremony when the authenticator supports it.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -9,11 +9,11 @@ sidebar:
 
 import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
 
-A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey; apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
+A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey. Apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions evaluate the passkey's [PRF](/concepts/passkeys-and-prf/) against a fresh random 32-byte salt and store that salt in the vault; the resulting PRF output produces the key material that decrypts the secret. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions evaluate the passkey's [PRF](/concepts/passkeys-and-prf/) against a fresh random 32-byte salt and store that salt in the vault. The resulting PRF output produces the key material that decrypts the secret. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 
@@ -21,13 +21,13 @@ The vault itself is ordinary JSON and can live in `localStorage`, on a backend, 
 
 ## The secret exists on its own
 
-The secret exists independently of the passkey: an account that predates it can be imported by encrypting its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext, the encrypted bytes; decrypting it requires the passkey ceremony.
+The secret exists independently of the passkey: an account that predates it can be imported by encrypting its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext, the encrypted bytes. Decrypting it requires the passkey ceremony.
 
 ## When to use a vault
 
 Use a vault when the key material must come from outside the passkey. The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs: losing the passkey still loses access through mera, but any surviving copy of the secret restores the account, while a passkey account is recoverable only through an export taken beforehand.
 
-The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns; losing every copy of both the vault and the secret loses the account. That design burden is why vaults are the advanced option: when no secret exists yet, passkey accounts avoid the storage problem entirely.
+The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account. That design burden is why vaults are the advanced option: when no secret exists yet, passkey accounts avoid the storage problem entirely.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -13,7 +13,7 @@ A secret vault holds one secret (a recovery phrase, a private key, any bytes), e
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher (one key both encrypts and decrypts) that authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. The secret-vault functions evaluate the passkey's PRF, the extension that makes a passkey return deterministic secret bytes ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains it), against a fresh random salt, the PRF's 32-byte input, for each secret and store that salt in the vault; the resulting PRF output produces the key material that decrypts it. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions evaluate the passkey's [PRF](/concepts/passkeys-and-prf/) against a fresh random 32-byte salt and store that salt in the vault; the resulting PRF output produces the key material that decrypts the secret. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -5,11 +5,11 @@ description: What mera protects, what it cannot, and the risks left to the app.
 
 import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
-mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/). All of it runs in the page, with software keys; the guarantees match a wallet app holding an imported seed phrase in the page.
+mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/). All of it runs in the page, with software keys. The guarantees match a wallet app holding an imported seed phrase in the page.
 
-- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session until `session.lock()`. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary; locking sessions when idle and keeping derivation windows short shorten the exposure.
+- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session until `session.lock()`. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Locking sessions when idle and keeping derivation windows short shorten the exposure.
 - The passkey's own private key never leaves the authenticator. The PRF output does leave it, and every derived key is an ordinary value in page memory while in use.
-- Losing the passkey without a prior export loses the accounts derived from it; [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
+- Losing the passkey without a prior export loses the accounts derived from it. [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The secret-vault workflow functions generate a fresh random 32-byte salt per secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves the fresh salt to the caller.
 - Dependencies are kept to a minimum: the only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,19 +5,19 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing. A ceremony is one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, and PRF output is the 32 secret bytes the passkey returns deterministically; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains both.
+A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing. A ceremony is one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt. PRF output is the 32 secret bytes the passkey returns deterministically; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains both.
 
-Two constructors exist, one per signature scheme ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces both): [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests (a digest is the fixed-length hash of the content to sign) and [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
+Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests; a digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 
 ## Independent of passkeys
 
-A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design; [passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
+A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design. [Passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
 
 Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the ceremony that produced the entropy, and it covers any number of signatures.
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent: a locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, there is no unlock, and new signatures require a new session; an unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
@@ -33,7 +33,7 @@ Unless the app kept the key somewhere else, fresh key material means another pas
 
 Frequent signing justifies a held session. A high-frequency trading app that ran a fresh ceremony per order would prompt constantly, so it keeps one session for the active burst of work and locks it when the burst ends.
 
-Apps that sign occasionally are better served by holding no session at all: derive the public key, identify the account by its address, and zero the private key right away; the next signature starts with a fresh ceremony. Key material then exists only in the moments that use it.
+Apps that sign occasionally are better served by holding no session at all: derive the public key, identify the account by its address, and zero the private key right away; the next signature starts with a fresh ceremony.
 
 ## Why sessions exist
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,19 +5,19 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing. A ceremony is one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt. PRF output is the 32 secret bytes the passkey returns deterministically; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains both.
+A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing. A ceremony is one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt. PRF output is the 32 secret bytes the passkey returns deterministically. [Passkeys and PRF](/concepts/passkeys-and-prf/) explains both.
 
-Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests; a digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
+Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. A digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 
 ## Independent of passkeys
 
-A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere; the session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design. [Passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
+A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere. The session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design. [Passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
 
 Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the ceremony that produced the entropy, and it covers any number of signatures.
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, there is no unlock, and new signatures require a new session; an unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
@@ -33,7 +33,7 @@ Unless the app kept the key somewhere else, fresh key material means another pas
 
 Frequent signing justifies a held session. A high-frequency trading app that ran a fresh ceremony per order would prompt constantly, so it keeps one session for the active burst of work and locks it when the burst ends.
 
-Apps that sign occasionally are better served by holding no session at all: derive the public key, identify the account by its address, and zero the private key right away; the next signature starts with a fresh ceremony.
+Apps that sign occasionally are better served by holding no session at all: derive the public key, identify the account by its address, and zero the private key right away. The next signature then starts with a fresh ceremony.
 
 ## Why sessions exist
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -5,12 +5,12 @@ description: Install the library, derive an account, and make a first signature.
 
 import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
-A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory; the [security model](/concepts/security-model/) states what that trusts.
+A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory. The [security model](/concepts/security-model/) states what that trusts.
 
 Prerequisites:
 
 - A secure context: HTTPS, or `localhost` during development.
-- An authenticator that supports the PRF extension. [Authenticator support](/authenticator-support/) lists the combinations known to work; 1Password and iCloud Keychain are good first choices.
+- An authenticator that supports the PRF extension. [Authenticator support](/authenticator-support/) lists the combinations known to work. 1Password and iCloud Keychain are good first choices.
 
 ## Install
 
@@ -18,7 +18,7 @@ Prerequisites:
 npm install @category-labs/mera
 ```
 
-This walkthrough derives accounts with `@scure/bip32` and `@scure/bip39`; any derivation scheme works.
+This walkthrough derives accounts with `@scure/bip32` and `@scure/bip39`. Any derivation scheme works.
 
 ```sh
 npm install @scure/bip32 @scure/bip39
@@ -41,7 +41,7 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 
 The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF. An assertion is a second WebAuthn call, one that uses the new passkey.
 
-mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID; [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
+mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 
@@ -82,7 +82,7 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The digest is the 32-byte hash of the transaction or message to sign; this walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) the session's copy; a locked session throws on signing.
+The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) the session's copy. A locked session throws on signing.
 
 ## Sign back in
 
@@ -96,7 +96,7 @@ const { prfOutput } = await getPasskeyPrfOutput({
 });
 ```
 
-Without `credential`, the browser offers any discoverable passkey it holds for the relying party; apps with returning users pin the stored credential ID instead.
+Without `credential`, the browser offers any discoverable passkey it holds for the relying party. Apps with returning users pin the stored credential ID instead.
 
 ## From passkey to signature
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -5,7 +5,7 @@ description: Create numbered EVM and Solana accounts from one passkey ceremony, 
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a PRF-capable authenticator ([authenticator support](/authenticator-support/)). PRF is the [WebAuthn](https://www.w3.org/TR/webauthn-3/) extension that makes a passkey return deterministic secret bytes; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism.
+This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)).
 
 Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
@@ -101,7 +101,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32, on `m/44'/501'/{index}'/0'`, the path Phantom and Solflare use (501 is Solana's coin type). A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
+Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32. The path is `m/44'/501'/{index}'/0'`, the one Phantom and Solflare use; 501 is Solana's registered coin type. A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {
@@ -153,5 +153,4 @@ Sessions zero their own key copies on `lock()`. The seed is the app's buffer, so
 ## Pitfalls
 
 - **Do not change the derivation after launch.** Changing the mnemonic mapping or either path changes every account address.
-- **Zero the PRF output as soon as the seed exists**, and the seed on lock. Between those two moments a compromised runtime can read them ([security model](/concepts/security-model/)).
 - **Accounts reproduce only under the same [rpId](/concepts/passkeys-and-prf/)**, the domain the passkey is bound to. A domain migration leaves them unreachable, with no error until someone tries to sign in; give accounts an export path first. The phrase to show is `entropyToMnemonic` over the PRF output from a fresh sign-in ceremony, the same mapping the seed step uses ([Passkey accounts](/concepts/passkey-accounts/)).

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -46,7 +46,7 @@ localStorage.setItem(
 
 `transports` is optional and only a hint: the browser uses it to reach the authenticator directly (a platform prompt for a platform passkey, a QR flow for a phone) instead of offering every option. Sign-in works the same without it.
 
-A fresh device has no record; sign-in falls back to a discoverable ceremony, and the synced passkey still produces the same accounts.
+A fresh device has no record, so sign-in falls back to a discoverable ceremony and the synced passkey still produces the same accounts.
 
 ## Sign in
 
@@ -153,4 +153,4 @@ Sessions zero their own key copies on `lock()`. The seed is the app's buffer, so
 ## Pitfalls
 
 - **Do not change the derivation after launch.** Changing the mnemonic mapping or either path changes every account address.
-- **Accounts reproduce only under the same [rpId](/concepts/passkeys-and-prf/)**, the domain the passkey is bound to. A domain migration leaves them unreachable, with no error until someone tries to sign in; give accounts an export path first. The phrase to show is `entropyToMnemonic` over the PRF output from a fresh sign-in ceremony, the same mapping the seed step uses ([Passkey accounts](/concepts/passkey-accounts/)).
+- **Accounts reproduce only under the same [rpId](/concepts/passkeys-and-prf/)**, the domain the passkey is bound to. A domain migration leaves them unreachable, with no error until someone tries to sign in. Give accounts an export path first. The phrase to show is `entropyToMnemonic` over the PRF output from a fresh sign-in ceremony, the same mapping the seed step uses ([Passkey accounts](/concepts/passkey-accounts/)).

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -17,7 +17,7 @@ const rpId = location.hostname;
 const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 ```
 
-The call runs one ceremony with one user-verification prompt, the only prompt in this recipe. Without `credential`, the browser offers every discoverable passkey for the domain; [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID.
+The call runs one ceremony with one user-verification prompt, the only prompt in this recipe. Without `credential`, the browser offers every discoverable passkey for the domain. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID.
 
 ## Derive the key
 
@@ -37,7 +37,7 @@ if (node.privateKey === null) throw new Error("derivation produced no key");
 
 ## Create the viem account
 
-`toViemAccount` lives in the `@category-labs/mera/viem` entry point, which requires the optional `viem` peer dependency; the root entry point does not use viem.
+`toViemAccount` lives in the `@category-labs/mera/viem` entry point, which requires the optional `viem` peer dependency. The root entry point does not use viem.
 
 ```ts
 import { createSecp256k1SigningSession } from "@category-labs/mera";
@@ -51,7 +51,7 @@ seed.fill(0);
 const account = toViemAccount(session);
 ```
 
-The returned account signs transactions, messages, and typed data through `session.signDigest`; the [toViemAccount reference](/reference/to-viem-account/) documents each method.
+The returned account signs transactions, messages, and typed data through `session.signDigest`. The [toViemAccount reference](/reference/to-viem-account/) documents each method.
 
 ## Send the transaction
 
@@ -74,15 +74,15 @@ const hash = await client.sendTransaction({
 session.lock();
 ```
 
-`sepolia` is Ethereum's Sepolia test network. `http()` with no URL uses the chain's default public RPC endpoint; RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL. Signing shows no passkey prompt: the one prompt happened at sign-in, and the session covers every signature until it is locked.
+`sepolia` is Ethereum's Sepolia test network. `http()` with no URL uses the chain's default public RPC endpoint. RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL. Signing shows no passkey prompt: the one prompt happened at sign-in, and the session covers every signature until it is locked.
 
-`sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query; viem's `waitForTransactionReceipt` on a public client covers it.
+`sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query. viem's `waitForTransactionReceipt` on a public client covers it.
 
 ## Pitfalls
 
-- **The derivation must match the app's other sign-in paths.** This recipe repeats the mapping and path from [Create passkey accounts](/recipes/create-passkey-accounts/); a different mapping or path reaches a different address.
+- **The derivation must match the app's other sign-in paths.** This recipe repeats the mapping and path from [Create passkey accounts](/recipes/create-passkey-accounts/). A different mapping or path reaches a different address.
 - **A locked session rejects every viem signing method** with [`SESSION_LOCKED`](/reference/errors/#session_locked), and the account has no key of its own. Keep the session for the active burst of work, lock it when the burst ends, and build a new session from a fresh ceremony for the next one ([Signing sessions](/concepts/signing-sessions/)).
-- **Concurrent transactions can be assigned the same nonce**, the per-account counter that orders transactions, and the chain accepts only one of them. viem's nonce manager assigns nonces in sequence; pass it through [toViemAccount](/reference/to-viem-account/) options.
+- **Concurrent transactions can be assigned the same nonce**, the per-account counter that orders transactions, and the chain accepts only one of them. viem's nonce manager assigns nonces in sequence. Pass it through [toViemAccount](/reference/to-viem-account/) options.
 
 ## See also
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -3,9 +3,9 @@ title: Send a transaction with viem
 description: Sign in with a passkey, derive the first EVM account, and send a transaction through viem.
 ---
 
-This recipe turns a passkey sign-in into a sent transaction. Prerequisites: `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed, a PRF-capable authenticator ([authenticator support](/authenticator-support/)), an existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit), and test funds on the sending address. PRF is the [WebAuthn](https://www.w3.org/TR/webauthn-3/) extension that makes a passkey return deterministic secret bytes; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism.
+This recipe turns a passkey sign-in into a sent transaction. Prerequisites: `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed, a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)), an existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit), and test funds on the sending address.
 
-[viem](https://viem.sh) is a TypeScript client library for EVM chains (chains that run the Ethereum Virtual Machine); [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session. Derivation and client setup are app-owned; mera provides the ceremony, the session, and the adapter.
+[viem](https://viem.sh) is a TypeScript client library for EVM chains (chains that run the Ethereum Virtual Machine). [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session. Derivation and client setup are app-owned; mera provides the ceremony, the session, and the adapter.
 
 ## Sign in
 
@@ -74,7 +74,7 @@ const hash = await client.sendTransaction({
 session.lock();
 ```
 
-`sepolia` is Ethereum's Sepolia test network, and `http()` with no URL uses the chain's default public RPC endpoint (RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions); production apps pass a dedicated RPC URL. Signing shows no passkey prompt: the one prompt happened at sign-in, and the session covers every signature until it is locked.
+`sepolia` is Ethereum's Sepolia test network. `http()` with no URL uses the chain's default public RPC endpoint; RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL. Signing shows no passkey prompt: the one prompt happened at sign-in, and the session covers every signature until it is locked.
 
 `sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query; viem's `waitForTransactionReceipt` on a public client covers it.
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one recovery phrase (the [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) word encoding of an account's root entropy), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 
@@ -24,7 +24,7 @@ if (!validateMnemonic(phrase, wordlist)) {
 
 ## Create and persist the vault
 
-`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension), the PRF input that namespaces its output, creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault. A separate salt for each vault avoids shared encryption keys and interchangeable nonce/ciphertext pairs ([one output, one purpose](/concepts/security-model/)).
+`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension), creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault. A separate salt for each vault avoids shared encryption keys ([one output, one purpose](/concepts/security-model/)).
 
 ```ts
 import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
@@ -44,7 +44,7 @@ try {
 }
 ```
 
-The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before it finishes, even when it fails. PRF output is the deterministic secret bytes the passkey returns through the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension, and it keys the encryption; [Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
+The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before it finishes, even when it fails. The [PRF output](/concepts/passkeys-and-prf/) keys the encryption. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
 
 ## Unlock
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -74,7 +74,7 @@ async function unlockPhrase(): Promise<string> {
 
 ## Derive signing sessions
 
-The phrase is a standard BIP-39 mnemonic, so key derivation from here is the same derivation passkey accounts use: one seed, then per-index paths. [Create passkey accounts](/recipes/create-passkey-accounts/) has both curves; pass it `mnemonicToSeedSync(phrase)` instead of a PRF-derived seed and zero the seed after the sessions exist.
+The phrase is a standard BIP-39 mnemonic, so key derivation from here is the same derivation passkey accounts use: one seed, then per-index paths. [Create passkey accounts](/recipes/create-passkey-accounts/) has both curves. Pass it `mnemonicToSeedSync(phrase)` instead of a PRF-derived seed and zero the seed after the sessions exist.
 
 ## Pitfalls
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -79,7 +79,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key (the WebAuthn term for a discoverable credential), and required user verification. The user-verification requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the PRF output nor remove the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
+The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key, and required user verification. Resident key is the WebAuthn term for a [discoverable](/concepts/passkeys-and-prf/) credential. The user-verification requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the PRF output nor remove the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
 The WebAuthn challenge is generated internally. The raw attestation response is not returned.
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -81,7 +81,7 @@ Signing needs no passkey ceremony and shows no prompt; the session signs as ofte
 
 The digest is read before `signDigest` returns; mutating the buffer after the call cannot change what was signed.
 
-The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA, the signature algorithm secp256k1 uses, but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would fail loudly with [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
+The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA, the signature algorithm secp256k1 uses, but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would throw [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
 
 ## See also
 


### PR DESCRIPTION
External reviewer feedback flagged a recognizable generated-text rhythm, and a second note observed the prose is so dense every sentence carries critical information, so nothing can be skimmed. Both point at the same root cause: sentences that define two or three terms inline at once, plus aphoristic closers.

The pass applies two mechanical rules across every page: a sentence defines at most one term (a second definition becomes its own sentence, or a link when another page owns the term), and rhetorical closers become plain statements. Re-glosses of PRF, derivation scheme, and recovery phrase in the recipes are now links to the owning concept pages. The reference pages were audited page by page and needed only two fixes; the zeroing statements there are distinct per-buffer facts, not repetition, and stay.

docs/AGENTS.md gains the two rules that keep this from regressing (one definition per sentence; placeholder comments name the value). Verified beyond the build: every internal fragment link resolves against its target page's headings, and grep sweeps confirm no em dashes, banned vocabulary, or "not X, but Y" constructions anywhere in the content tree.

Stacked on #210 (5/5, closes out the docs-feedback series).