### PR TITLE
Reuse the high-level secret snapshot

### DIFF
--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -78,7 +78,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-A fresh random 32-byte PRF salt is generated for each call and stored in the vault. The secret and supplied credential metadata are copied before the ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
+A fresh random 32-byte PRF salt is generated for each call and stored in the vault. The secret is copied once, and supplied credential metadata is copied before the ceremony begins. The internal secret and PRF output are zeroed before the function finishes, even when it fails.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -72,7 +72,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Notes
 
-A fresh random 32-byte PRF salt is generated for the vault and stored in it. The secret is copied before either ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
+A fresh random 32-byte PRF salt is generated for the vault and stored in it. The secret is copied once before either ceremony begins. The internal secret and PRF output are zeroed before the function finishes, even when it fails.
 
 If the fallback ceremony or vault encryption fails after creation, the passkey remains on the authenticator and the error does not contain its metadata.
 

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -72,7 +72,7 @@ A vault is bound to its `prfOutput` only, never to the credential ID or salt: se
 
 The GCM nonce (12 bytes) is generated internally for each encryption, so a caller cannot accidentally reuse one.
 
-Input byte buffers are copied before async cryptographic work starts; mutating them after the call does not change the vault being produced. The internal secret copy is zeroed before the function returns. Caller-owned `prfOutput` and `secret` buffers are never modified.
+Input byte buffers are copied before async cryptographic work starts; mutating them after the call does not change the vault being produced. The internal secret copy is zeroed before the function returns.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -72,7 +72,7 @@ A vault is bound to its `prfOutput` only, never to the credential ID or salt: se
 
 The GCM nonce (12 bytes) is generated internally for each encryption, so a caller cannot accidentally reuse one.
 
