### PR TITLE
Give every repeated docs fact one owning page

### DIFF
--- a/docs/src/content/docs/authenticator-support.md
+++ b/docs/src/content/docs/authenticator-support.md
@@ -31,7 +31,7 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local profile authenticator lacks [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) primitive behind PRF.
 
-Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts). Either way the passkey exists but returns no PRF output, so mera cannot use it. [createPasskey](/reference/create-passkey/) fails only after the creation ceremony has completed, so the unusable passkey stays in the authenticator's passkey list.
+Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts). Either way the passkey exists but returns no PRF output, so mera cannot use it: [createPasskey](/reference/create-passkey/) fails, and the unusable passkey stays in the authenticator's passkey list.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -6,7 +6,7 @@ description: How random bytes become a private key, an address, and a reproducib
 import DerivationPipeline from "../../../assets/diagrams/derivation-pipeline.svg";
 import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
 
-The rest of the docs assume the blockchain background this page teaches: how 32 random bytes become a private key, an account, and a reproducible family of accounts. Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
+The rest of the docs assume the blockchain background this page teaches. Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
 
 <DerivationPipeline />
 
@@ -24,7 +24,7 @@ The docs use two signature schemes, named for their curves: secp256k1 on Ethereu
 
 A key-derivation function (KDF) turns one secret into others: the output looks random, and the same input always produces the same output. Because a KDF recomputes its outputs on demand, derived keys need no storage.
 
-A seed is the byte string a key tree starts from. BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, a scheme called hierarchical deterministic (HD) derivation, and a derivation path such as `m/44'/60'/0'/0/0` names one key in the tree. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account. (BIP is a Bitcoin Improvement Proposal; several became standards beyond Bitcoin.)
+A seed is the byte string a key tree starts from. BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, a scheme called hierarchical deterministic (HD) derivation, and a derivation path such as `m/44'/60'/0'/0/0` names one key in the tree. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account.
 
 <Bip32Tree />
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -3,7 +3,7 @@ title: Passkey accounts
 description: Accounts derived from a passkey's PRF output, with no stored secret.
 ---
 
-A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). No secret is stored anywhere: each ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, recomputes the same accounts. This is the default way to use mera.
+A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). Each ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, recomputes the same accounts. This is the default way to use mera.
 
 ## One salt, one stable output
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -21,13 +21,13 @@ The vault itself is ordinary JSON and can live in `localStorage`, on a backend, 
 
 ## The secret exists on its own
 
-The secret exists independently of the passkey: an account that predates it can be imported by encrypting its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext, the encrypted bytes. Decrypting it requires the passkey ceremony.
+The secret exists independently of the passkey: an account that predates it can be imported by encrypting its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext, the encrypted bytes.
 
 ## When to use a vault
 
-Use a vault when the key material must come from outside the passkey. The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs: losing the passkey still loses access through mera, but any surviving copy of the secret restores the account, while a passkey account is recoverable only through an export taken beforehand.
+The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs: losing the passkey still loses access through mera, but any surviving copy of the secret restores the account, while a passkey account is recoverable only through an export taken beforehand.
 
