### PR TITLE
Destructure credential metadata instead of rebuilding it

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -377,13 +377,10 @@ async function createPasskeyWithPrfOutput({
     prfSalt: prfSaltCopy,
   });
 
-  const credentialMetadata = toCredentialMetadata(
-    credential.credentialId,
-    credential.transports,
-  );
+  const { prfOutput: createTimePrfOutput, ...credentialMetadata } = credential;
 
   const prfOutput =
-    credential.prfOutput ??
+    createTimePrfOutput ??
     (
       await getPasskeyPrfOutput({
         rpId: rp.id,


### PR DESCRIPTION
`createPasskeyWithPrfOutput` rebuilt its credential metadata with `toCredentialMetadata`, re-copying a value that `createPasskey` had just built with the same helper. That defends a library-internal invariant TypeScript already proves, which the repository guidelines say not to re-check.

A rest destructure that drops `prfOutput` is equivalent: `credential` is a local with no other holder, and its `transports` array was freshly built inside `createPasskey`, so nothing the caller can reach is aliased.