-Input byte buffers are copied before async cryptographic work starts; mutating them after the call does not change the vault being produced. The internal copies of the PRF output and secret are zeroed before it returns, so the caller's `prfOutput` and `secret` buffers are the only copies left in memory.
+Input byte buffers are copied before async cryptographic work starts; mutating them after the call does not change the vault being produced. The internal secret copy is zeroed before the function returns. Caller-owned `prfOutput` and `secret` buffers are never modified.
 
 ## See also
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -184,6 +184,23 @@ async function createSecretVault({
   credential,
   secret,
 }: CreateSecretVaultOptions): Promise<PasskeySecretVault> {
+  const secretCopy = copyNonEmptySecret(secret);
+
+  try {
+    return await createSecretVaultFromSecretCopy({
+      credential,
+      secret: secretCopy,
+    });
+  } finally {
+    secretCopy.fill(0);
+  }
+}
+
+/** Encrypts a non-empty secret snapshot that its caller owns and zeroes. */
+async function createSecretVaultFromSecretCopy({
+  credential,
+  secret,
+}: CreateSecretVaultOptions): Promise<PasskeySecretVault> {
   const { credentialId, transports, prfSalt, prfOutput } = credential;
 
   base64UrlDecode(credentialId, {
@@ -195,33 +212,24 @@ async function createSecretVault({
     throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
   }
 
-  if (secret.length === 0) {
-    throw new MeraError("INPUT_INVALID", "secret must not be empty");
-  }
-
   const prfSaltCopy = copyBytes(prfSalt);
-  const secretCopy = copyBytes(secret);
 
-  try {
-    // The copy guarantee for prfOutput is provided by hkdfSha256AesGcmKey,
-    // which snapshots it synchronously before its first await.
-    const encryptionKey = await deriveEncryptionKey(prfOutput);
-    const encrypted = await aesGcmEncrypt({
-      plaintext: secretCopy,
-      encryptionKey,
-      aad: SECRET_AAD,
-    });
+  // The copy guarantee for prfOutput is provided by hkdfSha256AesGcmKey,
+  // which snapshots it synchronously before its first await.
+  const encryptionKey = await deriveEncryptionKey(prfOutput);
+  const encrypted = await aesGcmEncrypt({
+    plaintext: secret,
+    encryptionKey,
+    aad: SECRET_AAD,
+  });
 
-    return {
-      version: 1,
-      credential: toCredentialMetadata(credentialId, transports),
-      prfSalt: base64UrlEncode(prfSaltCopy),
-      nonce: base64UrlEncode(encrypted.nonce),
-      ciphertext: base64UrlEncode(encrypted.ciphertext),
-    };
-  } finally {
-    secretCopy.fill(0);
-  }
+  return {
+    version: 1,
+    credential: toCredentialMetadata(credentialId, transports),
+    prfSalt: base64UrlEncode(prfSaltCopy),
+    nonce: base64UrlEncode(encrypted.nonce),
+    ciphertext: base64UrlEncode(encrypted.ciphertext),
+  };
 }
 
 /** Inputs for creating a secret vault together with a new passkey. */
@@ -266,9 +274,9 @@ function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
  * creation, also invokes `navigator.credentials.get()`, which means a second
  * browser prompt.
  *
- * `secret` is copied and validated before either ceremony starts. Post-call
- * mutation does not change the encrypted secret. The internal secret and PRF
- * output are zeroed before the function finishes, even when it fails.
+ * `secret` is copied once and validated before either ceremony starts.
+ * Post-call mutation does not change the encrypted secret. The internal secret
+ * and PRF output are zeroed before the function finishes, even when it fails.
  *
  * If the fallback ceremony or vault encryption fails, the passkey from the
  * completed creation ceremony still exists on the authenticator, but the
@@ -296,7 +304,10 @@ async function createSecretVaultWithNewPasskey({
     });
     prfOutput = credential.prfOutput;
 
-    return await createSecretVault({ credential, secret: secretCopy });
+    return await createSecretVaultFromSecretCopy({
+      credential,
+      secret: secretCopy,
+    });
   } finally {
     secretCopy.fill(0);
     prfOutput?.fill(0);
@@ -315,9 +326,10 @@ async function createSecretVaultWithNewPasskey({
  * discoverable credential for the relying party.
  *
  * A fresh random PRF salt is generated internally and stored in the returned
- * vault. `secret` and `credential` are copied before the ceremony starts, so
- * post-call mutation does not change the operation. The internal secret and
- * PRF output are zeroed before the function finishes, even when it fails.
+ * vault. `secret` is copied once, and `credential` is copied before the
+ * ceremony starts, so post-call mutation does not change the operation. The
+ * internal secret and PRF output are zeroed before the function finishes, even
+ * when it fails.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `secret` is empty, or `credential.credentialId` is empty or not canonical base64url.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -346,7 +358,7 @@ async function createSecretVaultWithExistingPasskey({
     });
     prfOutput = evaluated.prfOutput;
 
-    return await createSecretVault({
+    return await createSecretVaultFromSecretCopy({
       credential: {
         credentialId: evaluated.credentialId,
         ...(credentialCopy?.credentialId === evaluated.credentialId &&

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -250,7 +250,7 @@ type CreateSecretVaultWithExistingPasskeyOptions = Omit<
   secret: Uint8Array;
 };
 
-/** Copies and validates a secret before a WebAuthn ceremony can start. */
+/** Copies and validates a secret before async ceremony or crypto work starts. */
 function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
   if (secret.length === 0) {
     throw new MeraError("INPUT_INVALID", "secret must not be empty");


### PR DESCRIPTION
The high-level vault workflows snapshot the caller's secret before a WebAuthn prompt, then call the public low-level primitive, which takes a second snapshot. That temporarily keeps two library-owned copies of the same secret without strengthening the mutation or lifetime guarantees.

This adds a private encryption path for a snapshot already owned by its caller. High-level creation takes one copy before WebAuthn, reuses it for encryption, and zeroes it in the existing `finally`. Direct `createSecretVault` calls still take and zero their own snapshot, so public behavior and caller-buffer ownership are unchanged.

The wire format and cryptographic operations are unchanged. Existing mutation, failure, zeroing, and real-browser vault tests cover both high-level paths.

Validation:

- `npm run check`
- `npm test` (77 tests)
- documentation `npm run build`
