### PR TITLE
Trim repeated facts and self-evident clauses from docs and JSDoc

### DIFF
--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -12,7 +12,7 @@ Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.m
 
 ## Keys, signatures, and accounts
 
-Entropy is randomness an attacker cannot predict, and 32 random bytes carry 256 bits of it. Searching 2^256 values is infeasible for any computer.
+Entropy is randomness an attacker cannot predict, and 32 random bytes carry 256 bits of it.
 
 A private key is a 256-bit secret number. A one-way function computes the public key from it, so the public key is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -3,7 +3,7 @@ title: Passkey accounts
 description: Accounts derived from a passkey's PRF output, with no stored secret.
 ---
 
-A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). Each ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, recomputes the same accounts. This is the default way to use mera.
+A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). Each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts. This is the default way to use mera.
 
 ## One salt, one stable output
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -7,7 +7,7 @@ import PrfFunction from "../../../assets/diagrams/prf-function.svg";
 
 A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords. A credential is one such key pair, created at a website's request by an authenticator: a phone, a password manager, or a hardware key. The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
-**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, ceremonies under the new domain cannot reach the old credential, so everything derived from it becomes unreachable there. The [security model](/concepts/security-model/) covers migrations in depth.
+**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, the old credential and everything derived from it are unreachable. The [security model](/concepts/security-model/) covers migrations in depth.
 
 **Passkeys sync.** Platform authenticators, the credential stores built into an operating system or a password manager, replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -35,7 +35,7 @@ Passed to a [key-derivation scheme](/concepts/entropy-keys-and-accounts/), the o
 
 A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential or runs an assertion, the call that uses an existing credential. In both, the authenticator proves possession of the key pair and can evaluate the PRF. mera runs both kinds:
 
-- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) makes the credential and returns the PRF output: one prompt when the authenticator evaluates PRF at create time, two when it needs a follow-up assertion.
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) makes the credential and returns the PRF output.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
 
 Signing itself never prompts: it runs in a [signing session](/concepts/signing-sessions/) built from a ceremony's output.

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -23,7 +23,7 @@ The vault itself is ordinary JSON and can live in `localStorage`, on a backend, 
 
 The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs. Losing the passkey still loses access through mera, but any surviving copy of the secret restores the account. A passkey account, by contrast, is recoverable only through an export taken beforehand.
 
-The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
+The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -9,11 +9,11 @@ sidebar:
 
 import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
 
