### PR TITLE
Trim cross-page repeats and restatements from the docs site

### DIFF
--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -7,7 +7,7 @@ A passkey account is a blockchain account whose keys derive from a passkey's PRF
 
 ## One salt, one stable output
 
-When the PRF salt is omitted, mera uses its [default salt](/reference/get-passkey-prf-output/). The same passkey and relying party then produce the same 32 bytes of PRF output on every ceremony, on every device the passkey syncs to. There is no stored secret; all state lives in the passkey. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
+When the PRF salt is omitted, mera uses its [default salt](/reference/get-passkey-prf-output/). The same passkey and relying party then produce the same PRF output on every device the passkey syncs to. There is no stored secret; all state lives in the passkey. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## Losing the passkey
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -7,7 +7,7 @@ import PrfFunction from "../../../assets/diagrams/prf-function.svg";
 
 A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords. A credential is one such key pair, created at a website's request by an authenticator: a phone, a password manager, or a hardware key. The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
-**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, the old credential and everything derived from it are unreachable. The [security model](/concepts/security-model/) covers migrations in depth.
+**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, the old credential and everything derived from it are unreachable. The [security model](/concepts/security-model/) covers migrations.
 
 **Passkeys sync.** Platform authenticators, the credential stores built into an operating system or a password manager, replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
 
@@ -27,13 +27,13 @@ PRF output is determined by the credential, relying party ID, and salt. Those in
 
 ## Using the output
 
-The output is suitable as the root secret for accounts. It is stable wherever the passkey syncs, it appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony. The output, unlike the credential's private key, leaves the authenticator and returns to the page ([security model](/concepts/security-model/)).
+The output appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony. The output, unlike the credential's private key, leaves the authenticator and returns to the page ([security model](/concepts/security-model/)).
 
 Passed to a [key-derivation scheme](/concepts/entropy-keys-and-accounts/), the output produces a hierarchy of accounts. Used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
 
 ## Ceremonies and prompts
 
-A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential or runs an assertion, the call that uses an existing credential. In both, the authenticator proves possession of the key pair and can evaluate the PRF. mera runs both kinds:
+A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential or runs an assertion, the call that uses an existing credential. Either kind can evaluate the PRF. mera runs both:
 
 - [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) makes the credential and returns the PRF output.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -13,7 +13,7 @@ A secret vault holds one secret (a recovery phrase, a private key, any bytes), e
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault ([one output, one purpose](/concepts/security-model/)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault. The fresh salt keeps vaults from sharing an encryption key ([security model](/concepts/security-model/)).
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service. The storage holds only ciphertext, the encrypted bytes.
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,15 +5,15 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked. It is the last step in mera's flow: a passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) produces the 32-byte PRF output. The app turns that output into a private key, and the session does the signing.
+A signing session holds one private key and signs with it until it is locked.
 
-Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. A digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. The custody model is the same for both.
+Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. A digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. Both hold and destroy the key the same way.
 
 ## Independent of passkeys
 
 A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design. [Passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
 
-Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the ceremony that produced the entropy, and it covers any number of signatures.
+Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) that produced the entropy, and it covers any number of signatures.
 
 ## The lifecycle
 
@@ -33,7 +33,7 @@ After `lock()`, the next signature needs fresh key material, and both sources (r
 
 A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends.
 
-Apps that sign occasionally are better served by holding no session at all: derive the public key, identify the account by its address, and zero the private key right away. The next signature then starts with a fresh ceremony.
+Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
 
 ## Why sessions exist
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -5,7 +5,9 @@ description: Install the library, derive an account, and make a first signature.
 
 import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
-A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) is one call to [WebAuthn](https://www.w3.org/TR/webauthn-3/), the browser standard for signing in with key pairs instead of passwords, and shows one user-verification prompt. Through the [PRF extension](/concepts/passkeys-and-prf/), a ceremony returns 32 secret bytes, which the app uses as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts. A [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory ([security model](/concepts/security-model/)).
+A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) shows one user-verification prompt and returns 32 secret bytes through the [PRF extension](/concepts/passkeys-and-prf/). The app uses those bytes as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts, and a [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory ([security model](/concepts/security-model/)).
+
+<GettingStartedOverview />
 
 Prerequisites:
 
@@ -41,19 +43,17 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 
 The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF.
 
-mera uses its [default salt](/reference/get-passkey-prf-output/) for this call, so a later sign-in reproduces the same 32 bytes. The `rpId` is the relying party ID, the domain the passkey is bound to. The result also carries the credential ID. [Create passkey accounts](/recipes/create-passkey-accounts/) stores it to pin later sign-ins.
+mera uses its [default salt](/reference/get-passkey-prf-output/) for this call, so a later sign-in reproduces the same 32 bytes. The `rpId` is the relying party ID, the domain the passkey is bound to.
 
 ## Derive an account
 
-The PRF output is entropy, the root of every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), so a wallet app that follows both standards can import the account.
+The PRF output is entropy, the root of every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
 
 ```ts
 import { HDKey } from "@scure/bip32";
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
-// App-owned derivation: the PRF output becomes BIP-39 entropy, so the same
-// phrase imported into a standard wallet app reproduces the same account.
 const mnemonic = entropyToMnemonic(prfOutput, wordlist);
 const seed = mnemonicToSeedSync(mnemonic);
 const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
@@ -96,11 +96,7 @@ const { prfOutput } = await getPasskeyPrfOutput({
 });
 ```
 
-Without `credential`, the browser offers any discoverable passkey it holds for the relying party. Apps with returning users pin the stored credential ID instead.
-
-## From passkey to signature
-
-<GettingStartedOverview />
+Without `credential`, the browser offers any discoverable passkey it holds for the relying party. [Create passkey accounts](/recipes/create-passkey-accounts/) stores the credential ID at create time and pins later sign-ins to it.
 
 ## Where next
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -5,9 +5,7 @@ description: Create numbered EVM and Solana accounts from one passkey ceremony, 
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)).
-
-Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
+This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)). Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
 <FirstVsReturning />
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -17,7 +17,7 @@ const rpId = location.hostname;
 const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 ```
 
-The call runs one ceremony with one user-verification prompt, the only prompt in this recipe. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID so the browser does not offer every discoverable passkey for the domain.
+The call runs one ceremony, the only prompt in this recipe. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID so the browser does not offer every discoverable passkey for the domain.
 
 ## Derive the key
 
@@ -50,8 +50,6 @@ seed.fill(0);
 
 const account = toViemAccount(session);
 ```