-The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account. That design burden is why vaults are the advanced option: when no secret exists yet, passkey accounts avoid the storage problem entirely.
+The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account. That design burden is why vaults are the advanced option.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -12,7 +12,7 @@ mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompt
 - Losing the passkey without a prior export loses the accounts derived from it. [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The secret-vault workflow functions generate a fresh random 32-byte salt per secret; on the low-level path, [createSecretVault](/reference/create-secret-vault/) leaves the fresh salt to the caller.
-- Dependencies are kept to a minimum: the only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.
+- The only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.
 
 <TrustBoundary />
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -31,7 +31,7 @@ Between construction and lock, a compromised runtime can request signatures with
 
 Unless the app kept the key somewhere else, fresh key material means another passkey ceremony: reproducing a derived key and decrypting a vault both start with one, so after `lock()` the next signature costs one more user-verification prompt. Session lifetime is a trade-off between that prompt and the open window.
 
-Frequent signing justifies a held session. A high-frequency trading app that ran a fresh ceremony per order would prompt constantly, so it keeps one session for the active burst of work and locks it when the burst ends.
+A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends.
 
 Apps that sign occasionally are better served by holding no session at all: derive the public key, identify the account by its address, and zero the private key right away. The next signature then starts with a fresh ceremony.
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -5,7 +5,7 @@ description: Install the library, derive an account, and make a first signature.
 
 import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
-A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory. The [security model](/concepts/security-model/) states what that trusts.
+A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory ([security model](/concepts/security-model/)).
 
 Prerequisites:
 
@@ -26,7 +26,7 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call. The salt is a 32-byte input that acts as a namespace. For one passkey and salt, the returned 32 bytes are always the same.
+`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call. The salt is a 32-byte input that acts as a namespace.
 
 ```ts
 import { createPasskeyWithPrfOutput } from "@category-labs/mera";
@@ -101,8 +101,6 @@ Without `credential`, the browser offers any discoverable passkey it holds for t
 ## From passkey to signature
 
 <GettingStartedOverview />
-
-Each sign-in repeats this pipeline: the same passkey and salt return the same 32 bytes, and no secret is stored anywhere.
 
 ## Where next
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -131,7 +131,7 @@ function deriveSolanaAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-The derivation paths are an app choice; these two are the conventions wallet apps share. A phrase imported into a wallet app that follows them (MetaMask and Phantom are two) reproduces the same addresses, so accounts keep an exit path that does not depend on mera.
+The derivation paths are an app choice; these two are the conventions wallet apps share, so an imported phrase reproduces the same addresses ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/#seed-phrases)).
 
 Build the account list from these helpers:
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -21,7 +21,7 @@ The call runs one ceremony with one user-verification prompt, the only prompt in
 
 ## Derive the key
 
-The seed comes from the same mapping [Create passkey accounts](/recipes/create-passkey-accounts/) uses: the PRF output becomes [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) entropy, the seed feeds [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), and `m/44'/60'/0'/0/0` is the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces the standards). Matching that recipe exactly means both flows reach the same address.
+The seed comes from the same mapping [Create passkey accounts](/recipes/create-passkey-accounts/) uses: the PRF output becomes [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) entropy, the seed feeds [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), and `m/44'/60'/0'/0/0` is the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces the standards).
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -37,7 +37,7 @@ if (node.privateKey === null) throw new Error("derivation produced no key");
 
 ## Create the viem account
 
-`toViemAccount` lives in the `@category-labs/mera/viem` entry point, which requires the optional `viem` peer dependency. The root entry point does not use viem.
+`toViemAccount` lives in the `@category-labs/mera/viem` entry point, which requires the optional `viem` peer dependency.
 
 ```ts
 import { createSecp256k1SigningSession } from "@category-labs/mera";
@@ -74,7 +74,7 @@ const hash = await client.sendTransaction({
 session.lock();
 ```
 
-`sepolia` is Ethereum's Sepolia test network. `http()` with no URL uses the chain's default public RPC endpoint. RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL. Signing shows no passkey prompt: the one prompt happened at sign-in, and the session covers every signature until it is locked.
+`sepolia` is Ethereum's Sepolia test network. `http()` with no URL uses the chain's default public RPC endpoint. RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL.
 
 `sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query. viem's `waitForTransactionReceipt` on a public client covers it.
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey; mera never interprets it. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
 
@@ -44,7 +44,7 @@ try {
 }
 ```
 
-The function copies the secret before the passkey prompt and zeroes its internal secret and PRF output before it finishes, even when it fails. The [PRF output](/concepts/passkeys-and-prf/) keys the encryption. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
+The [PRF output](/concepts/passkeys-and-prf/) keys the encryption. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
 
 ## Unlock
 