-A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey. Apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
+A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey. Apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions evaluate the passkey's [PRF](/concepts/passkeys-and-prf/) against a fresh random 32-byte salt and store that salt in the vault ([one output, one purpose](/concepts/security-model/)). The resulting PRF output produces the key material that decrypts the secret.
+Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault ([one output, one purpose](/concepts/security-model/)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service. The storage holds only ciphertext, the encrypted bytes.
 
@@ -21,7 +21,7 @@ The vault itself is ordinary JSON and can live in `localStorage`, on a backend, 
 
 ## When to use a vault
 
-The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs: losing the passkey still loses access through mera, but any surviving copy of the secret restores the account, while a passkey account is recoverable only through an export taken beforehand.
+The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs. Losing the passkey still loses access through mera, but any surviving copy of the secret restores the account. A passkey account, by contrast, is recoverable only through an export taken beforehand.
 
 The challenge is storage. The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -11,7 +11,7 @@ mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompt
 - The passkey's own private key never leaves the authenticator. The PRF output does leave it, and every derived key is an ordinary value in page memory while in use.
 - Losing the passkey without a prior export loses the accounts derived from it. [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
-- Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The secret-vault functions generate a fresh random 32-byte salt per secret.
+- Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.
 - The only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.
 
 <TrustBoundary />

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -29,7 +29,7 @@ Between construction and lock, a compromised runtime can request signatures with
 
 ## How long to keep a session
 
-After `lock()`, the next signature needs fresh key material, and both sources, reproducing a derived key and decrypting a vault, start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
+After `lock()`, the next signature needs fresh key material, and both sources (reproducing a derived key, decrypting a vault) start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
 
 A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends.
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,7 +5,7 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a ceremony, one [WebAuthn](https://www.w3.org/TR/webauthn-3/) call with a user-verification prompt, produces the 32-byte [PRF output](/concepts/passkeys-and-prf/). The app turns that output into a private key, and the session does the signing.
+A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) produces the 32-byte PRF output. The app turns that output into a private key, and the session does the signing.
 
 Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. A digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
 
@@ -29,7 +29,7 @@ Between construction and lock, a compromised runtime can request signatures with
 
 ## How long to keep a session
 
-Unless the app kept the key somewhere else, fresh key material means another passkey ceremony: reproducing a derived key and decrypting a vault both start with one, so after `lock()` the next signature costs one more user-verification prompt. Session lifetime is a trade-off between that prompt and the open window.
+After `lock()`, the next signature needs fresh key material, and both sources, reproducing a derived key and decrypting a vault, start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
 
 A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends.
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -41,7 +41,7 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 
 The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF.
 
-mera uses its [default salt](/reference/get-passkey-prf-output/) for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
+mera uses its [default salt](/reference/get-passkey-prf-output/) for this call, so a later sign-in reproduces the same 32 bytes. The `rpId` is the relying party ID, the domain the passkey is bound to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -41,11 +41,11 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 
 The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF.
 
-mera uses its [default salt](/reference/get-passkey-prf-output/) for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The same passkey and relying party produce the same 32 bytes on any device the passkey syncs to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
+mera uses its [default salt](/reference/get-passkey-prf-output/) for this call. The `rpId` is the relying party ID, the domain the passkey is bound to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
 
 ## Derive an account
 
-The PRF output is entropy: 32 bytes an attacker cannot predict, enough to root every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), so a wallet app that follows both standards can import the account.
+The PRF output is entropy, the root of every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), so a wallet app that follows both standards can import the account.
 
 ```ts
 import { HDKey } from "@scure/bip32";
@@ -60,7 +60,7 @@ const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
-`m/44'/60'/0'/0/0` is a [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) derivation path, the name of one key in the BIP-32 tree. This path selects the first Ethereum account, the key MetaMask derives first from an imported phrase.
+`m/44'/60'/0'/0/0` is the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) path for the first Ethereum account, the key MetaMask derives first from an imported phrase.
 
 ## Sign
 
@@ -82,7 +82,7 @@ const signature = await session.signDigest(digest);
 session.lock();
 ```
 
-The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key, and `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) that copy. A locked session throws on signing.
+The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key, and `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) that copy.
 
 ## Sign back in
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -7,7 +7,7 @@ import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
 This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)).
 
-Derivation and storage are app-owned; mera provides the ceremonies and signing sessions. Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
+Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
 <FirstVsReturning />
 
@@ -44,7 +44,7 @@ localStorage.setItem(
 );
 ```
 
-`transports` is optional and only a hint: the browser uses it to reach the authenticator directly (a platform prompt for a platform passkey, a QR flow for a phone) instead of offering every option. Sign-in works the same without it.
+`transports` is optional and only a hint: the browser uses it to reach the authenticator directly (a platform prompt for a platform passkey, a QR flow for a phone) instead of offering every option.
 
 A fresh device has no record, so sign-in falls back to a discoverable ceremony and the synced passkey still produces the same accounts.
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -5,7 +5,7 @@ description: Sign in with a passkey, derive the first EVM account, and send a tr
 
 This recipe turns a passkey sign-in into a sent transaction. Prerequisites: `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed, a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)), an existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit), and test funds on the sending address.
 
-[viem](https://viem.sh) is a TypeScript client library for EVM chains (chains that run the Ethereum Virtual Machine). [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session. Derivation and client setup are app-owned; mera provides the ceremony, the session, and the adapter.
+[viem](https://viem.sh) is a TypeScript client library for EVM chains (chains that run the Ethereum Virtual Machine). [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session.
 
 ## Sign in
 
@@ -17,7 +17,7 @@ const rpId = location.hostname;
 const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 ```
 
-The call runs one ceremony with one user-verification prompt, the only prompt in this recipe. Without `credential`, the browser offers every discoverable passkey for the domain. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID.
+The call runs one ceremony with one user-verification prompt, the only prompt in this recipe. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID so the browser does not offer every discoverable passkey for the domain.
 
 ## Derive the key
 
