### PR TITLE
Preserve WebAuthn transport hints

### DIFF
--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -44,7 +44,7 @@ localStorage.setItem(
 );
 ```
 
-`transports` is optional and only a hint: the browser uses it to reach the authenticator directly (a platform prompt for a platform passkey, a QR flow for a phone) instead of offering every option. Sign-in works the same without it.
+`transports` contains opaque browser routing hints. Store the array exactly as returned and pass it back unchanged: removing or filtering values can degrade the browser's routing and may prevent it from reaching the credential. The field may be absent when the browser does not expose transport metadata.
 
 A fresh device has no record; sign-in falls back to a discoverable ceremony, and the synced passkey still produces the same accounts.
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -68,7 +68,7 @@ WebAuthn timeout in milliseconds.
 
 ## Returns
 
-`Promise<CreatePasskeyResult>`. The credential ID as canonical unpadded base64url, the authenticator transports when the browser reports them, and a 32-byte `prfOutput` when `prfSalt` was provided and evaluated during creation.
+`Promise<CreatePasskeyResult>`. The credential ID as canonical unpadded base64url, opaque authenticator transport hints when the browser reports them, and a 32-byte `prfOutput` when `prfSalt` was provided and evaluated during creation. Store reported transports with the credential and pass them back unchanged; Mera preserves unknown values for compatibility with future browsers.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -35,7 +35,7 @@ Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) [assertio
 - Type: `PasskeyCredentialMetadata`
 - Optional; when omitted, WebAuthn may choose any discoverable credential for the relying party
 
-Credential metadata that restricts the assertion to one passkey: a `credentialId` in canonical unpadded base64url, plus the `transports` reported when it was created. An empty `credentialId` is rejected rather than passed through, because WebAuthn would treat it as no restriction at all and silently widen the assertion to any discoverable passkey.
+Credential metadata that restricts the assertion to one passkey: a `credentialId` in canonical unpadded base64url, plus the opaque `transports` reported when it was created. Mera passes transport values to WebAuthn unchanged, including values it does not recognize. An empty `credentialId` is rejected rather than passed through, because WebAuthn would treat it as no restriction at all and silently widen the assertion to any discoverable passkey.
 
 ### options.prfSalt
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -30,7 +30,7 @@ The passkey credential that unlocks this vault, as canonical unpadded [base64url
 
 ### credential.transports
 
-Authenticator transports reported by the browser when the passkey was created. Optional; when present, they help the browser route the unlock assertion (to a security key, to a phone) without guessing.
+Opaque authenticator transport hints reported by the browser when the passkey was created. They are stored and replayed unchanged, including values Mera does not recognize, because removing values can degrade routing or prevent the browser from reaching the credential. The field may be omitted when the browser does not expose transport metadata.
 
 ### prfSalt
 

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -400,8 +400,8 @@ async function createPasskeyWithPrfOutput({
 }
 
 /**
- * Builds credential metadata, copying `transports` so the result never aliases
- * a caller-owned array.
+ * Builds credential metadata, copying opaque `transports` without filtering so
+ * the result never aliases a caller-owned array or drops future values.
  */
 function toCredentialMetadata(
   credentialId: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,11 +28,13 @@ type Brand<T, Name extends string> = T & { readonly [brand]: Name };
 type SolanaAddress = Brand<string, "SolanaAddress">;
 
 /**
- * WebAuthn authenticator transport metadata, including future browser transport values.
+ * An opaque WebAuthn authenticator transport hint, including values introduced
+ * by future browsers.
  *
  * The `string & {}` arm accepts any string without collapsing the union to
  * plain `string`, so editors keep offering the known `AuthenticatorTransport`
- * literals in autocomplete.
+ * literals in autocomplete. Values returned by WebAuthn are preserved rather
+ * than interpreted by Mera.
  */
 type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});
 
@@ -40,7 +42,7 @@ type PasskeyCredentialTransport = AuthenticatorTransport | (string & {});
 type PasskeyCredentialMetadata = {
   /** Credential ID encoded as canonical unpadded base64url. */
   readonly credentialId: string;
-  /** Authenticator transports reported by the browser, when available. */
+  /** Opaque authenticator transport hints reported by the browser, when available. */
   readonly transports?: readonly PasskeyCredentialTransport[];
 };
 

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -329,6 +329,51 @@ test("passkey helpers generate internal challenges and request no attestation", 
   expect(new Uint8Array(getOptions.challenge as ArrayBuffer)).toHaveLength(32);
 });
 
+test("passkey helpers preserve opaque transport hints", async () => {
+  const reportedTransports = ["internal", "future-transport"];
+  let allowedTransports: readonly string[] | undefined;
+
+  const navigator = {
+    credentials: {
+      async create() {
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          response: { getTransports: () => reportedTransports },
+          getClientExtensionResults: () => ({ prf: { enabled: true } }),
+        };
+      },
+      async get({ publicKey }: CredentialRequestOptions) {
+        allowedTransports = publicKey?.allowCredentials?.[0]?.transports;
+        return {
+          type: "public-key",
+          rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+          getClientExtensionResults: () => ({
+            prf: { results: { first: new Uint8Array(32).buffer } },
+          }),
+        };
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    const created = await createPasskey({
+      rp: { id: "example.com", name: "Mera Test" },
+      user: { name: "nad", displayName: "nad" },
+    });
+
+    reportedTransports[0] = "usb";
+    expect(created.transports).toEqual(["internal", "future-transport"]);
+
+    await getPasskeyPrfOutput({
+      rpId: "example.com",
+      credential: created,
+    });
+  });
+
+  expect(allowedTransports).toEqual(["internal", "future-transport"]);
+});
+
 test("getPasskeyPrfOutput rejects an empty credentialId without prompting", async () => {
   // A malformed stored ID must fail closed instead of silently widening the
   // assertion to any discoverable credential for the relying party.


### PR DESCRIPTION
WebAuthn transport values are opaque credential-record data, but the current documentation describes them as an optional optimization whose removal does not affect sign-in. That guidance can lead an app to filter or discard values even though the WebAuthn specification warns that doing so can degrade UX or prevent the credential from being used.

This change makes the existing contract explicit: Mera copies browser-reported transport arrays, stores and replays every value unchanged, and accepts values introduced by future browsers. Regression coverage exercises both the creation result and the later `allowCredentials` descriptor with an unknown transport value.

There is no API or wire-format change. The security benefit is fail-closed credential targeting without risking authenticator reachability through application-side transport interpretation.

Validation:

- `npm run check`
- `npm test` (78 tests)
- documentation `npm run build`

Reference: https://www.w3.org/TR/webauthn-3/#credential-record