-
-The returned account signs transactions, messages, and typed data through `session.signDigest`. The [toViemAccount reference](/reference/to-viem-account/) documents each method.
 
 ## Send the transaction
 
@@ -88,4 +86,4 @@ session.lock();
 
 - [toViemAccount](/reference/to-viem-account/): every signing method the account implements, and the adapter contract.
 - [Create passkey accounts](/recipes/create-passkey-accounts/): the first visit, credential pinning, and numbered accounts.
-- [Signing sessions](/concepts/signing-sessions/): the custody model and how long to hold a session.
+- [Signing sessions](/concepts/signing-sessions/): how a session owns the key and how long to hold one.

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,7 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. The vault is the pattern for secrets that predate the passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 ## Validate the phrase
 
@@ -22,7 +22,7 @@ if (!validateMnemonic(phrase, wordlist)) {
 
 ## Create and persist the vault
 
-`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension) per vault ([one output, one purpose](/concepts/security-model/)), creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault ([vault format](/reference/secret-vault-format/)).
+`createSecretVaultWithNewPasskey` generates a fresh 32-byte [salt](/concepts/passkeys-and-prf/#the-prf-extension) per vault, creates the passkey, and encrypts the secret. The salt and credential metadata are stored in the returned vault ([vault format](/reference/secret-vault-format/)).
 
 ```ts
 import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
@@ -42,7 +42,7 @@ try {
 }
 ```
 
-The [PRF output](/concepts/passkeys-and-prf/) keys the encryption. The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text.
+The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text.
 
 ## Unlock
 
@@ -68,7 +68,7 @@ async function unlockPhrase(): Promise<string> {
 }
 ```
 
-`parseSecretVault` is the boundary for the untrusted stored JSON. The decrypted buffer is a fresh allocation, so the `finally` zeroes it after decoding.
+`parseSecretVault` is the boundary for the untrusted stored JSON. The decrypted buffer is a fresh allocation.
 
 ## Derive signing sessions
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -69,4 +69,4 @@ Calls `lock`, so a `using` declaration locks the session when its scope exits.
 ## See also
 
 - [getSolanaAddress](/reference/get-solana-address/): the address for `session.publicKey`.
-- [Signing sessions](/concepts/signing-sessions/): the custody model, the lifecycle, and what an active session exposes.
+- [Signing sessions](/concepts/signing-sessions/): how a session owns the key, the lifecycle, and what an active session exposes.

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -22,14 +22,14 @@ const { credentialId, prfSalt, prfOutput } = await createPasskeyWithPrfOutput({
 
 ## Parameters
 
-`options` is a `CreatePasskeyWithPrfOutputOptions`. It requires `rp.id` so the fallback ceremony can target the same relying party.
+`options` is a `CreatePasskeyWithPrfOutputOptions`.
 
 ### options.rp
 
 - Type: `PublicKeyCredentialRpEntity & { id: string }`
 - Required, including `rp.id`
 
-Relying party identity, passed to WebAuthn.
+Relying party identity, passed to WebAuthn. `rp.id` lets the fallback ceremony target the same relying party.
 
 ### options.user.name
 
@@ -50,7 +50,7 @@ Human-readable display name for the authenticator UI.
 - Type: `Uint8Array`
 - Optional; a fresh 32-byte random handle is generated per call when omitted
 
-User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). The generated handle is not correlated with an app account, so repeated calls do not share a stable user handle. Copied before use.
+User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). The generated handle is not correlated with an app account. Copied before use.
 
 ### options.prfSalt
 
@@ -74,7 +74,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF, or did not return PRF output on the fallback ceremony.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): an explicit `prfSalt` is not 32 bytes, or the provided `user.id` length is outside 1 to 64 bytes.
-- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -81,4 +81,4 @@ The recovery ID is declared `0 | 1`. Values 2 and 3 exist in ECDSA, the signatur
 
 - [getEvmAddress](/reference/get-evm-address/): the address for `session.publicKey`.
 - [toViemAccount](/reference/to-viem-account/): a viem account backed by the session.
