### PR TITLE
Specialize vault key derivation

### DIFF
--- a/src/secret.ts
+++ b/src/secret.ts
@@ -21,7 +21,7 @@ import type {
   PasskeyPrfResult,
   PasskeySecretVault,
 } from "./types.js";
-import { getCrypto, hkdfSha256AesGcmKey, randomBytes } from "./webcrypto.js";
+import { getCrypto, randomBytes } from "./webcrypto.js";
 
 const PRF_SALT_LENGTH = 32;
 const PRF_OUTPUT_LENGTH = 32;
@@ -46,14 +46,39 @@ type EncryptedBytes = {
   ciphertext: Uint8Array;
 };
 
-// Derives the vault encryption key. The 32-byte check validates caller-supplied
-// PRF output at the public boundary before it becomes key material.
+// Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256. The
+// fixed info domain-separates this key from other uses of the same PRF output.
+// asArrayBuffer snapshots the output before importKey's first await, preserving
+// the public copy guarantee while the 32-byte check validates the key material.
 async function deriveEncryptionKey(prfOutput: Uint8Array): Promise<CryptoKey> {
   if (prfOutput.length !== PRF_OUTPUT_LENGTH) {
     throw new MeraError("INPUT_INVALID", "PRF output must be 32 bytes");
   }
 
-  return hkdfSha256AesGcmKey(prfOutput, SECRET_ENCRYPTION_INFO);
+  const crypto = getCrypto();
+  const material = await crypto.subtle.importKey(
+    "raw",
+    asArrayBuffer(prfOutput),
+    "HKDF",
+    false,
+    ["deriveKey"],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(0),
+      info: asArrayBuffer(SECRET_ENCRYPTION_INFO),
+    },
+    material,
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    false,
+    ["encrypt", "decrypt"],
+  );
 }
 
 // AES-256-GCM encrypt. subtle.encrypt copies its inputs synchronously and the
@@ -203,7 +228,7 @@ async function createSecretVault({
   const secretCopy = copyBytes(secret);
 
   try {
-    // The copy guarantee for prfOutput is provided by hkdfSha256AesGcmKey,
+    // The copy guarantee for prfOutput is provided by deriveEncryptionKey,
     // which snapshots it synchronously before its first await.
     const encryptionKey = await deriveEncryptionKey(prfOutput);
     const encrypted = await aesGcmEncrypt({
@@ -389,7 +414,7 @@ async function decryptSecretVault({
   vault,
   prfOutput,
 }: DecryptSecretVaultOptions): Promise<Uint8Array<ArrayBuffer>> {
-  // The copy guarantee documented above is provided by hkdfSha256AesGcmKey,
+  // The copy guarantee documented above is provided by deriveEncryptionKey,
   // which snapshots prfOutput synchronously before its first await.
   const encryptionKey = await deriveEncryptionKey(prfOutput);
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -228,8 +228,6 @@ async function createSecretVault({
   const secretCopy = copyBytes(secret);
 
   try {
-    // The copy guarantee for prfOutput is provided by deriveEncryptionKey,
-    // which snapshots it synchronously before its first await.
     const encryptionKey = await deriveEncryptionKey(prfOutput);
     const encrypted = await aesGcmEncrypt({
       plaintext: secretCopy,
@@ -414,8 +412,6 @@ async function decryptSecretVault({
   vault,
   prfOutput,
 }: DecryptSecretVaultOptions): Promise<Uint8Array<ArrayBuffer>> {
-  // The copy guarantee documented above is provided by deriveEncryptionKey,
-  // which snapshots prfOutput synchronously before its first await.
   const encryptionKey = await deriveEncryptionKey(prfOutput);
 
   return aesGcmDecrypt({

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -1,4 +1,3 @@
-import { asArrayBuffer } from "./encoding.js";
 import { MeraError } from "./errors.js";
 
 /**
@@ -28,48 +27,4 @@ function getCrypto(): Crypto {
   return globalThis.crypto;
 }
 
-/**
- * Derives a non-extractable AES-256-GCM key with HKDF-SHA-256 and an empty salt.
- *
- * @param ikm - Input keying material.
- * @param info - HKDF info/context bytes; domain-separates keys derived from the same `ikm`.
- * @returns A non-extractable AES-GCM `CryptoKey` usable for encryption and decryption.
- * @remarks
- * `ikm` and `info` are copied into standalone buffers synchronously, before
- * the first `await`, so mutating either input after the call starts does not
- * affect the derived key. Public copy guarantees (`decryptSecretVault`'s
- * `prfOutput` remark) rest on this ordering; the copies must stay ahead of
- * every `await`.
- * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
- */
-async function hkdfSha256AesGcmKey(
-  ikm: Uint8Array,
-  info: Uint8Array,
-): Promise<CryptoKey> {
-  const crypto = getCrypto();
-  const material = await crypto.subtle.importKey(
-    "raw",
-    asArrayBuffer(ikm),
-    "HKDF",
-    false,
-    ["deriveKey"],
-  );
-
-  return crypto.subtle.deriveKey(
-    {
-      name: "HKDF",
-      hash: "SHA-256",
-      salt: new Uint8Array(0),
-      info: asArrayBuffer(info),
-    },
-    material,
-    {
-      name: "AES-GCM",
-      length: 256,
-    },
-    false,
-    ["encrypt", "decrypt"],
-  );
-}
-
-export { getCrypto, hkdfSha256AesGcmKey, randomBytes };
+export { getCrypto, randomBytes };


### PR DESCRIPTION
The internal HKDF helper accepts arbitrary input material and context even though its only caller always derives the same secret-vault AES key. That generality makes the security-critical context another value a caller must supply correctly.

This moves the derivation into the vault module and removes the generic helper. HKDF-SHA-256, the empty salt, `mera.v1.encrypt.secret` info, AES-256-GCM output, non-extractability, and encrypt/decrypt usages are unchanged. The PRF output is still copied before the first `await`, preserving the public mutation guarantee.

Vault wire compatibility is unchanged; existing vaults derive the same key and continue to decrypt.

Validation:

- `npm run check`
- `npm test` (77 tests)

Reference: https://www.rfc-editor.org/rfc/rfc5869.html#section-3.2
