### PR TITLE
Cut docs repetition and state the ceremony prompt plainly

### DIFF
--- a/docs/src/content/docs/authenticator-support.md
+++ b/docs/src/content/docs/authenticator-support.md
@@ -31,7 +31,7 @@ In the table, `✓` means a live PRF create + get cycle has been confirmed end-t
 
 On desktop Chrome, only passkeys saved to Google Password Manager carry PRF. The local profile authenticator lacks [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension), the [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html) primitive behind PRF.
 
-Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts). Either way the passkey exists but returns no PRF output, so mera cannot use it: [createPasskey](/reference/create-passkey/) fails, and the unusable passkey stays in the authenticator's passkey list.
+Chrome may create the passkey in the local profile instead of Google Password Manager when its "Offer to save passwords and passkeys" setting is off, or when a third-party password-manager extension intercepts WebAuthn and relays the browser fallback [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts). Either way the passkey exists but returns no PRF output, so mera cannot use it and [createPasskey](/reference/create-passkey/) fails.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -6,7 +6,7 @@ description: How random bytes become a private key, an address, and a reproducib
 import DerivationPipeline from "../../../assets/diagrams/derivation-pipeline.svg";
 import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
 
-This page teaches the blockchain background the rest of the docs assume; readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
+Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
 
 <DerivationPipeline />
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -6,7 +6,7 @@ description: How random bytes become a private key, an address, and a reproducib
 import DerivationPipeline from "../../../assets/diagrams/derivation-pipeline.svg";
 import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
 
-The rest of the docs assume the blockchain background this page teaches. Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
+This page teaches the blockchain background the rest of the docs assume; readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
 
 <DerivationPipeline />
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -7,11 +7,7 @@ A passkey account is a blockchain account whose keys derive from a passkey's PRF
 
 ## One salt, one stable output
 
-When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony. The app passes that output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
-
-## No stored state
-
-There is no stored secret; all state lives in the passkey. Once the passkey has synced to a new device, sign-in there is the same ceremony and produces the same accounts. During use, the PRF output and the keys derived from it are values in the page's memory, readable by any script on the page ([security model](/concepts/security-model/)).
+When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony, on every device the passkey syncs to. There is no stored secret; all state lives in the passkey. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## Losing the passkey
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -27,7 +27,7 @@ PRF output is determined by the credential, relying party ID, and salt. Those in
 
 ## Using the output
 
-The output is suitable as the root secret for accounts. It is stable wherever the passkey syncs, it appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony. The output, unlike the credential's private key, leaves the authenticator: it returns to the page, and every key derived from it lives in the page's memory ([security model](/concepts/security-model/)).
+The output is suitable as the root secret for accounts. It is stable wherever the passkey syncs, it appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony. The output, unlike the credential's private key, leaves the authenticator and returns to the page ([security model](/concepts/security-model/)).
 
 Passed to a [key-derivation scheme](/concepts/entropy-keys-and-accounts/), the output produces a hierarchy of accounts. Used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
 
@@ -39,7 +39,7 @@ A ceremony is one WebAuthn call and one user-verification prompt. A ceremony eit
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) chains the two: one prompt when the authenticator evaluates PRF at create time, two when it needs the follow-up assertion.
 
-Signing itself never prompts: a [signing session](/concepts/signing-sessions/) holds key material derived from a ceremony's output and signs until it is locked.
+Signing itself never prompts; it runs in a [signing session](/concepts/signing-sessions/) built from a ceremony's output.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -39,7 +39,7 @@ A ceremony is one WebAuthn call and one user-verification prompt. A ceremony eit
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) chains the two: one prompt when the authenticator evaluates PRF at create time, two when it needs the follow-up assertion.
 
-Signing itself never prompts; it runs in a [signing session](/concepts/signing-sessions/) built from a ceremony's output.
+Signing itself never prompts: it runs in a [signing session](/concepts/signing-sessions/) built from a ceremony's output.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -15,7 +15,7 @@ A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/T
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
 