-- [Signing sessions](/concepts/signing-sessions/): the custody model, the lifecycle, and what an active session exposes.
+- [Signing sessions](/concepts/signing-sessions/): how a session owns the key, the lifecycle, and what an active session exposes.

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -3,7 +3,7 @@ title: createSecretVaultWithExistingPasskey
 description: Encrypts one secret into a vault using an existing passkey and a fresh random salt.
 ---
 
-Evaluates an existing passkey and encrypts one secret into a vault. Runs one `navigator.credentials.get()` ceremony and shows one user-verification prompt.
+Evaluates an existing passkey and encrypts one secret into a vault. Runs one `navigator.credentials.get()` [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts).
 
 ## Import
 
@@ -73,7 +73,7 @@ WebAuthn timeout in milliseconds.
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `secret` is empty, or `credential.credentialId` is empty or not canonical base64url.
-- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes
@@ -84,4 +84,4 @@ The secret and supplied credential metadata are copied before the ceremony begin
 
 - [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create the first vault together with a passkey.
 - [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/): perform the assertion and decrypt a stored vault.
-- [One output, one purpose](/concepts/security-model/): why each vault receives a fresh salt.
+- [Security model](/concepts/security-model/): why each vault receives a fresh salt.

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -67,7 +67,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF or return a usable 32-byte output.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `secret` is empty, or the provided `user.id` length is outside 1 to 64 bytes.
-- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -3,7 +3,7 @@ title: decryptSecretVaultWithPasskey
 description: Performs a passkey assertion and decrypts one secret vault.
 ---
 
-Performs the passkey [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) for a parsed vault and decrypts its secret. Runs one `navigator.credentials.get()` ceremony and shows one user-verification prompt.
+Performs the passkey [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) for a parsed vault and decrypts its secret. Runs one `navigator.credentials.get()` ceremony.
 
 ## Import
 
@@ -58,14 +58,14 @@ WebAuthn timeout in milliseconds.
 
 ## Returns
 
-`Promise<Uint8Array>`: the decrypted secret bytes as a fresh allocation. The library keeps no reference to this buffer; the caller controls its lifetime.
+`Promise<Uint8Array>`: the decrypted secret bytes as a fresh allocation. The library keeps no reference to this buffer.
 
 ## Errors
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
 - [`DECRYPT_FAILED`](/reference/errors/#decrypt_failed): [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed because the PRF output was wrong or the vault was modified.
-- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -3,7 +3,7 @@ title: getPasskeyPrfOutput
 description: Requests a passkey PRF evaluation and returns the output.
 ---
 
-Requests a passkey PRF evaluation and returns the output. Runs one `navigator.credentials.get()` ceremony and shows one user-verification prompt.
+Requests a passkey PRF evaluation and returns the output. Runs one `navigator.credentials.get()` [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts).
 
 ## Import
 
@@ -59,12 +59,12 @@ WebAuthn timeout in milliseconds.
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): an explicit `prfSalt` is not 32 bytes, or `credential.credentialId` is empty or not canonical base64url.
-- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): Web Crypto is unavailable.
+- [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes
 
-When `prfSalt` is omitted, the default salt is used: `sha256("mera.prf.salt.v1")`. The salt will not change across library versions: one assertion against it produces one stable 32-byte PRF output per credential and relying party. Another implementation can reproduce the output from the same constant. The salt encodes no account selection; that happens in the derivation scheme the app applies to the PRF output.
+When `prfSalt` is omitted, the default salt is used: `sha256("mera.prf.salt.v1")`. The salt will not change across library versions, and another implementation can reproduce the output from the same constant. The salt encodes no account selection; that happens in the derivation scheme the app applies to the PRF output.
 
 The assertion requires user verification, and the requirement is not configurable ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism).
 

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -38,7 +38,7 @@ A 32-byte Ed25519 public key.
 
 ## Returns
 
