### PR TITLE
Cut restated facts and hard-parse sentences across the docs

### DIFF
--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -18,7 +18,7 @@ A private key is a 256-bit secret number. A one-way function computes the public
 
 A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key.
 
-The docs use two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
+mera supports two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
 
 ## Deterministic derivation
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -18,7 +18,7 @@ A private key is a 256-bit secret number. A one-way function computes the public
 
 A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key.
 
-mera supports two signature schemes, named for their curves: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
+mera supports two signature schemes: secp256k1 on Ethereum and other EVM chains (chains that run the Ethereum Virtual Machine), and Ed25519 on Solana.
 
 ## Deterministic derivation
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -7,7 +7,7 @@ import PrfFunction from "../../../assets/diagrams/prf-function.svg";
 
 A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords. A credential is one such key pair, created at a website's request by an authenticator: a phone, a password manager, or a hardware key. The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
 
-**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, the old credential and everything derived from it are unreachable. The [security model](/concepts/security-model/) covers migrations.
+**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, the old credential and everything derived from it are unreachable.
 
 **Passkeys sync.** Platform authenticators, the credential stores built into an operating system or a password manager, replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
 
@@ -29,7 +29,7 @@ PRF output is determined by the credential, relying party ID, and salt. Those in
 
 The output appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony. The output, unlike the credential's private key, leaves the authenticator and returns to the page ([security model](/concepts/security-model/)).
 
-Passed to a [key-derivation scheme](/concepts/entropy-keys-and-accounts/), the output produces a hierarchy of accounts. Used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a vault. mera returns the output and does nothing else with it. [Passkey accounts](/concepts/passkey-accounts/) is the default pattern built on the first path; [secret vaults](/concepts/secret-vaults/) cover the second, for secrets that already exist.
+mera returns the output and does nothing else with it. Passed to a [key-derivation scheme](/concepts/entropy-keys-and-accounts/), it produces a hierarchy of accounts: [passkey accounts](/concepts/passkey-accounts/), the default pattern. Used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a [secret vault](/concepts/secret-vaults/), the advanced pattern for secrets that already exist.
 
 ## Ceremonies and prompts
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -13,7 +13,7 @@ A secret vault holds one secret (a recovery phrase, a private key, any bytes), e
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault ([security model](/concepts/security-model/)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault.
 
 The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service. Nothing it stores reveals the secret without the passkey.
 
@@ -21,7 +21,7 @@ The vault itself is ordinary JSON and can live in `localStorage`, on a backend, 
 
 ## When to use a vault
 
-The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs. Losing the passkey still loses access through mera, but any surviving copy of the secret restores the account. A passkey account, by contrast, is recoverable only through an export taken beforehand.
+The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Losing the passkey still loses access through mera, but any surviving copy of the secret restores the account. A passkey account, by contrast, is recoverable only through an export taken beforehand.
 
 Where the vault lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -9,13 +9,13 @@ sidebar:
 
 import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
 
-A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey. Apps creating new accounts need only [passkey accounts](/concepts/passkey-accounts/).
+A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey.
 
 ## How a vault works
 
-Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault. The fresh salt keeps vaults from sharing an encryption key ([security model](/concepts/security-model/)).
+Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault ([security model](/concepts/security-model/)).
 
-The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service. The storage holds only ciphertext, the encrypted bytes.
+The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service. Nothing it stores reveals the secret without the passkey.
 
 <VaultRoundtrip />
 
@@ -23,7 +23,7 @@ The vault itself is ordinary JSON and can live in `localStorage`, on a backend, 
 
 The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Recovery also differs. Losing the passkey still loses access through mera, but any surviving copy of the secret restores the account. A passkey account, by contrast, is recoverable only through an export taken beforehand.
 
-The vault blob must live in durable storage, and where it lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
+Where the vault lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -7,7 +7,7 @@ import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
 mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/). All of it runs in the page, with software keys. The guarantees match a wallet app holding an imported seed phrase in the page.
 
-- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session until `session.lock()`. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Locking sessions when idle and keeping derivation windows short shorten the exposure.
+- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session until `session.lock()`. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Locking sessions when idle and zeroing key material promptly shorten the exposure.
 - The passkey's own private key never leaves the authenticator. The PRF output does leave it, and every derived key is an ordinary value in page memory while in use.
 - Losing the passkey without a prior export loses the accounts derived from it. [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -17,7 +17,7 @@ Because a session never contacts an authenticator, signing never prompts: the on
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`. The key's lifetime is visible in the code: it spans the line that creates the session and the line that locks it.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
@@ -34,10 +34,6 @@ After `lock()`, the next signature needs fresh key material, and both sources (r
 A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends.
 
 Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
-
-## Why sessions exist
-
-A signing function that took the key as an argument on every call would spread copies across every caller and make zeroing each one the app's job. The session shape keeps the key in one place with one owner, and it makes key lifetime visible in the code: the lifetime spans the line that creates the session and the line that locks it.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -31,9 +31,7 @@ Between construction and lock, a compromised runtime can request signatures with
 
 After `lock()`, the next signature needs fresh key material, and both sources (reproducing a derived key, decrypting a vault) start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
 
-A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends.
-
-Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
+A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends. Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -31,7 +31,7 @@ Between construction and lock, a compromised runtime can request signatures with
 
 After `lock()`, the next signature needs fresh key material, and both sources (reproducing a derived key, decrypting a vault) start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
 
-An app that signs frequently keeps one session for the active burst of work and locks it when the burst ends. Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
+An app that signs frequently may keep the session active for a burst of work and lock it when the burst ends. Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -17,7 +17,7 @@ Because a session never contacts an authenticator, signing never prompts: the on
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`. The key's lifetime is visible in the code: it spans the line that creates the session and the line that locks it.
+Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -31,7 +31,7 @@ Between construction and lock, a compromised runtime can request signatures with
 
 After `lock()`, the next signature needs fresh key material, and both sources (reproducing a derived key, decrypting a vault) start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
 
-A high-frequency trading app keeps one session for the active burst of work and locks it when the burst ends. Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
+An app that signs frequently keeps one session for the active burst of work and locks it when the burst ends. Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
 
 ## See also
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -28,7 +28,7 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call.
+`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call. The `rpId` is the relying party ID, the domain the passkey is bound to.
 
 ```ts
 import { createPasskeyWithPrfOutput } from "@category-labs/mera";
@@ -43,7 +43,7 @@ const { prfOutput } = await createPasskeyWithPrfOutput({
 
 The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF.
 
-mera uses its [default salt](/reference/get-passkey-prf-output/) for this call, so a later sign-in reproduces the same 32 bytes. The `rpId` is the relying party ID, the domain the passkey is bound to.
+mera uses its [default salt](/reference/get-passkey-prf-output/) for this call, so a later sign-in reproduces the same 32 bytes.
 
 ## Derive an account
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -5,7 +5,7 @@ description: Create numbered EVM and Solana accounts from one passkey ceremony, 
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/) with numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)). Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
+This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/): numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)). Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
 
 <FirstVsReturning />
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -17,7 +17,7 @@ const rpId = location.hostname;
 const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 ```
 
-The call runs one ceremony, the only prompt in this recipe. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the stored credential ID so the browser does not offer every discoverable passkey for the domain.
+The call runs one ceremony, the only prompt in this recipe. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the sign-in to a stored credential ID.
 
 ## Derive the key
 
@@ -78,8 +78,8 @@ session.lock();
 
 ## Pitfalls
 
-- **The derivation must match the app's other sign-in paths.** This recipe repeats the mapping and path from [Create passkey accounts](/recipes/create-passkey-accounts/). A different mapping or path reaches a different address.
-- **A locked session rejects every viem signing method** with [`SESSION_LOCKED`](/reference/errors/#session_locked), and the account has no key of its own.
+- **The derivation must match the app's other sign-in paths.** A different mapping or path reaches a different address.
+- **A locked session rejects every viem signing method** with [`SESSION_LOCKED`](/reference/errors/#session_locked): the account holds no key of its own and cannot sign without the session.
 - **Concurrent transactions can be assigned the same nonce**, the per-account counter that orders transactions, and the chain accepts only one of them. viem's nonce manager assigns nonces in sequence. Pass it through [toViemAccount](/reference/to-viem-account/) options.
 
 ## See also

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -68,7 +68,7 @@ async function unlockPhrase(): Promise<string> {
 }
 ```
 
-`parseSecretVault` is the boundary for the untrusted stored JSON. The decrypted buffer is a fresh allocation.
+`parseSecretVault` is the boundary for the untrusted stored JSON.
 
 ## Derive signing sessions
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -3,7 +3,7 @@ title: createEd25519SigningSession
 description: Creates a lockable signing session from an Ed25519 private key.
 ---
 
-Creates a lockable signing session from an Ed25519 private key.
+Creates a lockable signing session from an [Ed25519](/concepts/entropy-keys-and-accounts/) private key.
 
 ## Import
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -67,7 +67,7 @@ WebAuthn timeout in milliseconds.
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault containing the selected credential metadata, the fresh random 32-byte PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
+`Promise<PasskeySecretVault>`: a JSON-safe vault with the selected credential's metadata and a fresh random 32-byte PRF salt. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -61,7 +61,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault containing the new credential metadata, the fresh random 32-byte PRF salt, nonce, and ciphertext. The [secret vault format](/reference/secret-vault-format/) page documents every field.
+`Promise<PasskeySecretVault>`: a JSON-safe vault with the new credential's metadata and a fresh random 32-byte PRF salt. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -58,7 +58,7 @@ WebAuthn timeout in milliseconds.
 
 ## Returns
 