@@ -70,7 +70,7 @@ async function unlockPhrase(): Promise<string> {
 }
 ```
 
-`parseSecretVault` is the boundary for the untrusted stored JSON. The decrypt function owns and zeroes the transient PRF output. The decrypted buffer is a fresh allocation, so the `finally` zeroes it after decoding.
+`parseSecretVault` is the boundary for the untrusted stored JSON. The decrypted buffer is a fresh allocation, so the `finally` zeroes it after decoding.
 
 ## Derive signing sessions
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -59,7 +59,7 @@ Zeroes the session-owned private-key copy and permanently locks the session; lat
 
 ### [Symbol.dispose]()
 
-Calls `lock`, so a `using` declaration locks the session when its scope exits. Sessions bound with `const` or `let` are unaffected; disposal runs only where a caller opts in with `using`.
+Calls `lock`, so a `using` declaration locks the session when its scope exits.
 
 ## Errors
 
@@ -67,8 +67,6 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits. S
 - [`SESSION_LOCKED`](/reference/errors/#session_locked): `signMessage` was called after `lock`.
 
 ## Notes
-
-Signing needs no passkey ceremony and shows no prompt; the session signs as often as the app asks until it is locked.
 
 The message is read before `signMessage` returns; mutating the buffer after the call cannot change what was signed.
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -79,13 +79,11 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key, and required user verification. Resident key is the WebAuthn term for a [discoverable](/concepts/passkeys-and-prf/) credential. The user-verification requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the PRF output nor remove the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
+The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key, and required user verification. Resident key is the WebAuthn term for a [discoverable](/concepts/passkeys-and-prf/) credential. The user-verification requirement is not configurable; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
 The WebAuthn challenge is generated internally. The raw attestation response is not returned.
 
 A [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable) failure happens after the creation ceremony has completed: the passkey exists on the authenticator and appears in its passkey list, but the thrown error does not carry its metadata.
-
-WebAuthn availability is checked before Web Crypto, so an environment missing both throws [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed).
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -68,16 +68,12 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits:
 } // locked here
 ```
 
