### PR TITLE
Remove redundant copies of PRF material

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -261,12 +261,13 @@ async function getPasskeyPrfOutput({
   try {
     assertCredentialApiAvailable();
 
-    const prfSaltCopy = copyBytes(prfSalt ?? getDeterministicPrfSaltV1());
-    if (prfSaltCopy.length !== 32) {
+    if (prfSalt !== undefined && prfSalt.length !== 32) {
       throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
     }
 
-    const prf = { eval: { first: asArrayBuffer(prfSaltCopy) } };
+    const prf = {
+      eval: { first: asArrayBuffer(prfSalt ?? getDeterministicPrfSaltV1()) },
+    };
 
     const publicKey: PublicKeyCredentialRequestOptions = {
       rpId,
@@ -368,7 +369,8 @@ async function createPasskeyWithPrfOutput({
   timeout,
   prfSalt,
 }: CreatePasskeyWithPrfOutputOptions): Promise<CreatePasskeyWithPrfOutputResult> {
-  const prfSaltCopy = copyBytes(prfSalt ?? getDeterministicPrfSaltV1());
+  const prfSaltCopy =
+    prfSalt === undefined ? getDeterministicPrfSaltV1() : copyBytes(prfSalt);
 
   const credential = await createPasskey({
     rp,

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -200,11 +200,12 @@ async function createSecretVault({
   }
 
   const prfSaltCopy = copyBytes(prfSalt);
-  const prfOutputCopy = copyBytes(prfOutput);
   const secretCopy = copyBytes(secret);
 
   try {
-    const encryptionKey = await deriveEncryptionKey(prfOutputCopy);
+    // The copy guarantee for prfOutput is provided by hkdfSha256AesGcmKey,
+    // which snapshots it synchronously before its first await.
+    const encryptionKey = await deriveEncryptionKey(prfOutput);
     const encrypted = await aesGcmEncrypt({
       plaintext: secretCopy,
       encryptionKey,
@@ -219,7 +220,6 @@ async function createSecretVault({
       ciphertext: base64UrlEncode(encrypted.ciphertext),
     };
   } finally {
-    prfOutputCopy.fill(0);
     secretCopy.fill(0);
   }
 }


### PR DESCRIPTION
Three call sites copy PRF bytes to keep the documented "copied before use" guarantees true, but other code already provides each guarantee:

- `createSecretVault` copied `prfOutput` before deriving the encryption key. `hkdfSha256AesGcmKey` documents that it snapshots its input keying material synchronously before its first `await`, and `decryptSecretVault` already relies on that instead of copying. The extra copy only added a second buffer of key material to zero.
- `getPasskeyPrfOutput` copied the salt with `copyBytes` and then again with `asArrayBuffer`. The second copy is the one WebAuthn reads, and it happens synchronously before the ceremony. The defaulted salt from `getDeterministicPrfSaltV1` is already a fresh buffer.
- `createPasskeyWithPrfOutput` copied the defaulted salt a second time for the same reason. An explicit caller salt is still copied, since the returned salt must not alias caller input.

Each surviving copy runs in the same synchronous prefix as the one it replaces, so every documented guarantee holds and the existing snapshot tests pass unchanged.