-A `SolanaAddress`, a branded `string` type. TypeScript cannot check base58 the way `0x${string}` covers EVM addresses, so only this function produces values of the type. At runtime the value is a plain string.
+A `SolanaAddress`, a branded `string` type. TypeScript cannot check base58 the way `0x${string}` covers EVM addresses, so only this function produces values of the type.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -3,7 +3,7 @@ title: API reference
 description: The exported functions, the vault storage format, and the error codes.
 ---
 
-Each exported function has its own page. Types are documented on the pages of the functions that produce or accept them.
+Types are documented on the pages of the functions that produce or accept them.
 
 ## Passkeys
 

--- a/docs/src/content/docs/reference/to-viem-account.md
+++ b/docs/src/content/docs/reference/to-viem-account.md
@@ -100,4 +100,4 @@ Signatures are [low-S](/reference/create-secp256k1-signing-session/#signdigestdi
 
 - [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): the recipe built on this adapter.
 - [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): produces the session this adapter consumes.
-- [Signing sessions](/concepts/signing-sessions/): the custody model and lifecycle.
+- [Signing sessions](/concepts/signing-sessions/): how a session owns the key, and the lifecycle.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,7 @@
  * Stable error codes thrown by this package.
  *
  * - `PASSKEY_OPERATION_FAILED`: WebAuthn failed, was cancelled, returned an unexpected credential, or the credential API is unavailable.
- * - `CRYPTO_UNAVAILABLE`: Web Crypto is unavailable.
+ * - `CRYPTO_UNAVAILABLE`: the page is not in a secure context, or the runtime lacks Web Crypto.
  * - `PRF_UNAVAILABLE`: the authenticator did not enable or return a usable 32-byte WebAuthn PRF output.
  * - `SESSION_LOCKED`: a signing call was made after `lock()`.
  * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key or tampered nonce/ciphertext).

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -41,8 +41,7 @@ type CreatePasskeyOptions = {
      *
      * This value is stored as the WebAuthn user handle for the discoverable
      * credential. When omitted, a fresh 32-byte random handle is generated for
-     * each call, so repeated calls do not share a stable user handle. The
-     * generated handle is not correlated with an app account.
+     * each call. The generated handle is not correlated with an app account.
      */
     id?: Uint8Array;
     /** User name displayed or stored by the authenticator. */


### PR DESCRIPTION
## Problem

Before release, the docs site had accumulated overlapping prose. Getting started re-taught the definitions its concept-page links already carry, several pages stated the same fact twice a few lines apart, and reference pages glossed `CRYPTO_UNAVAILABLE` as "Web Crypto is unavailable" — the code name restated, with nothing to act on. Three pages also linked the label "one output, one purpose" to the security model, which never uses that phrase, so the link promised a principle the target page doesn't name.

## Approach

Only repetition was cut, not information. Reference pages keep their per-page contract facts: prompt counts stay spelled out on the two create-path pages, where the count varies (one or two); the fixed-count `get()` pages now say "one ceremony" with the concept link that defines it as one prompt. Each concept page still states standalone-necessary facts once.

Two `src` JSDoc sentences mirrored trimmed docs sentences (the `errors.ts` code list and the `user.id` clause in `passkey.ts`), so they changed together. The `@throws` one-liners were left alone — "when Web Crypto is unavailable" is the literal throw condition there, not a gloss.

One trade to review: the Getting started intro no longer explains why the walkthrough goes through a BIP-39 phrase; that rationale now lives on the concepts page and in the MetaMask line under the code block. One behavior-adjacent wording fix rode along: the signing-sessions "hold no session" advice now says how to get the public key (create a session, read it, lock it) instead of assuming it.

## Validation

`npm run check` and the docs site build (`astro build`, 27 pages) pass. No runtime code changed.