### PR TITLE
Rename the default PRF salt to getMeraPrfSalt

### DIFF
--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -7,7 +7,7 @@ A passkey account is a blockchain account whose keys derive from a passkey's PRF
 
 ## One salt, one stable output
 
-When the PRF salt is omitted, mera uses its [fixed v1 salt](/reference/get-passkey-prf-output/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony, on every device the passkey syncs to. There is no stored secret; all state lives in the passkey. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
+When the PRF salt is omitted, mera uses its [fixed salt](/reference/get-passkey-prf-output/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony, on every device the passkey syncs to. There is no stored secret; all state lives in the passkey. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## Losing the passkey
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -41,7 +41,7 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 
 The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF.
 
-mera uses its [fixed v1 salt](/reference/get-passkey-prf-output/) for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
+mera uses its [fixed salt](/reference/get-passkey-prf-output/) for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -1,6 +1,6 @@
 ---
 title: createPasskeyWithPrfOutput
-description: Creates a passkey and returns its deterministic PRF output in one call.
+description: Creates a passkey and returns its PRF output in one call.
 ---
 
 Creates a [discoverable](/concepts/passkeys-and-prf/), user-verified passkey with the [WebAuthn](https://www.w3.org/TR/webauthn-3/) PRF extension enabled and returns its PRF output. It runs one creation ceremony and shows one user-verification prompt; when the authenticator does not evaluate the PRF at create time, it runs [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) with the same salt, which shows a second.
@@ -55,7 +55,7 @@ User handle stored with the discoverable credential. Must be 1 to 64 bytes when 
 ### options.prfSalt
 
 - Type: `Uint8Array`
-- Optional; defaults to mera's fixed v1 deterministic salt
+- Optional; defaults to mera's fixed salt
 
 32-byte PRF salt evaluated during creation or by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts). An explicit value supports custom PRF namespaces and low-level composition. It is copied before async WebAuthn work starts, so post-call mutation changes neither the fallback ceremony nor the returned salt.
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -40,7 +40,7 @@ Credential metadata that restricts the assertion to one passkey: a `credentialId
 ### options.prfSalt
 
 - Type: `Uint8Array`
-- Optional; defaults to mera's fixed v1 deterministic salt
+- Optional; defaults to mera's fixed salt
 
 PRF salt as 32 raw bytes. An explicit value supports custom PRF namespaces and low-level composition. It is copied before use.
 
@@ -64,7 +64,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-When `prfSalt` is omitted, the fixed v1 salt is used: `sha256("mera.v1.deterministic.prf")`. The salt will not change across library versions, so one assertion against it produces one stable 32-byte PRF output per credential and relying party, and another implementation can reproduce the output from the same constant. The salt encodes no account selection; that happens in the derivation scheme the app applies to the PRF output.
+When `prfSalt` is omitted, mera's fixed salt is used: `sha256("mera.v1.prf.salt")`. The salt will not change across library versions, so one assertion against it produces one stable 32-byte PRF output per credential and relying party, and another implementation can reproduce the output from the same constant. The salt encodes no account selection; that happens in the derivation scheme the app applies to the PRF output.
 
 The assertion requires user verification, and the requirement is not configurable ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism).
 

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -7,8 +7,8 @@ Each exported function has its own page. Types are documented on the pages of th
 
 ## Passkeys
 
-- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns its deterministic PRF output in one call.
-- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the deterministic output.
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/): creates a passkey and returns its PRF output in one call.
+- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): requests a passkey PRF evaluation and returns the output.
 
 ## Signing sessions
 

--- a/site/index.html
+++ b/site/index.html
@@ -661,7 +661,7 @@ clientDataJSON
 
         <p>
           A passkey account is computed from the passkey. mera's PRF output
-          methods use a fixed v1 salt by default, so the same passkey yields the
+          methods use a fixed salt by default, so the same passkey yields the
           same account. The application runs the passkey-derived bytes through
           its derivation scheme of choice; mera's demo wallet app feeds them
           into BIP-39 and derives keys with

--- a/src/derived.ts
+++ b/src/derived.ts
@@ -1,10 +1,10 @@
 import { sha256 } from "@noble/hashes/sha2.js";
 import { utf8ToBytes } from "@noble/hashes/utils.js";
 
-const DETERMINISTIC_PRF_SALT = sha256(utf8ToBytes("mera.v1.deterministic.prf"));
+const MERA_PRF_SALT = sha256(utf8ToBytes("mera.v1.prf.salt"));
 
 /**
- * Returns Mera's fixed v1 deterministic PRF salt: `sha256("mera.v1.deterministic.prf")`.
+ * Returns Mera's fixed PRF salt: `sha256("mera.v1.prf.salt")`.
  *
  * The salt is a constant and will not change across library versions, so one
  * passkey assertion against it produces one stable 32-byte PRF output per
@@ -14,8 +14,8 @@ const DETERMINISTIC_PRF_SALT = sha256(utf8ToBytes("mera.v1.deterministic.prf"));
  * frozen, so a shared buffer mutated by one caller would silently change every
  * later derivation.
  */
-function getDeterministicPrfSaltV1(): Uint8Array<ArrayBuffer> {
-  return new Uint8Array(DETERMINISTIC_PRF_SALT);
+function getMeraPrfSalt(): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(MERA_PRF_SALT);
 }
 
-export { getDeterministicPrfSaltV1 };
+export { getMeraPrfSalt };

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -1,4 +1,4 @@
-import { getDeterministicPrfSaltV1 } from "./derived.js";
+import { getMeraPrfSalt } from "./derived.js";
 import {
   asArrayBuffer,
   base64UrlDecode,
@@ -53,8 +53,7 @@ type CreatePasskeyOptions = {
  * Inputs for creating a passkey and obtaining its first WebAuthn PRF output in one call.
  *
  * Tightens `CreatePasskeyOptions`: `rp.id` is required so the fallback ceremony
- * can target the same relying party. `prfSalt` defaults to the fixed v1
- * deterministic salt.
+ * can target the same relying party. `prfSalt` defaults to Mera's fixed salt.
  */
 type CreatePasskeyWithPrfOutputOptions = Omit<
   CreatePasskeyOptions,
@@ -64,7 +63,7 @@ type CreatePasskeyWithPrfOutputOptions = Omit<
   rp: PublicKeyCredentialRpEntity & { id: string };
   /**
    * 32-byte PRF salt evaluated during creation, or by the fallback assertion.
-   * Defaults to the fixed v1 deterministic salt.
+   * Defaults to Mera's fixed salt.
    */
   prfSalt?: Uint8Array;
 };
@@ -76,7 +75,7 @@ type GetPasskeyPrfOutputOptions = {
   /** Credential metadata to restrict the assertion to one passkey. */
   credential?: PasskeyCredentialMetadata;
   /**
-   * PRF salt as 32 raw bytes. Defaults to the fixed v1 deterministic salt.
+   * PRF salt as 32 raw bytes. Defaults to Mera's fixed salt.
    * Copied before use.
    */
   prfSalt?: Uint8Array;
@@ -227,11 +226,11 @@ async function createPasskey({
  *
  * The WebAuthn challenge is generated internally.
  *
- * When `prfSalt` is omitted, the fixed v1 salt is used:
- * `sha256("mera.v1.deterministic.prf")`. This default will not change across
- * library versions. The PRF output is a deterministic function of the
- * credential, `rpId`, and salt: the same three inputs reproduce the same
- * output, and a different salt yields an unrelated output.
+ * When `prfSalt` is omitted, Mera's fixed salt is used:
+ * `sha256("mera.v1.prf.salt")`. This default will not change across
+ * library versions. The PRF output depends only on the credential, `rpId`,
+ * and salt: the same three inputs reproduce the same output, and a
+ * different salt yields an unrelated output.
  *
  * The assertion requires user verification, and the requirement is not
  * configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs
@@ -260,7 +259,7 @@ async function getPasskeyPrfOutput({
     }
 
     const prf = {
-      eval: { first: asArrayBuffer(prfSalt ?? getDeterministicPrfSaltV1()) },
+      eval: { first: asArrayBuffer(prfSalt ?? getMeraPrfSalt()) },
     };
 
     const publicKey: PublicKeyCredentialRequestOptions = {
@@ -348,8 +347,8 @@ async function getPasskeyPrfOutput({
  * The requirement is not configurable ({@link getPasskeyPrfOutput} documents
  * the authenticator mechanism).
  *
- * When `prfSalt` is omitted, the fixed v1 salt is used:
- * `sha256("mera.v1.deterministic.prf")`. This default will not change across
+ * When `prfSalt` is omitted, Mera's fixed salt is used:
+ * `sha256("mera.v1.prf.salt")`. This default will not change across
  * library versions.
  *
  * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of
@@ -369,7 +368,7 @@ async function createPasskeyWithPrfOutput({
   prfSalt,
 }: CreatePasskeyWithPrfOutputOptions): Promise<CreatePasskeyWithPrfOutputResult> {
   const prfSaltCopy =
-    prfSalt === undefined ? getDeterministicPrfSaltV1() : copyBytes(prfSalt);
+    prfSalt === undefined ? getMeraPrfSalt() : copyBytes(prfSalt);
 
   const credential = await createPasskey({
     rp,

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -1,16 +1,16 @@
 import { bytesToHex } from "@noble/hashes/utils.js";
 import { expect, test } from "@playwright/test";
-import { getDeterministicPrfSaltV1 } from "../dist/derived.js";
+import { getMeraPrfSalt } from "../dist/derived.js";
 
-test("returns the fixed v1 deterministic PRF salt", () => {
-  const salt = getDeterministicPrfSaltV1();
+test("returns Mera's fixed PRF salt", () => {
+  const salt = getMeraPrfSalt();
 
   expect(bytesToHex(salt)).toBe(
-    "0843291565a6314a928d60d0e51a6d0c46a82b3faaa6e47560b920312ba35f90",
+    "0372d7979ec1483f2f82d860d96f18058486fc65bf0f0cc1c1303aba83d0e772",
   );
 
   salt.fill(0);
-  expect(bytesToHex(getDeterministicPrfSaltV1())).toBe(
-    "0843291565a6314a928d60d0e51a6d0c46a82b3faaa6e47560b920312ba35f90",
+  expect(bytesToHex(getMeraPrfSalt())).toBe(
+    "0372d7979ec1483f2f82d860d96f18058486fc65bf0f0cc1c1303aba83d0e772",
   );
 });

--- a/test/passkey.e2e.ts
+++ b/test/passkey.e2e.ts
@@ -88,7 +88,7 @@ test("creates a PRF-capable passkey and returns stable PRF output", async ({
   });
 });
 
-test("PRF output helpers use the deterministic v1 salt by default", async ({
+test("PRF output helpers use Mera's fixed salt by default", async ({
   page,
 }) => {
   await withVirtualAuthenticator(page, async () => {
@@ -112,7 +112,7 @@ test("PRF output helpers use the deterministic v1 salt by default", async ({
       const documentedSalt = new Uint8Array(
         await crypto.subtle.digest(
           "SHA-256",
-          new TextEncoder().encode("mera.v1.deterministic.prf"),
+          new TextEncoder().encode("mera.v1.prf.salt"),
         ),
       );
 

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { getDeterministicPrfSaltV1 } from "../dist/derived.js";
+import { getMeraPrfSalt } from "../dist/derived.js";
 import {
   createPasskey,
   createPasskeyWithPrfOutput,
@@ -134,7 +134,7 @@ test("createPasskey without prfSalt does not evaluate or return PRF output", asy
   expect(createOptions?.extensions?.prf).toEqual({});
 });
 
-test("PRF output helpers default to Mera's fixed v1 salt", async () => {
+test("PRF output helpers default to Mera's fixed salt", async () => {
   const evaluatedSalts: Uint8Array[] = [];
 
   function readSalt(value: BufferSource | undefined): ArrayBuffer {
@@ -170,7 +170,7 @@ test("PRF output helpers default to Mera's fixed v1 salt", async () => {
   };
 
   await withStubbedGlobal("navigator", navigator, async () => {
-    const expected = getDeterministicPrfSaltV1();
+    const expected = getMeraPrfSalt();
     const created = await createPasskeyWithPrfOutput({
       rp: { id: "example.com", name: "Mera Test" },
       user: { name: "nad", displayName: "nad" },
@@ -192,7 +192,7 @@ test("PRF output helpers default to Mera's fixed v1 salt", async () => {
 
   expect(evaluatedSalts).toHaveLength(5);
   for (const salt of evaluatedSalts) {
-    expect(salt).toEqual(getDeterministicPrfSaltV1());
+    expect(salt).toEqual(getMeraPrfSalt());
   }
 });
 

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -1,6 +1,6 @@
 import { utf8ToBytes } from "@noble/hashes/utils.js";
 import { expect, test } from "@playwright/test";
-import { getDeterministicPrfSaltV1 } from "../dist/derived.js";
+import { getMeraPrfSalt } from "../dist/derived.js";
 import type {
   PasskeyCredentialTransport,
   PasskeySecretVault,
@@ -241,7 +241,7 @@ test("createSecretVaultWithNewPasskey owns a random salt and snapshots the secre
       transports: ["internal"],
     });
     expect(vault.prfSalt).not.toBe(
-      Buffer.from(getDeterministicPrfSaltV1()).toString("base64url"),
+      Buffer.from(getMeraPrfSalt()).toString("base64url"),
     );
     await expect(
       decryptSecretVault({ vault, prfOutput: evaluatedSalt }),


### PR DESCRIPTION
## Why

Users read "V1" aloud as "we want" and did not know what "deterministic" meant. Neither word earns its place in the name. Every constant is deterministic, so the word says nothing about the salt. And a salt change can only ship as a breaking change with a migration guide, arriving as a new function no matter what this one is called, so the version tag buys nothing in the name. The codebase already versions this way: the vault format carries a `version: 1` data field rather than a versioned function name.

Since the library is unreleased, the salt string changes too: `mera.v1.deterministic.prf` becomes `mera.v1.prf.salt`, matching the `mera.v1.encrypt.secret` family. The version tag stays inside the hashed string, where it separates domains without confusing readers. The docs sweep replaces "the fixed v1 deterministic salt" with "mera's fixed salt" everywhere the phrase mirrored the JSDoc.

## Notes for reviewers

The salt bytes change, so passkey accounts and vaults created against the old salt during development derive different keys. Nothing released depends on the old bytes.

Validated with `npm run check`, `npm test` (72 passed, including the e2e test that recomputes the salt from the documented string in a real browser), and the docs build.