-The requirement is not configurable. PRF is built on the [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) primitive of [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the protocol browsers use to talk to authenticators. An authenticator keeps two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a setting could neither change the output nor skip the check. mera does not offer one.
+The requirement is not configurable. PRF is built on the [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) primitive of [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the protocol browsers use to talk to authenticators. An authenticator keeps two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a setting could neither change the output nor skip the check.
 
 ## The PRF extension
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -13,21 +13,17 @@ A secret vault holds one secret (a recovery phrase, a private key, any bytes), e
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions evaluate the passkey's [PRF](/concepts/passkeys-and-prf/) against a fresh random 32-byte salt and store that salt in the vault. The resulting PRF output produces the key material that decrypts the secret. Secrets encrypted using a reused salt would share one encryption key, and exposing that key would expose all of them ([one output, one purpose](/concepts/security-model/)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions evaluate the passkey's [PRF](/concepts/passkeys-and-prf/) against a fresh random 32-byte salt and store that salt in the vault ([one output, one purpose](/concepts/security-model/)). The resulting PRF output produces the key material that decrypts the secret.
 
-The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service.
+The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service. The storage holds only ciphertext, the encrypted bytes.
 
 <VaultRoundtrip />
-
-## The secret exists on its own
-
-The secret exists independently of the passkey: an account that predates it can be imported by encrypting its recovery phrase or private key, and a copy of that secret may live somewhere else entirely. Custody of the vault is an app design question. The holder has only ciphertext, the encrypted bytes.
 
 ## When to use a vault
 
 The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs: losing the passkey still loses access through mera, but any surviving copy of the secret restores the account, while a passkey account is recoverable only through an export taken beforehand.
 
-The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account. That design burden is why vaults are the advanced option.
+The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,7 +5,7 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, produces the 32-byte [PRF output](/concepts/passkeys-and-prf/); the app turns that output into a private key, and the session does the signing.
+A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, produces the 32-byte [PRF output](/concepts/passkeys-and-prf/). The app turns that output into a private key, and the session does the signing.
 
 Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. A digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,19 +5,19 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony produces PRF output, the app turns that output into a private key, and the session does the signing. A ceremony is one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt. PRF output is the 32 secret bytes the passkey returns deterministically. [Passkeys and PRF](/concepts/passkeys-and-prf/) explains both.
+A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, produces the 32-byte [PRF output](/concepts/passkeys-and-prf/); the app turns that output into a private key, and the session does the signing.
 
 Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. A digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 
 ## Independent of passkeys
 
-A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere. The session does not record where the key came from. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design. [Passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
+A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design. [Passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
 
 Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the ceremony that produced the entropy, and it covers any number of signatures.
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, there is no unlock, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -82,11 +82,11 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key and signs without further passkey prompts. `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) the session's copy. A locked session throws on signing.
+The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key; `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) that copy. A locked session throws on signing.
 
 ## Sign back in
 
-A later visit needs no stored secret: the same assertion with the same salt returns the same 32 bytes, and with them the same account.
+A later visit needs no stored secret: the same assertion reproduces the account.
 
 ```ts
 import { getPasskeyPrfOutput } from "@category-labs/mera";

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -26,7 +26,7 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call. The salt is a 32-byte input that acts as a namespace.
+`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call.
 
 ```ts
 import { createPasskeyWithPrfOutput } from "@category-labs/mera";
@@ -39,13 +39,13 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 });
 ```
 
-The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF. An assertion is a second WebAuthn call, one that uses the new passkey.
+The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF.
 
-mera uses its fixed v1 salt for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
+mera uses its [fixed v1 salt](/reference/get-deterministic-prf-salt-v1/) for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 
-The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), which encodes entropy as a phrase of common words. [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) then derives numbered keys from the [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation) computed from that phrase, so a wallet app that follows both standards can import the account.
+The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), so a wallet app that follows both standards can import the account.
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -104,9 +104,6 @@ Without `credential`, the browser offers any discoverable passkey it holds for t
 
 ## Where next
 
-- [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): the background behind the terms this page glosses.
-- [Create passkey accounts](/recipes/create-passkey-accounts/): numbered accounts, credential pinning, Solana keys.
 - [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): from sign-in to a sent transaction.
 - [Passkey accounts](/concepts/passkey-accounts/): why the same passkey reproduces the same accounts, and what losing it means.
 - [Secret vaults](/concepts/secret-vaults/): encrypting a secret that already exists behind the passkey.
-- [API reference](/reference/): every function used on this page.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -82,7 +82,7 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key; `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) that copy. A locked session throws on signing.
+The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key, and `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) that copy. A locked session throws on signing.
 
 ## Sign back in
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -131,8 +131,6 @@ function deriveSolanaAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-The derivation paths are an app choice; these two are the conventions wallet apps share, so an imported phrase reproduces the same addresses ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/#seed-phrases)).
-
 Build the account list from these helpers:
 
 ```ts

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -101,7 +101,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32. The path is `m/44'/501'/{index}'/0'`, the one Phantom and Solflare use; 501 is Solana's registered coin type. A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
+Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32. The path is `m/44'/501'/{index}'/0'`, the one Phantom and Solflare use, and 501 is Solana's registered coin type. A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -81,7 +81,7 @@ session.lock();
 ## Pitfalls
 
 - **The derivation must match the app's other sign-in paths.** This recipe repeats the mapping and path from [Create passkey accounts](/recipes/create-passkey-accounts/). A different mapping or path reaches a different address.
-- **A locked session rejects every viem signing method** with [`SESSION_LOCKED`](/reference/errors/#session_locked), and the account has no key of its own. Keep the session for the active burst of work, lock it when the burst ends, and build a new session from a fresh ceremony for the next one ([Signing sessions](/concepts/signing-sessions/)).
+- **A locked session rejects every viem signing method** with [`SESSION_LOCKED`](/reference/errors/#session_locked), and the account has no key of its own.
 - **Concurrent transactions can be assigned the same nonce**, the per-account counter that orders transactions, and the chain accepts only one of them. viem's nonce manager assigns nonces in sequence. Pass it through [toViemAccount](/reference/to-viem-account/) options.
 
 ## See also

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -74,7 +74,7 @@ const hash = await client.sendTransaction({
 session.lock();
 ```
 