@@ -74,7 +74,7 @@ const hash = await client.sendTransaction({
 session.lock();
 ```
 
-`http()` with no URL uses the chain's default public RPC endpoint. RPC, remote procedure call, is the HTTP API a chain node exposes for queries and transactions. Production apps pass a dedicated RPC URL.
+`http()` with no URL uses the chain's default public RPC endpoint. Production apps pass a dedicated RPC URL.
 
 `sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query. viem's `waitForTransactionReceipt` on a public client covers it.
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -22,7 +22,7 @@ if (!validateMnemonic(phrase, wordlist)) {
 
 ## Create and persist the vault
 
-`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension) per vault ([one output, one purpose](/concepts/security-model/)), creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault.
+`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension) per vault ([one output, one purpose](/concepts/security-model/)), creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault ([vault format](/reference/secret-vault-format/)).
 
 ```ts
 import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
@@ -42,7 +42,7 @@ try {
 }
 ```
 
-The [PRF output](/concepts/passkeys-and-prf/) keys the encryption. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text. The [vault format](/reference/secret-vault-format/) stores everything needed for the later ceremony.
+The [PRF output](/concepts/passkeys-and-prf/) keys the encryption. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text.
 
 ## Unlock
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -1,9 +1,9 @@
 ---
 title: createEd25519SigningSession
-description: Creates an explicitly lockable signing session from an Ed25519 private key.
+description: Creates a lockable signing session from an Ed25519 private key.
 ---
 
-Creates an explicitly lockable signing session from an Ed25519 private key.
+Creates a lockable signing session from an Ed25519 private key.
 
 ## Import
 
@@ -68,7 +68,7 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits.
 
 ## Notes
 
-The message is read before `signMessage` returns; mutating the buffer after the call cannot change what was signed.
+The message is read before `signMessage` returns.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -66,10 +66,6 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `privateKey` is not 32 bytes.
 - [`SESSION_LOCKED`](/reference/errors/#session_locked): `signMessage` was called after `lock`.
 
-## Notes
-
-The message is read before `signMessage` returns.
-
 ## See also
 
 - [getSolanaAddress](/reference/get-solana-address/): the address for `session.publicKey`.

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -57,7 +57,7 @@ User handle stored with the discoverable credential. Must be 1 to 64 bytes when 
 - Type: `Uint8Array`
 - Optional; defaults to mera's fixed salt
 
-32-byte PRF salt evaluated during creation or by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts). An explicit value supports custom PRF namespaces and low-level composition. It is copied before async WebAuthn work starts, so post-call mutation changes neither the fallback ceremony nor the returned salt.
+32-byte PRF salt evaluated during creation or by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts). An explicit value supports custom PRF namespaces. It is copied before async WebAuthn work starts.
 
 ### options.timeout
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -75,8 +75,6 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits:
 
 ## Notes
 
-The digest is read before `signDigest` returns.
-
 The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA, the signature algorithm secp256k1 uses, but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would throw [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
 
 ## See also

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -1,9 +1,9 @@
 ---
 title: createSecp256k1SigningSession
-description: Creates an explicitly lockable signing session from a secp256k1 private key.
+description: Creates a lockable signing session from a secp256k1 private key.
 ---
 
-Creates an explicitly lockable signing session from a [secp256k1](/concepts/entropy-keys-and-accounts/) private key.
+Creates a lockable signing session from a [secp256k1](/concepts/entropy-keys-and-accounts/) private key.
 
 ## Import
 
@@ -75,7 +75,7 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits:
 
 ## Notes
 
-The digest is read before `signDigest` returns; mutating the buffer after the call cannot change what was signed.
+The digest is read before `signDigest` returns.
 
 The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA, the signature algorithm secp256k1 uses, but require the signature's `r` to reach the curve order, which happens with probability around 2^-127; if it ever did, the call would throw [`INPUT_INVALID`](/reference/errors/#input_invalid) rather than return a signature that cannot be address-recovered.
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -67,7 +67,7 @@ WebAuthn timeout in milliseconds.
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault containing the selected credential metadata, generated PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
+`Promise<PasskeySecretVault>`: a JSON-safe vault containing the selected credential metadata, the fresh random 32-byte PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 
@@ -78,7 +78,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-A fresh random 32-byte PRF salt is generated for each call and stored in the vault. The secret and supplied credential metadata are copied before the ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
+The secret and supplied credential metadata are copied before the ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -61,7 +61,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault containing the new credential metadata, generated PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
+`Promise<PasskeySecretVault>`: a JSON-safe vault containing the new credential metadata, the fresh random 32-byte PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 
@@ -72,7 +72,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Notes
 
-A fresh random 32-byte PRF salt is generated for the vault and stored in it. The secret is copied before either ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
+The secret is copied before either ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
 
 If the fallback ceremony or vault encryption fails after creation, the passkey remains on the authenticator and the error does not contain its metadata.
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -70,7 +70,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The vault is copied before the assertion starts, so post-call mutation changes neither the credential restriction nor the ciphertext being decrypted. The transient PRF output is zeroed before the function finishes, even when decryption fails.
+The vault is copied before the assertion starts. The transient PRF output is zeroed before the function finishes, even when decryption fails.
 
 The WebAuthn challenge is generated internally.
 

--- a/docs/src/content/docs/reference/get-evm-address.md
+++ b/docs/src/content/docs/reference/get-evm-address.md
@@ -3,7 +3,7 @@ title: getEvmAddress
 description: Derives the EIP-55 checksummed EVM address for a secp256k1 public key.
 ---
 
-Derives the EIP-55 checksummed EVM address for a secp256k1 public key: keccak-256 over the uncompressed key's coordinates, last 20 bytes, mixed-case checksum.
+Derives the [EIP-55](https://eips.ethereum.org/EIPS/eip-55) checksummed EVM address for a secp256k1 public key: keccak-256 over the uncompressed key's coordinates, last 20 bytes, mixed-case checksum.
 
 ## Import
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -42,7 +42,7 @@ Credential metadata that restricts the assertion to one passkey: a `credentialId
 - Type: `Uint8Array`
 - Optional; defaults to mera's fixed salt
 
-PRF salt as 32 raw bytes. An explicit value supports custom PRF namespaces and low-level composition. It is copied before use.
+PRF salt as 32 raw bytes. An explicit value supports custom PRF namespaces. It is copied before use.
 
 ### options.timeout
 
@@ -64,7 +64,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-When `prfSalt` is omitted, the default salt is used: `sha256("mera.prf.salt.v1")`. The salt will not change across library versions, so one assertion against it produces one stable 32-byte PRF output per credential and relying party, and another implementation can reproduce the output from the same constant. The salt encodes no account selection; that happens in the derivation scheme the app applies to the PRF output.
+When `prfSalt` is omitted, the default salt is used: `sha256("mera.prf.salt.v1")`. The salt will not change across library versions: one assertion against it produces one stable 32-byte PRF output per credential and relying party. Another implementation can reproduce the output from the same constant. The salt encodes no account selection; that happens in the derivation scheme the app applies to the PRF output.
 
 The assertion requires user verification, and the requirement is not configurable ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism).
 

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -38,7 +38,7 @@ A 32-byte Ed25519 public key.
 
 ## Returns
 
-A `SolanaAddress`. The type is a nominal brand over `string`: base58 has no structural shape TypeScript could check the way `0x${string}` covers EVM addresses, so values of this type are minted only by this function. At runtime the value is a plain string.
+A `SolanaAddress`, a branded `string` type. TypeScript cannot check base58 the way `0x${string}` covers EVM addresses, so only this function produces values of the type. At runtime the value is a plain string.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -12,8 +12,8 @@ Each exported function has its own page. Types are documented on the pages of th
 
 ## Signing sessions
 
-- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): creates an explicitly lockable signing session from a secp256k1 private key.
-- [createEd25519SigningSession](/reference/create-ed25519-signing-session/): creates an explicitly lockable signing session from an Ed25519 private key.
+- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): creates a lockable signing session from a secp256k1 private key.
+- [createEd25519SigningSession](/reference/create-ed25519-signing-session/): creates a lockable signing session from an Ed25519 private key.
 - [toViemAccount](/reference/to-viem-account/): adapts a secp256k1 signing session into a viem local account.
 
 ## Secret vault

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -3,7 +3,7 @@ title: parseSecretVault
 description: Parses and validates untrusted secret-vault JSON or objects.
 ---
 
-Parses and validates untrusted secret-vault JSON or objects.
+Parses and validates untrusted secret-vault JSON or objects. It is the boundary between stored vault data and the typed `PasskeySecretVault` the other vault functions accept.
 
 ## Import
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -34,7 +34,7 @@ Authenticator transports reported by the browser when the passkey was created. O
 
 ### prfSalt
 
-The PRF salt for this secret, 32 bytes as canonical unpadded base64url. The workflow functions generate it fresh and randomly per vault. Storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
+The PRF salt for this secret, 32 bytes as canonical unpadded base64url. The vault functions generate a fresh random salt per vault. Storing it lets a later ceremony reproduce the exact PRF output that keyed the encryption. The salt is not secret: without the passkey it yields nothing, because the PRF lives in the authenticator.
 
 ### nonce
 

--- a/docs/src/content/docs/reference/to-viem-account.md
+++ b/docs/src/content/docs/reference/to-viem-account.md
@@ -94,11 +94,10 @@ Signs a 32-byte hash directly, with no additional hashing, and resolves to the 6
 
 ## Notes
 
-Signatures are low-S (the signature's `s` value lies in the lower half of the curve order), which EVM chains require since [EIP-2](https://eips.ethereum.org/EIPS/eip-2); `signDigest` enforces this.
+Signatures are [low-S](/reference/create-secp256k1-signing-session/#signdigestdigest32), which EVM chains require since [EIP-2](https://eips.ethereum.org/EIPS/eip-2); `signDigest` enforces this.
 
 ## See also
 
 - [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): the recipe built on this adapter.
 - [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): produces the session this adapter consumes.
 - [Signing sessions](/concepts/signing-sessions/): the custody model and lifecycle.
-

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -26,7 +26,7 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array<ArrayBuffer> {
 }
 
 /**
- * Creates an explicitly lockable signing session from an Ed25519 private key.
+ * Creates a lockable signing session from an Ed25519 private key.
  *
  * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
  * @returns An unlocked Ed25519 signing session.

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -365,8 +365,7 @@ async function getPasskeyPrfOutput({
  * `sha256("mera.prf.salt.v1")`. This default will not change across
  * library versions.
  *
- * `prfSalt` is copied before async WebAuthn work starts; post-call mutation of
- * an explicit input does not change the fallback ceremony or returned salt.
+ * `prfSalt` is copied before async WebAuthn work starts.
  *
  * Any failure after the creation ceremony completes leaves the passkey on the
  * authenticator, but the thrown error does not carry its metadata.

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -50,7 +50,7 @@ function normalizeSecp256k1PublicKey(
 }
 
 /**
- * Creates an explicitly lockable signing session from a secp256k1 private key.
+ * Creates a lockable signing session from a secp256k1 private key.
  *
  * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
  * @returns An unlocked secp256k1 signing session.

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -183,8 +183,7 @@ type CreateSecretVaultOptions = {
  * derived from the same PRF output.
  *
  * @remarks
- * The input byte buffers are copied before async cryptographic work starts;
- * post-call mutation does not change the vault being produced.
+ * The input byte buffers are copied before async cryptographic work starts.
  *
  * Security: a vault is bound to its `prfOutput` only, not to the credential
  * ID or salt. Secrets encrypted using one reused PRF output share an encryption
@@ -277,9 +276,9 @@ function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
  * prompt. On authenticators that do not evaluate PRF during creation, also
  * invokes `navigator.credentials.get()`, which shows a second.
  *
- * `secret` is copied and validated before either ceremony starts. Post-call
- * mutation does not change the encrypted secret. The internal secret and PRF
- * output are zeroed before the function finishes, even when it fails.
+ * `secret` is copied and validated before either ceremony starts. The internal
+ * secret and PRF output are zeroed before the function finishes, even when it
+ * fails.
  *
  * If the fallback ceremony or vault encryption fails, the passkey from the
  * completed creation ceremony still exists on the authenticator, but the
@@ -326,9 +325,9 @@ async function createSecretVaultWithNewPasskey({
  * credential for the relying party.
  *
  * A fresh random PRF salt is generated internally and stored in the returned
- * vault. `secret` and `credential` are copied before the ceremony starts, so
- * post-call mutation does not change the operation. The internal secret and
- * PRF output are zeroed before the function finishes, even when it fails.
+ * vault. `secret` and `credential` are copied before the ceremony starts. The
+ * internal secret and PRF output are zeroed before the function finishes, even
+ * when it fails.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `secret` is empty, or `credential.credentialId` is empty or not canonical base64url.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -387,8 +386,7 @@ type DecryptSecretVaultOptions = {
  * Decrypts the secret from a secret vault.
  *
  * @remarks
- * `prfOutput` is copied before async cryptographic work starts, so post-call
- * mutation does not change the decryption result.
+ * `prfOutput` is copied before async cryptographic work starts.
  *
  * @param options - Vault and PRF output; fields are documented on {@link DecryptSecretVaultOptions}.
  * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`. The returned buffer is a fresh allocation; the library keeps no reference to it.

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,7 @@ type Secp256k1SigningSession = LockableSession & {
   /**
    * Signs a 32-byte digest without prehashing it.
    *
-   * @param digest32 - Exactly 32 bytes to sign; read before the call returns.
+   * @param digest32 - Exactly 32 bytes to sign.
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
    * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
@@ -142,7 +142,7 @@ type Ed25519SigningSession = LockableSession & {
   /**
    * Signs an arbitrary-length message with Ed25519.
    *
-   * @param message - Message bytes to sign; read before the call returns. Hashing happens inside Ed25519 itself.
+   * @param message - Message bytes to sign. Hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,8 +60,8 @@ type CreatePasskeyResult = PasskeyCredentialMetadata & {
 /**
  * Result of creating a passkey together with its first PRF output.
  *
- * `prfSalt` is the salt WebAuthn evaluated. It is returned for explicit
- * low-level composition and protocol interoperability.
+ * `prfSalt` is the salt WebAuthn evaluated. It is returned for protocol
+ * interoperability.
  */
 type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
   /** PRF salt that was evaluated. Always 32 bytes and never aliases the caller input. */
@@ -96,7 +96,7 @@ type Secp256k1Signature = {
   readonly recovery: 0 | 1;
 };
 
-/** Inputs for creating an explicitly lockable curve signing session. */
+/** Inputs for creating a lockable curve signing session. */
 type CreateSigningSessionOptions = {
   /**
    * Curve private key. Must be exactly 32 bytes; secp256k1 must also be a valid scalar.
@@ -127,7 +127,7 @@ type Secp256k1SigningSession = LockableSession & {
   /**
    * Signs a 32-byte digest without prehashing it.
    *
-   * @param digest32 - Exactly 32 bytes to sign; read before the call returns, so later mutation cannot change what is signed.
+   * @param digest32 - Exactly 32 bytes to sign; read before the call returns.
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
    * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
@@ -142,7 +142,7 @@ type Ed25519SigningSession = LockableSession & {
   /**
    * Signs an arbitrary-length message with Ed25519.
    *
-   * @param message - Message bytes to sign; read before the call returns, so later mutation cannot change what is signed. Hashing happens inside Ed25519 itself.
+   * @param message - Message bytes to sign; read before the call returns. Hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
    * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
    */


### PR DESCRIPTION
A pre-release review of the docs found the same facts stated on several pages, consequence clauses that restate what the preceding clause already implies, and a few passages heavier than what they explain. Repetition makes the docs slower to read and harder to keep accurate: a behavior change would have to be fixed in up to four places.

The cuts move each fact toward one owning page, per the information architecture in docs/AGENTS.md:

- PRF-output determinism now lives in the concept pages and the getPasskeyPrfOutput reference; getting started links instead of restating.
- The one-or-two-prompt behavior of passkey creation lives on its reference page only.
- The "derivation is app-owned" framing stays in the concept pages and leaves the recipe preambles.
- Per-page duplicates (the fresh-salt fact stated three times on each create-vault reference page, a vault-format sentence repeated in the existing-secret recipe) are collapsed to one statement.
- "So post-call mutation cannot change X" clauses are cut where "copied/read before the call" already carries the fact.
- Reworded for plainness: "explicitly lockable" becomes "lockable", "low-level composition" is dropped, the SolanaAddress brand explanation loses its type-theory vocabulary, and the RPC gloss leaves the viem recipe.

Because docs/AGENTS.md makes the JSDoc in src/ the source of truth for reference prose, the same cuts are mirrored in the JSDoc (comment-only changes; no behavior change).

Validation: `npm run check`, `npm test` (72 passed), and the docs build all pass. The new in-page anchor link on the toViemAccount page (`#signdigestdigest32`) was verified against the built HTML.