### PR TITLE
Remove redundant vault AAD

### DIFF
--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -5,7 +5,7 @@ description: Encrypts an arbitrary secret into a passkey-protected vault.
 
 Encrypts an arbitrary secret into a passkey-protected vault from explicit credential, salt, and PRF material. This is the low-level encryption primitive; secret-vault workflow functions own the ceremony and random salt.
 
-An AES-256-GCM encryption key is derived from the PRF output with fixed HKDF-SHA-256 info (`mera.v1.encrypt.secret`), which separates it from any other key derived from the same output. The secret is encrypted under fixed additional authenticated data.
+An AES-256-GCM encryption key is derived from the PRF output with fixed HKDF-SHA-256 info (`mera.v1.encrypt.secret`), which separates it from any other key derived from the same output.
 
 ## Import
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -57,7 +57,7 @@ A signing call was made after the session's `lock()`. Locking is permanent; new 
 
 ### DECRYPT_FAILED
 
-[AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed while decrypting a vault: wrong key material, or tampered ciphertext or [additional authenticated data](/reference/secret-vault-format/#what-is-deliberately-absent). The two cases are indistinguishable by design; GCM authenticates before it decrypts.
+[AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed while decrypting a vault: wrong key material or a tampered nonce/ciphertext pair. The two cases are indistinguishable by design; GCM authenticates before it decrypts.
 
 ### INPUT_INVALID
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -48,7 +48,7 @@ The AES-GCM ciphertext including its 16-byte authentication tag, the value decry
 
 The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
 
-The credential ID and salt are stored but not authenticated: the AES-GCM additional authenticated data is the fixed constant `mera.v1.secret.aad`, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored JSON.
+The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored JSON.
 
 ## Portability
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,7 +5,7 @@
  * - `CRYPTO_UNAVAILABLE`: Web Crypto is unavailable.
  * - `PRF_UNAVAILABLE`: the authenticator did not enable or return a usable 32-byte WebAuthn PRF output.
  * - `SESSION_LOCKED`: a signing call was made after `lock()`.
- * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key, or tampered ciphertext or additional authenticated data).
+ * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key or tampered nonce/ciphertext).
  * - `INPUT_INVALID`: a caller-supplied value at a public boundary did not satisfy a length, range, encoding, or curve (scalar or point) constraint.
  * - `VAULT_FORMAT_INVALID`: untrusted vault data (JSON or object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version.
  */

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -31,12 +31,9 @@ const NONCE_LENGTH = 12;
 // any authentic ciphertext is at least this long.
 const GCM_TAG_LENGTH = 16;
 
-// HKDF info and AAD for the secret vault. The HKDF info keeps the encryption key
-// distinct from any other key derived from the same PRF output. The AAD is a
-// fixed constant: vault fields such as the credential ID and PRF salt are
-// deliberately not bound; see the Security remark on createSecretVault.
+// HKDF info keeps the encryption key distinct from any other key derived from
+// the same PRF output.
 const SECRET_ENCRYPTION_INFO = utf8ToBytes("mera.v1.encrypt.secret");
-const SECRET_AAD = utf8ToBytes("mera.v1.secret.aad");
 
 /** AES-GCM encrypted bytes. */
 type EncryptedBytes = {
@@ -62,11 +59,9 @@ async function deriveEncryptionKey(prfOutput: Uint8Array): Promise<CryptoKey> {
 async function aesGcmEncrypt({
   plaintext,
   encryptionKey,
-  aad,
 }: {
   plaintext: Uint8Array;
   encryptionKey: CryptoKey;
-  aad: Uint8Array;
 }): Promise<EncryptedBytes> {
   const iv = randomBytes(NONCE_LENGTH);
 
@@ -74,7 +69,6 @@ async function aesGcmEncrypt({
     {
       name: "AES-GCM",
       iv: asArrayBuffer(iv),
-      additionalData: asArrayBuffer(aad),
     },
     encryptionKey,
     asArrayBuffer(plaintext),
@@ -86,23 +80,20 @@ async function aesGcmEncrypt({
   };
 }
 
-// AES-256-GCM decrypt. Authentication failures (wrong key, tampered ciphertext
-// or AAD) surface as DECRYPT_FAILED. The returned bytes are not interpreted.
+// AES-256-GCM decrypt. Authentication failures from a wrong key or tampered
+// nonce/ciphertext surface as DECRYPT_FAILED. The returned bytes are not interpreted.
 async function aesGcmDecrypt({
   encrypted,
   encryptionKey,
-  aad,
 }: {
   encrypted: EncryptedBytes;
   encryptionKey: CryptoKey;
-  aad: Uint8Array;
 }): Promise<Uint8Array<ArrayBuffer>> {
   try {
     const plaintext = await getCrypto().subtle.decrypt(
       {
         name: "AES-GCM",
         iv: asArrayBuffer(encrypted.nonce),
-        additionalData: asArrayBuffer(aad),
       },
       encryptionKey,
       asArrayBuffer(encrypted.ciphertext),
@@ -164,8 +155,7 @@ type CreateSecretVaultOptions = {
  *
  * An AES-256-GCM encryption key is derived from the PRF output with fixed
  * HKDF info (`mera.v1.encrypt.secret`), which separates it from other keys
- * derived from the same PRF output. The secret is encrypted under fixed
- * additional authenticated data (AAD).
+ * derived from the same PRF output.
  *
  * @remarks
  * The input byte buffers are copied before async cryptographic work starts;
@@ -209,7 +199,6 @@ async function createSecretVault({
     const encrypted = await aesGcmEncrypt({
       plaintext: secretCopy,
       encryptionKey,
-      aad: SECRET_AAD,
     });
 
     return {
@@ -399,7 +388,6 @@ async function decryptSecretVault({
       ciphertext: base64UrlDecode(vault.ciphertext),
     },
     encryptionKey,
-    aad: SECRET_AAD,
   });
 }
 

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -321,7 +321,7 @@ test("secret vault helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavaila
   });
 });
 
-test("secret vault AAD is independent of credential metadata and PRF salt", async () => {
+test("secret vault encryption is independent of credential metadata and PRF salt", async () => {
   const vault = await createTestVault();
   const edited = parseSecretVault({
     ...vault,


### PR DESCRIPTION
The vault passes a fixed string as AES-GCM additional authenticated data, but that value binds no vault metadata and duplicates the protocol separation already provided by the fixed HKDF info `mera.v1.encrypt.secret`. Keeping both labels adds parameters and documentation without changing the vault's security boundary.

This removes the fixed AAD from encryption and decryption. AES-GCM still authenticates each random nonce/ciphertext pair under a non-extractable AES-256 key derived with the same fixed HKDF context. The credential ID and PRF salt remain deliberately unauthenticated, so the documented metadata-binding contract is unchanged.

This changes the unreleased v1 ciphertext format: vaults produced from the previous `main` implementation will not decrypt after this change. No migration path is included because the package has not been released.

Validation:

- `npm run check`
- `npm test` (77 tests)
- documentation `npm run build`

References: https://www.rfc-editor.org/rfc/rfc5869.html#section-3.2 and https://csrc.nist.gov/pubs/sp/800/38/d/final