-`sepolia` is Ethereum's Sepolia test network. `http()` with no URL uses the chain's default public RPC endpoint. RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL.
+`http()` with no URL uses the chain's default public RPC endpoint. RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL.
 
 `sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query. viem's `waitForTransactionReceipt` on a public client covers it.
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -5,8 +5,6 @@ description: Encrypt an existing secret into a passkey-protected vault and unloc
 
 A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
-The surrounding code is app-owned; mera provides the passkey ceremonies and vault functions.
-
 ## Validate the phrase
 
 A real app reads the phrase from a form field. The library never interprets the secret, so validation is app code:
@@ -24,7 +22,7 @@ if (!validateMnemonic(phrase, wordlist)) {
 
 ## Create and persist the vault
 
-`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension), creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault. A separate salt for each vault avoids shared encryption keys ([one output, one purpose](/concepts/security-model/)).
+`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension) per vault ([one output, one purpose](/concepts/security-model/)), creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault.
 
 ```ts
 import { createSecretVaultWithNewPasskey } from "@category-labs/mera";

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -3,7 +3,7 @@ title: createPasskeyWithPrfOutput
 description: Creates a passkey and returns its deterministic PRF output in one call.
 ---
 
-Creates a passkey and returns its [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output. It runs [createPasskey](/reference/create-passkey/)'s creation ceremony, which may show browser or authenticator UI; when that ceremony returns no `prfOutput`, it runs [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt, which may show a second prompt.
+Creates a passkey and returns its [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF output. It runs [createPasskey](/reference/create-passkey/)'s creation ceremony and shows one user-verification prompt; when that ceremony returns no `prfOutput`, it runs [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt, which shows a second.
 
 ## Import
 
@@ -79,7 +79,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Notes
 
-WebAuthn challenges are generated internally. Raw attestation and assertion responses are not returned.
+WebAuthn challenges are generated internally.
 
 If the fallback ceremony fails, the passkey from the completed creation ceremony still exists on the authenticator, but the thrown error does not carry its metadata.
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -79,7 +79,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key, and required user verification. Resident key is the WebAuthn term for a [discoverable](/concepts/passkeys-and-prf/) credential. The user-verification requirement is not configurable; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
+The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key, and required user verification. Resident key is the WebAuthn term for a [discoverable](/concepts/passkeys-and-prf/) credential. The user-verification requirement is not configurable ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism).
 
 The WebAuthn challenge is generated internally.
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -83,7 +83,7 @@ The credential is requested with fixed parameters: ES256 or RS256 key types, att
 
 The WebAuthn challenge is generated internally.
 
-A [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable) failure happens after the creation ceremony has completed: the passkey exists on the authenticator and appears in its passkey list, but the thrown error does not carry its metadata.
+A [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable) failure happens after the creation ceremony has completed: the passkey exists on the authenticator, but the thrown error does not carry its metadata.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-passkey.md
+++ b/docs/src/content/docs/reference/create-passkey.md
@@ -3,7 +3,7 @@ title: createPasskey
 description: Creates a discoverable, user-verified passkey with the WebAuthn PRF extension enabled.
 ---
 
-Creates a [discoverable](/concepts/passkeys-and-prf/), user-verified passkey with the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension enabled. Runs one `navigator.credentials.create()` ceremony, which may show browser or authenticator UI.
+Creates a [discoverable](/concepts/passkeys-and-prf/), user-verified passkey with the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension enabled. Runs one `navigator.credentials.create()` ceremony and shows one user-verification prompt.
 
 ## Import
 
@@ -81,7 +81,7 @@ WebAuthn timeout in milliseconds.
 
 The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key, and required user verification. Resident key is the WebAuthn term for a [discoverable](/concepts/passkeys-and-prf/) credential. The user-verification requirement is not configurable; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
-The WebAuthn challenge is generated internally. The raw attestation response is not returned.
+The WebAuthn challenge is generated internally.
 
 A [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable) failure happens after the creation ceremony has completed: the passkey exists on the authenticator and appears in its passkey list, but the thrown error does not carry its metadata.
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -3,7 +3,7 @@ title: createSecretVaultWithExistingPasskey
 description: Encrypts one secret into a vault using an existing passkey and a fresh random salt.
 ---
 
-Evaluates an existing passkey and encrypts one secret into a vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Evaluates an existing passkey and encrypts one secret into a vault. Runs one `navigator.credentials.get()` ceremony and shows one user-verification prompt.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -56,7 +56,7 @@ Credential metadata that restricts the assertion to one passkey. Reported transp
 - Type: `Uint8Array`
 - Required
 
-Secret bytes to encrypt. Any non-empty length; the library does not interpret them.
+Secret bytes to encrypt. Any non-empty length.
 
 ### options.timeout
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -3,7 +3,7 @@ title: createSecretVaultWithNewPasskey
 description: Creates a passkey and encrypts one secret into a vault with a fresh random salt.
 ---
 
-Creates a passkey and encrypts one secret into a vault. Runs one `navigator.credentials.create()` ceremony and may run a fallback `navigator.credentials.get()` ceremony, so it may show one or two browser prompts.
+Creates a passkey and encrypts one secret into a vault. Runs one `navigator.credentials.create()` ceremony and may run a fallback `navigator.credentials.get()` ceremony, so it shows one or two user-verification prompts.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -50,7 +50,7 @@ User identity passed to WebAuthn. `id` must be 1 to 64 bytes when provided. A fr
 - Type: `Uint8Array`
 - Required
 
-Secret bytes to encrypt. Any non-empty length; the library does not interpret them.
+Secret bytes to encrypt. Any non-empty length.
 
 ### options.timeout
 

--- a/docs/src/content/docs/reference/create-secret-vault.md
+++ b/docs/src/content/docs/reference/create-secret-vault.md
@@ -55,7 +55,7 @@ The passkey credential plus the PRF salt and the PRF output it produced. A [crea
 - Type: `Uint8Array`
 - Required
 
-Secret bytes to encrypt. Any non-empty length; the library does not interpret them.
+Secret bytes to encrypt. Any non-empty length.
 
 ## Returns
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -3,7 +3,7 @@ title: decryptSecretVaultWithPasskey
 description: Performs a passkey assertion and decrypts one secret vault.
 ---
 
-Performs the passkey [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) for a parsed vault and decrypts its secret. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Performs the passkey [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) for a parsed vault and decrypts its secret. Runs one `navigator.credentials.get()` ceremony and shows one user-verification prompt.
 
 ## Import
 
@@ -72,7 +72,7 @@ WebAuthn timeout in milliseconds.
 
 The vault is copied before the assertion starts, so post-call mutation changes neither the credential restriction nor the ciphertext being decrypted. The transient PRF output is zeroed before the function finishes, even when decryption fails.
 
-The WebAuthn challenge is generated internally, and the raw assertion response is not returned.
+The WebAuthn challenge is generated internally.
 
 ## See also
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -49,7 +49,7 @@ Web Crypto is unavailable. In practice this means the page is running outside a 
 
 ### PRF_UNAVAILABLE
 
-The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path the passkey may already exist; [createPasskey](/reference/create-passkey/) documents that behavior. [Authenticator support](/authenticator-support/) lists tested compatible stacks.
+The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path the passkey may already exist ([createPasskey](/reference/create-passkey/) documents that behavior). [Authenticator support](/authenticator-support/) lists tested compatible stacks.
 
 ### SESSION_LOCKED
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -31,12 +31,6 @@ None.
 
 None.
 
-## Notes
-
-The salt encodes no account selection: choosing account 0 versus account 7 happens in the derivation scheme the app applies to the PRF output.
-
-This salt belongs to passkey-account flows. The secret-vault creation functions generate and store 32 fresh random bytes for each vault ([one output, one purpose](/concepts/security-model/)).
-
 ## See also
 
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): evaluate a passkey with this default or an explicit salt.

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -35,7 +35,7 @@ None.
 
 The salt encodes no account selection. Selecting account 0 versus account 7 happens in the derivation scheme the app applies to the PRF output, never in the salt.
 
-This salt belongs to passkey-account flows. The secret-vault creation functions generate and store 32 fresh random bytes for each vault because vaults sharing one PRF output would share an encryption key.
+This salt belongs to passkey-account flows. The secret-vault creation functions generate and store 32 fresh random bytes for each vault ([one output, one purpose](/concepts/security-model/)).
 
 ## See also
 

--- a/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
+++ b/docs/src/content/docs/reference/get-deterministic-prf-salt-v1.md
@@ -33,7 +33,7 @@ None.
 
 ## Notes
 
-The salt encodes no account selection. Selecting account 0 versus account 7 happens in the derivation scheme the app applies to the PRF output, never in the salt.
+The salt encodes no account selection: choosing account 0 versus account 7 happens in the derivation scheme the app applies to the PRF output.
 
 This salt belongs to passkey-account flows. The secret-vault creation functions generate and store 32 fresh random bytes for each vault ([one output, one purpose](/concepts/security-model/)).
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -64,7 +64,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The assertion requires user verification, and the requirement is not configurable; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
+The assertion requires user verification, and the requirement is not configurable ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism).
 
 The WebAuthn challenge is generated internally.
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -3,7 +3,7 @@ title: getPasskeyPrfOutput
 description: Requests a passkey PRF evaluation and returns the output.
 ---
 
