### PR TITLE
Pin library dependencies to exact versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@noble/curves": "2.2.0",
-        "@noble/hashes": "^2.2.0",
-        "@scure/base": "^2.2.0"
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.4",
-        "@playwright/test": "^1.61.1",
-        "@types/node": "^24.13.3",
-        "publint": "^0.3.21",
-        "typescript": "^7.0.2",
-        "viem": "^2.55.2"
+        "@playwright/test": "1.61.1",
+        "@types/node": "24.13.3",
+        "publint": "0.3.21",
+        "typescript": "7.0.2",
+        "viem": "2.55.2"
       },
       "engines": {
         "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   },
   "dependencies": {
     "@noble/curves": "2.2.0",
-    "@noble/hashes": "^2.2.0",
-    "@scure/base": "^2.2.0"
+    "@noble/hashes": "2.2.0",
+    "@scure/base": "2.2.0"
   },
   "peerDependencies": {
     "viem": "^2.28.0"
@@ -72,11 +72,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.4",
-    "@playwright/test": "^1.61.1",
-    "@types/node": "^24.13.3",
-    "publint": "^0.3.21",
-    "typescript": "^7.0.2",
-    "viem": "^2.55.2"
+    "@playwright/test": "1.61.1",
+    "@types/node": "24.13.3",
+    "publint": "0.3.21",
+    "typescript": "7.0.2",
+    "viem": "2.55.2"
   },
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Why

Consumers install the library fresh from npm, so the ranges in `package.json` decide what resolves at their install time. Caret ranges let a compromised or broken future release of a dependency reach new installs with no change on our side. Exact pins close that window: a dependency moves only when a reviewed commit bumps it.

## Notes not visible in the diff

- The runtime closure is now fully exact: `@noble/curves` itself pins `@noble/hashes` at `2.2.0`, and `@scure/base` has no dependencies.
- Every pin matches the version already in the lockfile, so the installed tree is unchanged.
- The `viem` peer dependency stays a range on purpose. A peer describes what the consumer's app provides; an exact peer would force one viem version on every consumer. The dev dependency on viem, used in tests, is pinned.
- Docs and demo are untouched: they are apps whose own lockfiles already freeze installs, so exact ranges there add upgrade friction without a security gain.