-Sessions bound with `const` or `let` are unaffected; disposal runs only where a caller opts in with `using`.
-
 ## Errors
 
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `privateKey` is not a valid secp256k1 scalar, or `digest32` is not 32 bytes.
 - [`SESSION_LOCKED`](/reference/errors/#session_locked): `signDigest` was called after `lock`.
 
 ## Notes
-
-Signing needs no passkey ceremony and shows no prompt; the session signs as often as the app asks until it is locked.
 
 The digest is read before `signDigest` returns; mutating the buffer after the call cannot change what was signed.
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -49,7 +49,7 @@ Web Crypto is unavailable. In practice this means the page is running outside a 
 
 ### PRF_UNAVAILABLE
 
-The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path this fires after the creation ceremony has completed, so the passkey exists on the authenticator even though the error carries no metadata ([createPasskey](/reference/create-passkey/) documents the create path). [Authenticator support](/authenticator-support/) lists tested compatible stacks.
+The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path the passkey may already exist; [createPasskey](/reference/create-passkey/) documents that behavior. [Authenticator support](/authenticator-support/) lists tested compatible stacks.
 
 ### SESSION_LOCKED
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -17,7 +17,6 @@ import { getDeterministicPrfSaltV1 } from "@category-labs/mera";
 
 ```ts
 const prfSalt = getDeterministicPrfSaltV1();
-// 32 bytes, identical on every call and every mera version.
 ```
 
 ## Parameters

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -64,13 +64,9 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The PRF output is a deterministic function of the credential, `rpId`, and salt. The same inputs reproduce the same 32 bytes, and a different salt yields an unrelated output. The default salt is permanently the fixed v1 value.
-
-The assertion requires user verification, and the requirement is not configurable: the PRF extension evaluates only the credential's user-verified PRF, so a `userVerification` setting could neither change the output nor skip the check. [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
+The assertion requires user verification, and the requirement is not configurable; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
 The WebAuthn challenge is generated internally. The raw assertion response is not returned.
-
-WebAuthn availability is checked before Web Crypto, so an environment missing both throws [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed).
 
 ## See also
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -36,8 +36,6 @@ A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The creden
 
 ## Notes
 
-A vault that came through this function cannot trigger the [`INPUT_INVALID`](/reference/errors/#input_invalid) re-checks in [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), [decryptSecretVault](/reference/decrypt-secret-vault/), or [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/). Cryptographic failure ([`DECRYPT_FAILED`](/reference/errors/#decrypt_failed)) and ceremony failure remain possible.
-
 Rejecting an unknown version keeps an old library from misreading data written by a newer format.
 
 ## See also

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -48,11 +48,7 @@ The AES-GCM ciphertext including its 16-byte authentication tag, the value decry
 
 The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
 
-The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key, and their nonce/ciphertext pairs become interchangeable to anyone who can rewrite stored JSON.
-
-## Portability
-
-The vault is plain JSON suitable for `localStorage`, a database, a file, or a sync service. Decryption requires the passkey ceremony and user verification.
+The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key ([createSecretVault](/reference/create-secret-vault/) documents the risk).
 
 ## See also
 

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -110,8 +110,7 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * @returns Credential metadata, plus the first PRF output when `prfSalt` was provided and evaluated during creation.
  * @remarks
  * Invokes `navigator.credentials.create()`, which may show browser or
- * authenticator UI. WebAuthn availability is checked before Web Crypto, so an
- * environment missing both throws `PASSKEY_OPERATION_FAILED`.
+ * authenticator UI.
  *
  * The WebAuthn challenge is generated internally. The raw attestation response
  * is not returned.
@@ -120,10 +119,8 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * attestation `"none"`, a required resident key, and required user
  * verification. User verification is the authenticator's local check; the
  * gesture depends on the platform (a biometric, a device PIN, or a password).
- * The requirement is not configurable: the PRF extension evaluates only the
- * credential's user-verified PRF, so a `userVerification` setting could
- * neither change the PRF output nor remove the check ({@link
- * getPasskeyPrfOutput} documents the authenticator mechanism).
+ * The requirement is not configurable ({@link getPasskeyPrfOutput} documents
+ * the authenticator mechanism).
  *
  * A `PRF_UNAVAILABLE` failure happens after the creation ceremony has
  * completed: the passkey exists on the authenticator, but the thrown error
@@ -227,8 +224,7 @@ async function createPasskey({
  * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks
  * Invokes `navigator.credentials.get()`, which may show browser or
- * authenticator UI. WebAuthn availability is checked before Web Crypto, so an
- * environment missing both throws `PASSKEY_OPERATION_FAILED`.
+ * authenticator UI.
  *
  * The WebAuthn challenge is generated internally. The raw assertion response is
  * not returned.


### PR DESCRIPTION
## Problem

A pre-release redundancy review of the docs site found the same facts restated in full across pages, against the docs' own rule that one page owns a detail and every other page links to it. The worst cases: the fresh-salt/shared-key mechanism appeared on six pages (twice with the full nonce/ciphertext-interchangeability explanation), the user-verification non-configurability mechanism on three, and the PRF determinism claim four times on Getting started alone. Duplicates like these mean a future behavior change has to be chased across the site.

## Approach

Each duplicated fact now has one owning page that carries the full mechanism; other mentions shrink to a short clause plus a link. Owners: [createSecretVault](https://github.com/category-labs/mera/blob/claude/docs-simplification-review-13a1e3/docs/src/content/docs/reference/create-secret-vault.md) for the shared-key risk, [Passkeys and the PRF extension](https://github.com/category-labs/mera/blob/claude/docs-simplification-review-13a1e3/docs/src/content/docs/concepts/passkeys-and-prf.mdx) for the user-verification mechanism, the concept pages for determinism.

Two notes are deleted rather than moved, on the grounds that they document nothing a reader can act on:

- "WebAuthn availability is checked before Web Crypto": error precedence in an environment missing both APIs.
- "Sessions bound with `const` or `let` are unaffected": JavaScript `using` semantics, not library behavior.

The same cuts land in the `src/passkey.ts` JSDoc so the reference pages stay aligned with their source of truth. `getPasskeyPrfOutput`'s JSDoc keeps the full user-verification mechanism: JSDoc cannot lean on a concept page, and it was already the designated owner within the source.

## Validation

Prose-only diff (27 insertions, 52 deletions). `npm run check`, `npm test` (77 passed), and `npm run check:pack` pass; the docs site builds, and the two newly linked anchors (`#seed-phrases`, `#user-verification`) were verified present in the built HTML.