### PR TITLE
Name option-bag types directly and compose the duplicated shapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 - Use strict typing and avoid `any`.
 - Prefer `type` aliases unless an `interface` is clearly better.
 - Exported functions should have explicit return types.
-- Keep central type files for durable shared/public data shapes. Define public single-function option bags near the implementation, export them as `Parameters<typeof functionName>[0]` aliases when a named caller type is useful, and avoid moving those aliases into the central type file.
+- Keep central type files for durable shared/public data shapes. Define public single-function option bags near the implementation as named `<FunctionName>Options` types used directly in the signature, and avoid moving them into the central type file.
 - Keep exports grouped at the end of hand-written TypeScript files instead of scattering `export` keywords through declarations.
 - Use runtime validation at string and wire boundaries, where TypeScript cannot protect callers.
 - Do not add runtime checks for typed internal invariants that TypeScript already proves, such as required callbacks or disallowed fields within SDK-only control flow.

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -16,7 +16,7 @@ import type {
 import { randomBytes } from "./webcrypto.js";
 
 /** Inputs for creating a discoverable, user-verified passkey with PRF enabled. */
-type CreatePasskeyInput = {
+type CreatePasskeyOptions = {
   /** Relying party identity passed directly to WebAuthn. */
   rp: PublicKeyCredentialRpEntity;
   /** User identity passed to WebAuthn. `id` is copied before use. */
@@ -56,8 +56,8 @@ type CreatePasskeyInput = {
  * can target the same relying party. `prfSalt` defaults to the fixed v1 value
  * returned by {@link getDeterministicPrfSaltV1}.
  */
-type CreatePasskeyWithPrfOutputInput = Omit<
-  CreatePasskeyInput,
+type CreatePasskeyWithPrfOutputOptions = Omit<
+  CreatePasskeyOptions,
   "rp" | "prfSalt"
 > & {
   /** Relying party identity passed to WebAuthn. `id` is required here. */
@@ -70,7 +70,7 @@ type CreatePasskeyWithPrfOutputInput = Omit<
 };
 
 /** Inputs for requesting the first WebAuthn PRF output from a passkey. */
-type GetPasskeyPrfOutputInput = {
+type GetPasskeyPrfOutputOptions = {
   /** Relying party ID for the WebAuthn assertion. */
   rpId: string;
   /** Credential metadata to restrict the assertion to one passkey. */
@@ -140,7 +140,7 @@ async function createPasskey({
   user,
   timeout,
   prfSalt,
-}: CreatePasskeyInput): Promise<CreatePasskeyResult> {
+}: CreatePasskeyOptions): Promise<CreatePasskeyResult> {
   try {
     assertCredentialApiAvailable();
 
@@ -258,7 +258,7 @@ async function getPasskeyPrfOutput({
   credential: allowCredential,
   prfSalt,
   timeout,
-}: GetPasskeyPrfOutputInput): Promise<PasskeyPrfResult> {
+}: GetPasskeyPrfOutputOptions): Promise<PasskeyPrfResult> {
   try {
     assertCredentialApiAvailable();
 
@@ -369,7 +369,7 @@ async function createPasskeyWithPrfOutput({
   user,
   timeout,
   prfSalt,
-}: CreatePasskeyWithPrfOutputInput): Promise<CreatePasskeyWithPrfOutputResult> {
+}: CreatePasskeyWithPrfOutputOptions): Promise<CreatePasskeyWithPrfOutputResult> {
   const prfSaltCopy = copyBytes(prfSalt ?? getDeterministicPrfSaltV1());
 
   const credential = await createPasskey({
@@ -503,15 +503,6 @@ function copyPrfOutput(
 
   return output;
 }
-
-/** Options accepted by `createPasskey`. */
-type CreatePasskeyOptions = Parameters<typeof createPasskey>[0];
-/** Options accepted by `createPasskeyWithPrfOutput`. */
-type CreatePasskeyWithPrfOutputOptions = Parameters<
-  typeof createPasskeyWithPrfOutput
->[0];
-/** Options accepted by `getPasskeyPrfOutput`. */
-type GetPasskeyPrfOutputOptions = Parameters<typeof getPasskeyPrfOutput>[0];
 
 export type {
   CreatePasskeyOptions,

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -6,6 +6,10 @@ import {
   copyBytes,
 } from "./encoding.js";
 import { MeraError } from "./errors.js";
+import type {
+  CreatePasskeyWithPrfOutputOptions,
+  GetPasskeyPrfOutputOptions,
+} from "./passkey.js";
 import {
   createPasskeyWithPrfOutput,
   getPasskeyPrfOutput,
@@ -140,16 +144,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /** Inputs for encrypting one arbitrary secret into a vault. */
-type CreateSecretVaultInput = {
+type CreateSecretVaultOptions = {
   /**
    * Passkey credential plus the PRF salt and PRF output it produced. Secret-vault
    * flows use a fresh salt for each secret.
    */
-  credential: {
-    /** Passkey credential ID as canonical unpadded base64url. */
-    credentialId: string;
-    /** Authenticator transports reported by the browser, when available. */
-    transports?: readonly PasskeyCredentialTransport[];
+  credential: PasskeyCredentialMetadata & {
     /** PRF salt for this secret. Must be exactly 32 bytes. */
     prfSalt: Uint8Array;
     /** First WebAuthn PRF output for `prfSalt`. Must be exactly 32 bytes. */
@@ -183,7 +183,7 @@ type CreateSecretVaultInput = {
 async function createSecretVault({
   credential,
   secret,
-}: CreateSecretVaultInput): Promise<PasskeySecretVault> {
+}: CreateSecretVaultOptions): Promise<PasskeySecretVault> {
   const { credentialId, transports, prfSalt, prfOutput } = credential;
 
   base64UrlDecode(credentialId, {
@@ -225,34 +225,21 @@ async function createSecretVault({
 }
 
 /** Inputs for creating a secret vault together with a new passkey. */
-type CreateSecretVaultWithNewPasskeyInput = {
-  /** Relying party identity passed directly to WebAuthn. `id` is required. */
-  rp: PublicKeyCredentialRpEntity & { id: string };
-  /** User identity passed to WebAuthn. `id` is copied before use. */
-  user: {
-    /** User handle. Must be 1 to 64 bytes when provided. */
-    id?: Uint8Array;
-    /** User name displayed or stored by the authenticator. */
-    name: string;
-    /** Human-readable display name for the authenticator UI. */
-    displayName: string;
-  };
+type CreateSecretVaultWithNewPasskeyOptions = Omit<
+  CreatePasskeyWithPrfOutputOptions,
+  "prfSalt"
+> & {
   /** Secret bytes to encrypt. Any non-empty length. */
   secret: Uint8Array;
-  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
-  timeout?: number;
 };
 
 /** Inputs for creating a secret vault with an existing passkey. */
-type CreateSecretVaultWithExistingPasskeyInput = {
-  /** Relying party ID for the WebAuthn assertion. */
-  rpId: string;
-  /** Credential metadata to restrict the assertion to one passkey. */
-  credential?: PasskeyCredentialMetadata;
+type CreateSecretVaultWithExistingPasskeyOptions = Omit<
+  GetPasskeyPrfOutputOptions,
+  "prfSalt"
+> & {
   /** Secret bytes to encrypt. Any non-empty length. */
   secret: Uint8Array;
-  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
-  timeout?: number;
 };
 
 /** Copies and validates a secret before a WebAuthn ceremony can start. */
@@ -296,7 +283,7 @@ async function createSecretVaultWithNewPasskey({
   user,
   secret,
   timeout,
-}: CreateSecretVaultWithNewPasskeyInput): Promise<PasskeySecretVault> {
+}: CreateSecretVaultWithNewPasskeyOptions): Promise<PasskeySecretVault> {
   const secretCopy = copyNonEmptySecret(secret);
   let prfOutput: Uint8Array | undefined;
 
@@ -341,7 +328,7 @@ async function createSecretVaultWithExistingPasskey({
   credential,
   secret,
   timeout,
-}: CreateSecretVaultWithExistingPasskeyInput): Promise<PasskeySecretVault> {
+}: CreateSecretVaultWithExistingPasskeyOptions): Promise<PasskeySecretVault> {
   const secretCopy = copyNonEmptySecret(secret);
   // Copied before async WebAuthn work starts.
   const credentialCopy =
@@ -378,7 +365,7 @@ async function createSecretVaultWithExistingPasskey({
 }
 
 /** Inputs for decrypting a secret vault. */
-type DecryptSecretVaultInput = {
+type DecryptSecretVaultOptions = {
   /** Parsed secret vault. */
   vault: PasskeySecretVault;
   /** WebAuthn PRF output for the vault's PRF salt. Must be exactly 32 bytes. */
@@ -401,7 +388,7 @@ type DecryptSecretVaultInput = {
 async function decryptSecretVault({
   vault,
   prfOutput,
-}: DecryptSecretVaultInput): Promise<Uint8Array<ArrayBuffer>> {
+}: DecryptSecretVaultOptions): Promise<Uint8Array<ArrayBuffer>> {
   // The copy guarantee documented above is provided by hkdfSha256AesGcmKey,
   // which snapshots prfOutput synchronously before its first await.
   const encryptionKey = await deriveEncryptionKey(prfOutput);
@@ -499,7 +486,7 @@ function copySecretVault(vault: PasskeySecretVault): PasskeySecretVault {
 }
 
 /** Inputs for the WebAuthn assertion that unlocks a secret vault. */
-type GetSecretVaultPrfOutputInput = {
+type GetSecretVaultPrfOutputOptions = {
   /** Relying party ID for the WebAuthn assertion. */
   rpId: string;
   /** Parsed secret vault. */
@@ -531,7 +518,7 @@ async function getSecretVaultPrfOutput({
   rpId,
   vault,
   timeout,
-}: GetSecretVaultPrfOutputInput): Promise<PasskeyPrfResult> {
+}: GetSecretVaultPrfOutputOptions): Promise<PasskeyPrfResult> {
   return getPasskeyPrfOutput({
     rpId,
     credential: vault.credential,
@@ -541,7 +528,7 @@ async function getSecretVaultPrfOutput({
 }
 
 /** Inputs for performing the passkey ceremony and decrypting a secret vault. */
-type DecryptSecretVaultWithPasskeyInput = {
+type DecryptSecretVaultWithPasskeyOptions = {
   /** Relying party ID for the WebAuthn assertion. */
   rpId: string;
   /** Parsed secret vault. Copied before use. */
@@ -574,7 +561,7 @@ async function decryptSecretVaultWithPasskey({
   rpId,
   vault,
   timeout,
-}: DecryptSecretVaultWithPasskeyInput): Promise<Uint8Array<ArrayBuffer>> {
+}: DecryptSecretVaultWithPasskeyOptions): Promise<Uint8Array<ArrayBuffer>> {
   const vaultCopy = copySecretVault(vault);
   const { prfOutput } = await getSecretVaultPrfOutput({
     rpId,
@@ -588,27 +575,6 @@ async function decryptSecretVaultWithPasskey({
     prfOutput.fill(0);
   }
 }
-
-/** Options accepted by `createSecretVault`. */
-type CreateSecretVaultOptions = Parameters<typeof createSecretVault>[0];
-/** Options accepted by `createSecretVaultWithExistingPasskey`. */
-type CreateSecretVaultWithExistingPasskeyOptions = Parameters<
-  typeof createSecretVaultWithExistingPasskey
->[0];
-/** Options accepted by `createSecretVaultWithNewPasskey`. */
-type CreateSecretVaultWithNewPasskeyOptions = Parameters<
-  typeof createSecretVaultWithNewPasskey
->[0];
-/** Options accepted by `decryptSecretVault`. */
-type DecryptSecretVaultOptions = Parameters<typeof decryptSecretVault>[0];
-/** Options accepted by `decryptSecretVaultWithPasskey`. */
-type DecryptSecretVaultWithPasskeyOptions = Parameters<
-  typeof decryptSecretVaultWithPasskey
->[0];
-/** Options accepted by `getSecretVaultPrfOutput`. */
-type GetSecretVaultPrfOutputOptions = Parameters<
-  typeof getSecretVaultPrfOutput
->[0];
 
 export type {
   CreateSecretVaultOptions,


### PR DESCRIPTION
## Motivation

Every public option bag had two names: a local `*Input` type plus a public `*Options` alias built via `Parameters<typeof fn>[0]` (nine aliases, ~40 lines). viem.ts already named its options type directly, so the codebase was split between two conventions, and the heavier one bought nothing. Separately, secret.ts hand-restated the `rp`/`user`/`timeout` and `rpId`/`credential`/`timeout` blocks that its passkey counterparts already declare.

## Why the replacement is equivalent

The local types now carry the public `*Options` names and appear directly in signatures — exported names and shapes are unchanged, so this is invisible to consumers. `CreateSecretVaultWithNewPasskeyOptions` and `CreateSecretVaultWithExistingPasskeyOptions` become `Omit<passkey options, "prfSalt"> & { secret }`, which is field-for-field identical to the removed declarations and keeps hover docs via the mapped type. `CreateSecretVaultOptions.credential` builds on `PasskeyCredentialMetadata`, making it explicit that `CreatePasskeyWithPrfOutputResult` is directly assignable to it (which `createSecretVaultWithNewPasskey` already relies on).

AGENTS.md's TypeScript bullet is updated to prescribe the direct-naming pattern it previously ruled out.

Stacked on #216.