-`Promise<Uint8Array>`: the decrypted secret bytes as a fresh allocation. The library keeps no reference to this buffer.
+`Promise<Uint8Array>`: the decrypted secret bytes as a fresh allocation.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -35,7 +35,7 @@ try {
 }
 ```
 
-`isMeraError` is a type guard that returns `true` when the value is a `MeraError` instance, narrowing the value so `code` can be branched on.
+`isMeraError` is a type guard: it narrows a caught value so `code` can be branched on.
 
 ## Codes
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -3,7 +3,7 @@ title: getPasskeyPrfOutput
 description: Requests a passkey PRF evaluation and returns the output.
 ---
 
-Requests a passkey PRF evaluation and returns the output. Runs one `navigator.credentials.get()` [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts).
+Runs one `navigator.credentials.get()` [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) and returns the passkey's PRF output.
 
 ## Import
 

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -3,7 +3,7 @@ title: getSolanaAddress
 description: Derives the base58-encoded Solana address for an Ed25519 public key.
 ---
 
-Derives the base58-encoded Solana address for an Ed25519 public key. A Solana address is the public key itself, base58-encoded.
+Derives the Solana address for an Ed25519 public key: the public key itself, base58-encoded.
 
 ## Import
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -3,7 +3,7 @@ title: parseSecretVault
 description: Parses and validates untrusted secret-vault JSON or objects.
 ---
 
-Parses and validates untrusted secret-vault JSON or objects. It is the boundary between stored vault data and the typed `PasskeySecretVault` the other vault functions accept.
+Parses and validates untrusted vault data into the typed `PasskeySecretVault` the other vault functions accept.
 
 ## Import
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -26,7 +26,7 @@ Always `1`. [parseSecretVault](/reference/parse-secret-vault/) rejects anything 
 
 ### credential.credentialId
 
-The passkey credential that unlocks this vault, as canonical unpadded [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5). Stored so the unlock [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can pin itself to the right passkey instead of letting the browser offer every discoverable credential.
+The passkey credential that unlocks this vault, as canonical unpadded [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5). Stored so the unlock [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can pin itself to the right passkey.
 
 ### credential.transports
 
@@ -42,11 +42,11 @@ The 12-byte [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) nonce, base64u
 
 ### ciphertext
 
-The AES-GCM ciphertext including its 16-byte authentication tag, the value decryption checks to detect tampering, base64url. The plaintext is the secret exactly as it was passed in.
+The AES-GCM ciphertext with its 16-byte authentication tag appended, base64url. Decryption checks the tag to detect tampering. The plaintext is the secret exactly as it was passed in.
 
 ## What is deliberately absent
 
-The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent: the vault does not record which relying party it belongs to, and the unlock assertion supplies it.
+The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent; the unlock assertion supplies it.
 
 The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key.
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -389,7 +389,7 @@ type DecryptSecretVaultOptions = {
  * `prfOutput` is copied before async cryptographic work starts.
  *
  * @param options - Vault and PRF output; fields are documented on {@link DecryptSecretVaultOptions}.
- * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`. The returned buffer is a fresh allocation; the library keeps no reference to it.
+ * @returns The decrypted secret bytes, exactly as passed to `createSecretVault`. The returned buffer is a fresh allocation.
  * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url (already validated for vaults from `parseSecretVault`).
  * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -525,13 +525,13 @@ type DecryptSecretVaultWithPasskeyOptions = GetSecretVaultPrfOutputOptions;
  * Performs the passkey assertion for a vault and decrypts its secret.
  *
  * @param options - Relying party and parsed vault; fields are documented on {@link DecryptSecretVaultWithPasskeyOptions}.
- * @returns The decrypted secret bytes. The returned buffer is a fresh allocation owned by the caller.
+ * @returns The decrypted secret bytes. The returned buffer is a fresh allocation.
  * @remarks
  * Invokes `navigator.credentials.get()` and shows one user-verification
  * prompt. The assertion is restricted to the credential stored in the vault.
  *
  * The internal PRF output is zeroed before the function finishes, even when
- * decryption fails. The returned secret's lifetime belongs to the caller.
+ * decryption fails.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
  * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.


### PR DESCRIPTION
## Why

The library is unreleased, so the docs can still be trimmed hard before the prose settles. A review pass found three kinds of waste: explanations spelled out in full on several pages, sentences that restate the sentence before them, and a few sentences that stack too many clauses to parse on first read.

## The rule behind most of the diff

A fact may appear on several pages, but its explanation lives on the page that owns it; other pages state the fact and link. Applied to the domain-migration consequence (owned by the security model), the credential-pinning rationale (owned by getPasskeyPrfOutput and the pinning recipe), and the vault field list (owned by the format page). The rest is sentence-level: leads that said the same thing twice, statements of non-behavior next to the fact that implies them, and the three hardest-parsing sentences reshaped.

Two sentences cut from the decrypt reference page were mirrored in src/secret.ts JSDoc; they are trimmed there too so source and reference stay in step.

## Left in place on purpose

- Getting started keeps the lock()-zeroing note: docs/AGENTS.md wants security behavior stated on the page where the risk is acted on.
- The one-sentence reference leads stay: the fixed reference-page shape in docs/AGENTS.md requires a lead stating what the function does.
- The fresh-salt fact still appears on the security model and vault format pages; each states it for its own job (risk boundary, AAD caveat). Only the concept page's restatement was cut.

Validated with `npm run check`, the library build, and the docs build.