### PR TITLE
Drop the vault copy in decryptSecretVaultWithPasskey

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -471,20 +471,6 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
   return { version: 1, credential, prfSalt, nonce, ciphertext };
 }
 
-/** Copies a parsed vault before a WebAuthn ceremony can yield control. */
-function copySecretVault(vault: PasskeySecretVault): PasskeySecretVault {
-  return {
-    version: vault.version,
-    credential: toCredentialMetadata(
-      vault.credential.credentialId,
-      vault.credential.transports,
-    ),
-    prfSalt: vault.prfSalt,
-    nonce: vault.nonce,
-    ciphertext: vault.ciphertext,
-  };
-}
-
 /** Inputs for the WebAuthn assertion that unlocks a secret vault. */
 type GetSecretVaultPrfOutputOptions = {
   /** Relying party ID for the WebAuthn assertion. */
@@ -528,14 +514,7 @@ async function getSecretVaultPrfOutput({
 }
 
 /** Inputs for performing the passkey ceremony and decrypting a secret vault. */
-type DecryptSecretVaultWithPasskeyOptions = {
-  /** Relying party ID for the WebAuthn assertion. */
-  rpId: string;
-  /** Parsed secret vault. Copied before use. */
-  vault: PasskeySecretVault;
-  /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
-  timeout?: number;
-};
+type DecryptSecretVaultWithPasskeyOptions = GetSecretVaultPrfOutputOptions;
 
 /**
  * Performs the passkey assertion for a vault and decrypts its secret.
@@ -547,10 +526,8 @@ type DecryptSecretVaultWithPasskeyOptions = {
  * authenticator UI. The assertion is restricted to the credential stored in
  * the vault.
  *
- * The vault is copied before the ceremony starts, so post-call mutation does
- * not change the assertion or ciphertext being decrypted. The internal PRF
- * output is zeroed before the function finishes, even when decryption
- * fails. The returned secret's lifetime belongs to the caller.
+ * The internal PRF output is zeroed before the function finishes, even when
+ * decryption fails. The returned secret's lifetime belongs to the caller.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
  * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
@@ -562,15 +539,14 @@ async function decryptSecretVaultWithPasskey({
   vault,
   timeout,
 }: DecryptSecretVaultWithPasskeyOptions): Promise<Uint8Array<ArrayBuffer>> {
-  const vaultCopy = copySecretVault(vault);
   const { prfOutput } = await getSecretVaultPrfOutput({
     rpId,
-    vault: vaultCopy,
+    vault,
     ...(timeout !== undefined ? { timeout } : {}),
   });
 
   try {
-    return await decryptSecretVault({ vault: vaultCopy, prfOutput });
+    return await decryptSecretVault({ vault, prfOutput });
   } finally {
     prfOutput.fill(0);
   }

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -5,7 +5,6 @@ import {
   createSecretVaultWithExistingPasskey,
   createSecretVaultWithNewPasskey,
   decryptSecretVault,
-  decryptSecretVaultWithPasskey,
   getDeterministicPrfSaltV1,
   type PasskeyCredentialTransport,
   type PasskeySecretVault,
@@ -298,51 +297,6 @@ test("createSecretVaultWithExistingPasskey snapshots inputs and preserves transp
     await expect(
       decryptSecretVault({ vault, prfOutput: evaluatedSalt }),
     ).resolves.toEqual(SECRET);
-  });
-});
-
-test("decryptSecretVaultWithPasskey snapshots the vault before prompting", async () => {
-  const stored = await createTestVault();
-  const vault = {
-    ...stored,
-    credential: {
-      ...stored.credential,
-      transports: [...(stored.credential.transports ?? [])],
-    },
-  };
-  let releaseAssertion: (() => void) | undefined;
-  const assertionGate = new Promise<void>((resolve) => {
-    releaseAssertion = resolve;
-  });
-
-  const navigator = {
-    credentials: {
-      async get() {
-        await assertionGate;
-        return {
-          type: "public-key",
-          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
-          getClientExtensionResults: () => ({
-            prf: { results: { first: PRF_OUTPUT.buffer } },
-          }),
-        };
-      },
-    },
-  };
-
-  await withStubbedGlobal("navigator", navigator, async () => {
-    const pending = decryptSecretVaultWithPasskey({
-      rpId: "example.com",
-      vault,
-    });
-
-    vault.credential.credentialId = "BQYHCA";
-    vault.prfSalt = "invalid";
-    vault.nonce = "invalid";
-    vault.ciphertext = "invalid";
-    releaseAssertion?.();
-
-    await expect(pending).resolves.toEqual(SECRET);
   });
 });
 


### PR DESCRIPTION
Behavior change: `decryptSecretVaultWithPasskey` no longer guarantees that mutating the vault object mid-ceremony leaves the operation unaffected. The copy backing that guarantee defended no security boundary — every vault field is an immutable string, and the worst outcome of mid-ceremony mutation is the caller's own decryption failing with the existing `INPUT_INVALID`/`DECRYPT_FAILED` codes. The `credential` and `prfSalt` fields are consumed synchronously before the ceremony either way; only `nonce` and `ciphertext` are read after it.

With the guarantee gone, `copySecretVault`, the doc sentences stating it, and the unit test pinning it ("decryptSecretVaultWithPasskey snapshots the vault before prompting") go too. The e2e suite still covers `decryptSecretVaultWithPasskey` against a virtual authenticator: two create-and-decrypt round trips and a wrong-credential failure.

Dropping the "copied before use" field note left `DecryptSecretVaultWithPasskeyOptions` field-for-field identical to `GetSecretVaultPrfOutputOptions`, so it is now an alias. Both exported names stay; the public API surface is unchanged.