-Requests a passkey PRF evaluation and returns the output. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Requests a passkey PRF evaluation and returns the output. Runs one `navigator.credentials.get()` ceremony and shows one user-verification prompt.
 
 ## Import
 
@@ -66,7 +66,7 @@ WebAuthn timeout in milliseconds.
 
 The assertion requires user verification, and the requirement is not configurable; [Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism.
 
-The WebAuthn challenge is generated internally. The raw assertion response is not returned.
+The WebAuthn challenge is generated internally.
 
 ## See also
 

--- a/docs/src/content/docs/reference/get-secret-vault-prf-output.md
+++ b/docs/src/content/docs/reference/get-secret-vault-prf-output.md
@@ -3,7 +3,7 @@ title: getSecretVaultPrfOutput
 description: Performs the WebAuthn assertion needed to unlock a secret vault.
 ---
 
-Performs the [WebAuthn](https://www.w3.org/TR/webauthn-3/) [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony, which may show browser or authenticator UI.
+Performs the [WebAuthn](https://www.w3.org/TR/webauthn-3/) [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) needed to unlock a secret vault. Runs one `navigator.credentials.get()` ceremony and shows one user-verification prompt.
 
 Reads the credential metadata and PRF salt out of a parsed vault and delegates to [getPasskeyPrfOutput](/reference/get-passkey-prf-output/), so the assertion is automatically pinned to the credential that encrypted the secret.
 
@@ -68,7 +68,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The WebAuthn challenge is generated internally, and the raw assertion response is not returned.
+The WebAuthn challenge is generated internally.
 
 ## See also
 

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -3,7 +3,7 @@ title: getSolanaAddress
 description: Derives the base58-encoded Solana address for an Ed25519 public key.
 ---
 
-Derives the base58-encoded Solana address for an Ed25519 public key. A Solana address is the public key itself, base58-encoded; there is no hashing step.
+Derives the base58-encoded Solana address for an Ed25519 public key. A Solana address is the public key itself, base58-encoded.
 
 ## Import
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -42,7 +42,7 @@ The 12-byte [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonce, base64u
 
 ### ciphertext
 
-The AES-GCM ciphertext including its 16-byte authentication tag, the value decryption checks to detect tampering, base64url. The plaintext is the secret exactly as it was passed in; the library never interprets it.
+The AES-GCM ciphertext including its 16-byte authentication tag, the value decryption checks to detect tampering, base64url. The plaintext is the secret exactly as it was passed in.
 
 ## What is deliberately absent
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -48,7 +48,7 @@ The AES-GCM ciphertext including its 16-byte authentication tag, the value decry
 
 The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
 
-The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt; [createSecretVault](/reference/create-secret-vault/) documents the risk.
+The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt ([createSecretVault](/reference/create-secret-vault/) documents the risk).
 
 ## See also
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -52,8 +52,5 @@ The credential ID and salt are stored but not authenticated: neither is supplied
 
 ## See also
 
-- [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/) and [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): workflow functions that produce this format.
-- [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/): the workflow function that performs the assertion and decryption.
-- [createSecretVault](/reference/create-secret-vault/), [getSecretVaultPrfOutput](/reference/get-secret-vault-prf-output/), and [decryptSecretVault](/reference/decrypt-secret-vault/): low-level primitives for the same format.
 - [parseSecretVault](/reference/parse-secret-vault/): the validation boundary for stored JSON.
 - [Secret vaults](/concepts/secret-vaults/): where the vault fits.

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -48,7 +48,7 @@ The AES-GCM ciphertext including its 16-byte authentication tag, the value decry
 
 The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
 
-The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key ([createSecretVault](/reference/create-secret-vault/) documents the risk).
+The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt; [createSecretVault](/reference/create-secret-vault/) documents the risk.
 
 ## See also
 

--- a/docs/src/content/docs/reference/to-viem-account.md
+++ b/docs/src/content/docs/reference/to-viem-account.md
@@ -94,7 +94,7 @@ Signs a 32-byte hash directly, with no additional hashing, and resolves to the 6
 
 ## Notes
 
-Signatures are low-S (the signature's `s` value lies in the lower half of the curve order), which EVM chains require since [EIP-2](https://eips.ethereum.org/EIPS/eip-2); `signDigest` enforces this, so the adapter adds no normalization.
+Signatures are low-S (the signature's `s` value lies in the lower half of the curve order), which EVM chains require since [EIP-2](https://eips.ethereum.org/EIPS/eip-2); `signDigest` enforces this.
 
 ## See also
 

--- a/src/derived.ts
+++ b/src/derived.ts
@@ -8,8 +8,7 @@ const DETERMINISTIC_PRF_SALT = sha256(utf8ToBytes("mera.v1.deterministic.prf"));
  *
  * The salt is a constant and will not change across library versions, so one
  * passkey assertion against it produces one stable 32-byte PRF output per
- * credential and relying party. The salt encodes no account selection; that
- * happens in the derivation scheme the app applies to the PRF output.
+ * credential and relying party.
  *
  * @returns A fresh 32-byte copy of the fixed salt: a `Uint8Array` cannot be
  * frozen, so a shared buffer mutated by one caller would silently change every

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -109,11 +109,10 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyOptions}.
  * @returns Credential metadata, plus the first PRF output when `prfSalt` was provided and evaluated during creation.
  * @remarks
- * Invokes `navigator.credentials.create()`, which may show browser or
- * authenticator UI.
+ * Invokes `navigator.credentials.create()` and shows one user-verification
+ * prompt.
  *
- * The WebAuthn challenge is generated internally. The raw attestation response
- * is not returned.
+ * The WebAuthn challenge is generated internally.
  *
  * The credential is requested with fixed parameters: ES256 or RS256 key types,
  * attestation `"none"`, a required resident key, and required user
@@ -223,11 +222,10 @@ async function createPasskey({
  * @param options - Passkey PRF request inputs; fields are documented on {@link GetPasskeyPrfOutputOptions}.
  * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks
- * Invokes `navigator.credentials.get()`, which may show browser or
- * authenticator UI.
+ * Invokes `navigator.credentials.get()` and shows one user-verification
+ * prompt.
  *
- * The WebAuthn challenge is generated internally. The raw assertion response is
- * not returned.
+ * The WebAuthn challenge is generated internally.
  *
  * When `prfSalt` is omitted, the value returned by {@link
  * getDeterministicPrfSaltV1} is used. This default is stable across library
@@ -337,12 +335,11 @@ async function getPasskeyPrfOutput({
  * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyWithPrfOutputOptions}.
  * @returns Credential metadata and the first PRF output.
  * @remarks
- * Invokes `navigator.credentials.create()`. On authenticators that do not
- * evaluate PRF during creation, also invokes `navigator.credentials.get()`,
- * which means a second browser prompt.
+ * Invokes `navigator.credentials.create()` and shows one user-verification
+ * prompt. On authenticators that do not evaluate PRF during creation, also
+ * invokes `navigator.credentials.get()`, which shows a second.
  *
- * WebAuthn challenges are generated internally. Raw attestation and assertion
- * responses are not returned.
+ * WebAuthn challenges are generated internally.
  *
  * When `prfSalt` is omitted, the value returned by {@link
  * getDeterministicPrfSaltV1} is used. This default is stable across library

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -106,7 +106,7 @@ async function aesGcmEncrypt({
 }
 
 // AES-256-GCM decrypt. Authentication failures from a wrong key or tampered
-// nonce/ciphertext surface as DECRYPT_FAILED. The returned bytes are not interpreted.
+// nonce/ciphertext surface as DECRYPT_FAILED.
 async function aesGcmDecrypt({
   encrypted,
   encryptionKey,
@@ -171,7 +171,7 @@ type CreateSecretVaultOptions = {
     /** First WebAuthn PRF output for `prfSalt`. Must be exactly 32 bytes. */
     prfOutput: Uint8Array;
   };
-  /** Secret bytes to encrypt. Any non-empty length; the library does not interpret them. */
+  /** Secret bytes to encrypt. Any non-empty length. */
   secret: Uint8Array;
 };
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -273,10 +273,9 @@ function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
  * @param options - Passkey creation inputs and secret bytes; fields are documented on {@link CreateSecretVaultWithNewPasskeyOptions}.
  * @returns A JSON-safe secret vault containing the new credential metadata.
  * @remarks
- * Invokes `navigator.credentials.create()`, which may show browser or
- * authenticator UI. On authenticators that do not evaluate PRF during
- * creation, also invokes `navigator.credentials.get()`, which means a second
- * browser prompt.
+ * Invokes `navigator.credentials.create()` and shows one user-verification
+ * prompt. On authenticators that do not evaluate PRF during creation, also
+ * invokes `navigator.credentials.get()`, which shows a second.
  *
  * `secret` is copied and validated before either ceremony starts. Post-call
  * mutation does not change the encrypted secret. The internal secret and PRF
@@ -322,9 +321,9 @@ async function createSecretVaultWithNewPasskey({
  * @param options - Passkey assertion inputs and secret bytes; fields are documented on {@link CreateSecretVaultWithExistingPasskeyOptions}.
  * @returns A JSON-safe secret vault containing the selected credential metadata.
  * @remarks
- * Invokes `navigator.credentials.get()`, which may show browser or
- * authenticator UI. When `credential` is omitted, WebAuthn may choose any
- * discoverable credential for the relying party.
+ * Invokes `navigator.credentials.get()` and shows one user-verification
+ * prompt. When `credential` is omitted, WebAuthn may choose any discoverable
+ * credential for the relying party.
  *
  * A fresh random PRF salt is generated internally and stored in the returned
  * vault. `secret` and `credential` are copied before the ceremony starts, so
@@ -499,11 +498,10 @@ type GetSecretVaultPrfOutputOptions = {
  * @param options - Secret-vault PRF inputs; fields are documented on {@link GetSecretVaultPrfOutputOptions}.
  * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks
- * Invokes `navigator.credentials.get()`, which may show browser or
- * authenticator UI.
+ * Invokes `navigator.credentials.get()` and shows one user-verification
+ * prompt.
  *
- * The WebAuthn challenge is generated internally and the raw assertion
- * response is not returned.
+ * The WebAuthn challenge is generated internally.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when the vault's `prfSalt` is not canonical base64url or does not decode to 32 bytes, or `credentialId` is empty or not canonical base64url (already validated for vaults from `parseSecretVault`).
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -531,9 +529,8 @@ type DecryptSecretVaultWithPasskeyOptions = GetSecretVaultPrfOutputOptions;
  * @param options - Relying party and parsed vault; fields are documented on {@link DecryptSecretVaultWithPasskeyOptions}.
  * @returns The decrypted secret bytes. The returned buffer is a fresh allocation owned by the caller.
  * @remarks
- * Invokes `navigator.credentials.get()`, which may show browser or
- * authenticator UI. The assertion is restricted to the credential stored in
- * the vault.
+ * Invokes `navigator.credentials.get()` and shows one user-verification
+ * prompt. The assertion is restricted to the credential stored in the vault.
  *
  * The internal PRF output is zeroed before the function finishes, even when
  * decryption fails. The returned secret's lifetime belongs to the caller.


### PR DESCRIPTION
## Why

A pre-release review of all 33 docs pages found the remaining weight was repetition, not bad writing. The fresh-salt rationale appeared in seven places, PRF stability on five pages, and two concept sections only restated facts owned elsewhere. Each copy ages on its own and drifts, and the repo's own rule (AGENTS.md) is that a detail lives on the page that owns it while every other page links there. This pass gives each repeated fact one owner and shrinks the rest to links.

Two reference-page patterns were also wrong or empty. The lead hedge "may show browser or authenticator UI" underclaimed: every ceremony requires user verification, so the prompt is certain, and the leads now say so. "The raw response is not returned" restated what each Returns section already enumerates. Both patterns came from the JSDoc in `src/passkey.ts` and `src/secret.ts`, so the JSDoc changes with the docs to keep the source of truth aligned; the `src` diff is comment-only.

## Notes for reviewers

- Manual validation beyond CI: grep gates confirm the old phrasing is gone from both trees, nothing links the two removed section anchors (`#no-stored-state`, `#the-secret-exists-on-its-own`), and the diff adds no em dashes or banned vocabulary. The four most-edited pages (getting started, secret vaults, passkey accounts, signing sessions) were re-read end to end for flow.
- Net effect: docs content drops from 12,372 to 11,906 words, all of it prose; code blocks, tables, and diagrams are untouched.