### PR TITLE
Flatten createSigningKey and share the lockable-session type

### DIFF
--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -35,17 +35,15 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array<ArrayBuffer> {
 function createEd25519SigningSession({
   privateKey,
 }: CreateSigningSessionOptions): Ed25519SigningSession {
-  const { key, publicKey } = createSigningKey(privateKey, getEd25519PublicKey);
-
-  // One function for both members, so lock and dispose cannot drift apart.
-  function lock(): void {
-    key.lock();
-  }
+  const { use, lock, publicKey } = createSigningKey(
+    privateKey,
+    getEd25519PublicKey,
+  );
 
   return {
     publicKey,
     async signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
-      return new Uint8Array(ed25519.sign(message, key.use()));
+      return new Uint8Array(ed25519.sign(message, use()));
     },
     lock,
     [Symbol.dispose]: lock,

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -59,15 +59,10 @@ function normalizeSecp256k1PublicKey(
 function createSecp256k1SigningSession({
   privateKey,
 }: CreateSigningSessionOptions): Secp256k1SigningSession {
-  const { key, publicKey } = createSigningKey(
+  const { use, lock, publicKey } = createSigningKey(
     privateKey,
     getSecp256k1PublicKey,
   );
-
-  // One function for both members, so lock and dispose cannot drift apart.
-  function lock(): void {
-    key.lock();
-  }
 
   return {
     publicKey,
@@ -76,7 +71,7 @@ function createSecp256k1SigningSession({
         throw new MeraError("INPUT_INVALID", "Digest must be 32 bytes");
       }
 
-      const unlockedKey = key.use();
+      const unlockedKey = use();
       const signature = secp256k1.sign(digest32, unlockedKey, {
         format: "recovered",
         lowS: true,

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,9 +2,10 @@ import { copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
 
 /**
- * Handle to a session-owned private key whose lifetime is gated by `lock`.
+ * Session-owned signing key whose lifetime is gated by `lock`, paired with the
+ * public key derived from it.
  */
-type LockableKey = {
+type SigningKey = {
   /**
    * Returns the live session-owned key for immediate use.
    *
@@ -13,6 +14,8 @@ type LockableKey = {
   use(): Uint8Array<ArrayBuffer>;
   /** Zeroes the session-owned key and permanently locks this handle. */
   lock(): void;
+  /** Public key derived from the session-owned key. */
+  readonly publicKey: Uint8Array<ArrayBuffer>;
 };
 
 /**
@@ -24,13 +27,13 @@ type LockableKey = {
  *
  * @param privateKey - Private key to copy into the signing key.
  * @param derivePublicKey - Derives the public key from the owned snapshot; a throw doubles as private-key validation.
- * @returns The lockable key handle paired with the derived public key.
+ * @returns The lockable signing key with its derived public key.
  * @throws Rethrows whatever `derivePublicKey` throws.
  */
 function createSigningKey(
   privateKey: Uint8Array,
   derivePublicKey: (privateKey: Uint8Array) => Uint8Array<ArrayBuffer>,
-): { key: LockableKey; publicKey: Uint8Array<ArrayBuffer> } {
+): SigningKey {
   let activePrivateKey: Uint8Array<ArrayBuffer> | undefined;
 
   try {
@@ -39,7 +42,7 @@ function createSigningKey(
     activePrivateKey = copyBytes(privateKey);
     const publicKey = derivePublicKey(activePrivateKey);
 
-    const key: LockableKey = {
+    return {
       use(): Uint8Array<ArrayBuffer> {
         return requireUnlocked(activePrivateKey);
       },
@@ -49,9 +52,8 @@ function createSigningKey(
           activePrivateKey = undefined;
         }
       },
+      publicKey,
     };
-
-    return { key, publicKey };
   } catch (error) {
     activePrivateKey?.fill(0);
     throw error;

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,19 +107,8 @@ type CreateSigningSessionOptions = {
   privateKey: Uint8Array;
 };
 
-/** secp256k1 signing session that can sign 32-byte digests until `lock` is called. */
-type Secp256k1SigningSession = {
-  /** Uncompressed secp256k1 public key for the session. */
-  readonly publicKey: Uint8Array<ArrayBuffer>;
-  /**
-   * Signs a 32-byte digest without prehashing it.
-   *
-   * @param digest32 - Exactly 32 bytes to sign; read before the call returns, so later mutation cannot change what is signed.
-   * @returns A compact secp256k1 ECDSA signature with its recovery ID.
-   * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
-   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
-   */
-  signDigest(digest32: Uint8Array): Promise<Secp256k1Signature>;
+/** Members shared by every signing session: an explicit lock and `using` disposal. */
+type LockableSession = {
   /**
    * Zeroes the session-owned private-key copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
    */
@@ -132,8 +121,23 @@ type Secp256k1SigningSession = {
   [Symbol.dispose](): void;
 };
 
+/** secp256k1 signing session that can sign 32-byte digests until `lock` is called. */
+type Secp256k1SigningSession = LockableSession & {
+  /** Uncompressed secp256k1 public key for the session. */
+  readonly publicKey: Uint8Array<ArrayBuffer>;
+  /**
+   * Signs a 32-byte digest without prehashing it.
+   *
+   * @param digest32 - Exactly 32 bytes to sign; read before the call returns, so later mutation cannot change what is signed.
+   * @returns A compact secp256k1 ECDSA signature with its recovery ID.
+   * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
+   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
+   */
+  signDigest(digest32: Uint8Array): Promise<Secp256k1Signature>;
+};
+
 /** Ed25519 signing session that can sign messages until `lock` is called. */
-type Ed25519SigningSession = {
+type Ed25519SigningSession = LockableSession & {
   /** 32-byte Ed25519 public key for the session. */
   readonly publicKey: Uint8Array<ArrayBuffer>;
   /**
@@ -144,16 +148,6 @@ type Ed25519SigningSession = {
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */
   signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>>;
-  /**
-   * Zeroes the session-owned private-key copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
-   */
-  lock(): void;
-  /**
-   * Calls `lock`, so a `using` declaration locks the session when its scope
-   * exits. Sessions bound with `const` or `let` are unaffected; disposal runs
-   * only where a caller opts in with `using`.
-   */
-  [Symbol.dispose](): void;
 };
 
 export type {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -13,7 +13,7 @@ test("derives the public key from the stored private-key snapshot", () => {
   const original = new Uint8Array(privateKey);
   let snapshot: Uint8Array | undefined;
 
-  const { key, publicKey } = createSigningKey(privateKey, (value) => {
+  const { use, lock, publicKey } = createSigningKey(privateKey, (value) => {
     snapshot = value;
     const derived = new Uint8Array(value);
     privateKey.fill(9);
@@ -26,10 +26,10 @@ test("derives the public key from the stored private-key snapshot", () => {
   expect(snapshot?.buffer).not.toBe(privateKey.buffer);
   expect(snapshot?.buffer).toBeInstanceOf(ArrayBuffer);
   expect(publicKey).toEqual(original);
-  expect(key.use()).toEqual(original);
-  key.lock();
+  expect(use()).toEqual(original);
+  lock();
   expect(snapshot).toEqual(new Uint8Array(4));
-  expectError(() => key.use(), "SESSION_LOCKED");
+  expectError(() => use(), "SESSION_LOCKED");
 });
 
 test("zeroes the stored private-key snapshot when validation fails", () => {


### PR DESCRIPTION
## Motivation

Both curve sessions carried a local `lock()` wrapper whose only purpose was to give `key.lock` a stable local name for the `lock`/`Symbol.dispose` alias, and `Secp256k1SigningSession`/`Ed25519SigningSession` duplicated the `lock` and `Symbol.dispose` members with verbatim-identical JSDoc that could silently drift.

## Why the replacement is equivalent

`createSigningKey` now returns `{ use, lock, publicKey }` flat — the `LockableKey` nesting existed only to be unwrapped at both call sites. Its members are closures over `activePrivateKey` and never read `this`, so the sessions can alias `lock` and `[Symbol.dispose]` to the same returned function; the documented dispose-equals-lock contract still holds structurally. The shared members now live once in an unexported `LockableSession` base type, so the two session types cannot drift; curve-specific `publicKey` and sign-method docs stay on each session type.

First PR of a stacked simplification series from a full `src/` review.