### PR TITLE
Simplify the getting-started opening and trim the walkthrough prose

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,13 +8,13 @@ The reader is a strong software engineer who may know none of blockchain, crypto
 
 Define every complex concept or acronym on first mention in a page: one to three sentences, tied to the step the reader is in, linking the owning page for depth. Later mentions on the same page reuse the short name without re-explaining. The foundations concept page (`concepts/entropy-keys-and-accounts`) owns the blockchain background; glosses elsewhere link there rather than re-teaching it.
 
-Reference pages are exempt: they state facts and link to the page that teaches.
+Reference pages are exempt: they state facts and link to the page that teaches. Getting started is exempt in the other direction: it links the owning concept page instead of defining inline.
 
 ## Information architecture
 
 The site follows the Diátaxis split (<https://diataxis.fr/>): each page does one job.
 
-- **Getting started** teaches one first success, end to end. It may explain just enough to keep the reader moving, nothing more.
+- **Getting started** teaches one first success, end to end. Its lead states what the reader will do, not how the mechanism works. Each step links the owning page instead of explaining; a detail the reader does not need for the next step is a link, not a sentence.
 - **Concepts** explain how something works and why it is designed that way. No step-by-step instructions.
 - **Recipes** solve one task each. A recipe assumes a competent reader with a goal, states its prerequisites, and gets to the point.
 - **Reference** states facts about the public API, one exported function per page. Keep instructions, opinions, and long explanations out of it; link to them instead.
@@ -59,7 +59,7 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 - Passkey accounts are the default path; secret vaults are the advanced option for secrets that predate the passkey. Never present the two as coequal alternatives.
 - Word choice fits technical documentation. Plain nouns over narrative or dramatic ones: "trade-offs", never "stories"; "complication", never "trap". A word that belongs in a blog headline gets replaced.
 - Plain verbs over idioms: "use a vault", never "reach for a vault". An idiom a non-native reader would pause on gets replaced with the literal verb.
-- Calm explanation, no marketing. If a sentence would fit in a product brochure, rewrite it.
+- Calm explanation, no marketing. If a sentence would fit in a product brochure, rewrite it. An accurate behavior claim can still be marketing: if it exists to impress rather than to move the reader forward, cut it and let the owning page state the behavior.
 - Named wallet apps are examples, never an exhaustive list.
 - Prefer a concrete statement over an abstract one. "The salt is 32 bytes" beats "the salt has a fixed size".
 - Neutral possessives: "the passkey", "the secret". Avoid "your passkey".
@@ -77,14 +77,20 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 - Short paragraphs, but not a wall of one-liners.
 - Banned vocabulary: seamless, robust, powerful, effortless, simply, leverage, unlock (as praise; unlocking a vault is fine), delve, game-changer.
 
+## Diagrams
+
+- A node carries the step name. An ownership row (mera, the app) is allowed when the library/app boundary matters.
+- No subtitle text that restates the surrounding prose or a concept page; the diagram shows the shape, the text explains.
+- The `<title>` element describes the whole diagram in sentences for screen readers.
+
 ## Accuracy
 
 - Every claim must be checkable against the JSDoc, implementation, or tests.
 - Implementation details live only on the page that owns them: error codes and library internals on the reference, demo internals (derivation schemes, storage, UI) in the recipes that adapt its code. Every other page links to the owning page instead of restating the detail, so a demo or library change touches one page.
 - Examples import only the public API plus explicitly declared app-side dependencies.
 - Examples define every identifier they use. Values the app supplies enter through a placeholder with realistic shape and provenance: `crypto.getRandomValues(new Uint8Array(32))` for key material, `new TextEncoder().encode(...)` for secret text, a literal for addresses and rpIds. Never use an all-zero buffer where the library validates the value; an all-zero secp256k1 key throws.
-- A placeholder value carries its meaning in a descriptive variable name (`recipient`, `privateKey`), not in a comment. A comment that restates the variable name is deleted; provenance worth stating moves to prose.
-- Security-sensitive behavior is stated plainly on the page where the risk is acted on: key material lifetimes, zeroing, nonce handling, prompt counts, and what the library cannot protect against.
+- A value carries its meaning in a descriptive variable name (`recipient`, `privateKey`), not in a comment and not in prose after the block. A literal worth explaining becomes a named variable. A comment that restates the variable name is deleted; provenance worth stating moves to prose.
+- Security-sensitive behavior (key material lifetimes, zeroing, nonce handling, prompt counts, what the library cannot protect against) is stated plainly on the concept and reference pages that own it, and in a recipe at the step that acts on the risk. Getting started links to it instead of restating.
 - Support claims are date-stamped. The authenticator matrix lives on the authenticator-support page and is maintained there only.
 
 ## Mechanics

--- a/docs/src/assets/diagrams/getting-started-overview.svg
+++ b/docs/src/assets/diagrams/getting-started-overview.svg
@@ -27,31 +27,25 @@
   </defs>
 
   <rect class="d-node" x="4" y="16" width="136" height="56" rx="8" />
-  <text x="72" y="40" text-anchor="middle">Sign in</text>
-  <text x="72" y="59" text-anchor="middle" class="d-sub">passkey ceremony</text>
+  <text x="72" y="49" text-anchor="middle">Sign in</text>
   <text x="72" y="92" text-anchor="middle" class="d-sub">mera</text>
 
   <path class="d-edge" d="M140 44 H160" marker-end="url(#gs-arrow)" />
 
   <rect class="d-secret" x="164" y="16" width="136" height="56" rx="8" />
-  <text x="232" y="40" text-anchor="middle">32 secret bytes</text>
-  <text x="232" y="59" text-anchor="middle" class="d-sub">
-    same every sign-in
-  </text>
+  <text x="232" y="49" text-anchor="middle">32 secret bytes</text>
   <text x="232" y="92" text-anchor="middle" class="d-sub">mera</text>
 
   <path class="d-edge" d="M300 44 H320" marker-end="url(#gs-arrow)" />
 
   <rect class="d-secret" x="324" y="16" width="136" height="56" rx="8" />
-  <text x="392" y="40" text-anchor="middle">Derive a key</text>
-  <text x="392" y="59" text-anchor="middle" class="d-sub">any scheme</text>
+  <text x="392" y="49" text-anchor="middle">Derive a key</text>
   <text x="392" y="92" text-anchor="middle" class="d-sub">the app</text>
 
   <path class="d-edge" d="M460 44 H480" marker-end="url(#gs-arrow)" />
 
   <rect class="d-secret" x="484" y="16" width="136" height="56" rx="8" />
-  <text x="552" y="40" text-anchor="middle">Signing session</text>
-  <text x="552" y="59" text-anchor="middle" class="d-sub">holds the key</text>
+  <text x="552" y="49" text-anchor="middle">Signing session</text>
   <text x="552" y="92" text-anchor="middle" class="d-sub">mera</text>
 
   <path class="d-edge" d="M620 44 H640" marker-end="url(#gs-arrow)" />

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,7 +3,7 @@ title: Getting started
 description: Install the library, derive an account, and make a first signature.
 ---
 
-import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg"
+import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
 mera lets you:
 
@@ -35,14 +35,14 @@ npm install @scure/bip32 @scure/bip39
 `createPasskeyWithPrfOutput` creates a passkey and evaluates its PRF in one call. The `rpId` is the relying party ID, the domain the passkey is bound to.
 
 ```ts
-import { createPasskeyWithPrfOutput } from "@category-labs/mera"
+import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 
-const rpId = "account.example.com"
+const rpId = "account.example.com";
 
 const { prfOutput } = await createPasskeyWithPrfOutput({
   rp: { id: rpId, name: "Example" },
   user: { name: "account@example.com", displayName: "Example account" },
-})
+});
 ```
 
 mera uses a stable PRF salt for this call, so a later sign-in reproduces the same 32 bytes.
@@ -52,33 +52,36 @@ mera uses a stable PRF salt for this call, so a later sign-in reproduces the sam
 The PRF output is entropy, the root of every account. This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
 
 ```ts
-import { HDKey } from "@scure/bip32"
-import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39"
-import { wordlist } from "@scure/bip39/wordlists/english.js"
+import { HDKey } from "@scure/bip32";
+import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
 
-const firstEthereumAccountPath = "m/44'/60'/0'/0/0"
+const firstEthereumAccountPath = "m/44'/60'/0'/0/0";
 
-const mnemonic = entropyToMnemonic(prfOutput, wordlist)
-const seed = mnemonicToSeedSync(mnemonic)
-const node = HDKey.fromMasterSeed(seed).derive(firstEthereumAccountPath)
-if (node.privateKey === null) throw new Error("derivation produced no key")
+const mnemonic = entropyToMnemonic(prfOutput, wordlist);
+const seed = mnemonicToSeedSync(mnemonic);
+const node = HDKey.fromMasterSeed(seed).derive(firstEthereumAccountPath);
+if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 
 ## Sign
 
 ```ts
-import { createSecp256k1SigningSession, getEvmAddress } from "@category-labs/mera"
+import {
+  createSecp256k1SigningSession,
+  getEvmAddress,
+} from "@category-labs/mera";
 
 const session = createSecp256k1SigningSession({
   privateKey: node.privateKey,
-})
+});
 
-const address = getEvmAddress(session.publicKey)
+const address = getEvmAddress(session.publicKey);
 
-const digest = new Uint8Array(32)
-const signature = await session.signDigest(digest)
+const digest = new Uint8Array(32);
+const signature = await session.signDigest(digest);
 
-session.lock()
+session.lock();
 ```
 
 ## Sign back in
@@ -86,11 +89,11 @@ session.lock()
 A later visit reproduces the same account.
 
 ```ts
-import { getPasskeyPrfOutput } from "@category-labs/mera"
+import { getPasskeyPrfOutput } from "@category-labs/mera";
 
 const { prfOutput } = await getPasskeyPrfOutput({
   rpId,
-})
+});
 ```
 
 Without `credential`, the browser offers any discoverable passkey it holds for the relying party. The [Create passkey accounts](/recipes/create-passkey-accounts/) recipe shows the app storing the credential ID at create time and passing it back to pin later sign-ins.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -32,11 +32,12 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a passkey and evaluates its PRF in one call. The `rpId` is the relying party ID, the domain the passkey is bound to.
+`createPasskeyWithPrfOutput` creates a passkey and evaluates its PRF in one call.
 
 ```ts
 import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 
+// The relying party ID, the domain the passkey is bound to.
 const rpId = "account.example.com";
 
 const { prfOutput } = await createPasskeyWithPrfOutput({

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -5,7 +5,7 @@ description: Install the library, derive an account, and make a first signature.
 
 import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
 
-mera lets you:
+What mera does:
 
 - Create a passkey and get 32 secret bytes from it through the [PRF extension](/concepts/passkeys-and-prf/).
 - Use those bytes as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,9 +3,13 @@ title: Getting started
 description: Install the library, derive an account, and make a first signature.
 ---
 
-import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg";
+import GettingStartedOverview from "../../assets/diagrams/getting-started-overview.svg"
 
-A passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) shows one user-verification prompt and returns 32 secret bytes through the [PRF extension](/concepts/passkeys-and-prf/). The app uses those bytes as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts, and a [signing session](/concepts/signing-sessions/) holds one derived private key and signs, without further prompts, until it is locked. Everything mera returns lives in the page's JavaScript memory ([security model](/concepts/security-model/)).
+mera lets you:
+
+- Create a passkey and get 32 secret bytes from it through the [PRF extension](/concepts/passkeys-and-prf/).
+- Use those bytes as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts.
+- Sign with a lockable [signing session](/concepts/signing-sessions/).
 
 <GettingStartedOverview />
 
@@ -28,78 +32,71 @@ npm install @scure/bip32 @scure/bip39
 
 ## Create a passkey
 
-`createPasskeyWithPrfOutput` creates a [discoverable](/concepts/passkeys-and-prf/) passkey and evaluates its PRF in one call. The `rpId` is the relying party ID, the domain the passkey is bound to.
+`createPasskeyWithPrfOutput` creates a passkey and evaluates its PRF in one call. The `rpId` is the relying party ID, the domain the passkey is bound to.
 
 ```ts
-import { createPasskeyWithPrfOutput } from "@category-labs/mera";
+import { createPasskeyWithPrfOutput } from "@category-labs/mera"
 
-const rpId = "account.example.com";
+const rpId = "account.example.com"
 
 const { prfOutput } = await createPasskeyWithPrfOutput({
   rp: { id: rpId, name: "Example" },
   user: { name: "account@example.com", displayName: "Example account" },
-});
+})
 ```
 
-The call prompts once, or twice when the authenticator needs a follow-up [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts) to evaluate PRF.
-
-mera uses its [default salt](/reference/get-passkey-prf-output/) for this call, so a later sign-in reproduces the same 32 bytes.
+mera uses a stable PRF salt for this call, so a later sign-in reproduces the same 32 bytes.
 
 ## Derive an account
 
-The PRF output is entropy, the root of every account that follows ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/)). This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
+The PRF output is entropy, the root of every account. This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
 
 ```ts
-import { HDKey } from "@scure/bip32";
-import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
-import { wordlist } from "@scure/bip39/wordlists/english.js";
+import { HDKey } from "@scure/bip32"
+import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39"
+import { wordlist } from "@scure/bip39/wordlists/english.js"
 
-const mnemonic = entropyToMnemonic(prfOutput, wordlist);
-const seed = mnemonicToSeedSync(mnemonic);
-const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
-if (node.privateKey === null) throw new Error("derivation produced no key");
+const firstEthereumAccountPath = "m/44'/60'/0'/0/0"
+
+const mnemonic = entropyToMnemonic(prfOutput, wordlist)
+const seed = mnemonicToSeedSync(mnemonic)
+const node = HDKey.fromMasterSeed(seed).derive(firstEthereumAccountPath)
+if (node.privateKey === null) throw new Error("derivation produced no key")
 ```
-
-`m/44'/60'/0'/0/0` is the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) path for the first Ethereum account, the key MetaMask derives first from an imported phrase.
 
 ## Sign
 
 ```ts
-import {
-  createSecp256k1SigningSession,
-  getEvmAddress,
-} from "@category-labs/mera";
+import { createSecp256k1SigningSession, getEvmAddress } from "@category-labs/mera"
 
 const session = createSecp256k1SigningSession({
   privateKey: node.privateKey,
-});
+})
 
-const address = getEvmAddress(session.publicKey);
+const address = getEvmAddress(session.publicKey)
 
-const digest = new Uint8Array(32);
-const signature = await session.signDigest(digest);
+const digest = new Uint8Array(32)
+const signature = await session.signDigest(digest)
 
-session.lock();
+session.lock()
 ```
-
-The digest is the 32-byte hash of the transaction or message to sign. This walkthrough signs a placeholder buffer. The session copies the key, and `lock()` [zeroes](/concepts/signing-sessions/#the-lifecycle) that copy.
 
 ## Sign back in
 
-A later visit needs no stored secret: the same assertion reproduces the account.
+A later visit reproduces the same account.
 
 ```ts
-import { getPasskeyPrfOutput } from "@category-labs/mera";
+import { getPasskeyPrfOutput } from "@category-labs/mera"
 
 const { prfOutput } = await getPasskeyPrfOutput({
   rpId,
-});
+})
 ```
 
-Without `credential`, the browser offers any discoverable passkey it holds for the relying party. [Create passkey accounts](/recipes/create-passkey-accounts/) stores the credential ID at create time and pins later sign-ins to it.
+Without `credential`, the browser offers any discoverable passkey it holds for the relying party. The [Create passkey accounts](/recipes/create-passkey-accounts/) recipe shows the app storing the credential ID at create time and passing it back to pin later sign-ins.
 
 ## Where next
 
 - [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): from sign-in to a sent transaction.
-- [Passkey accounts](/concepts/passkey-accounts/): why the same passkey reproduces the same accounts, and what losing it means.
-- [Secret vaults](/concepts/secret-vaults/): encrypting a secret that already exists behind the passkey.
+- [Passkey accounts](/concepts/passkey-accounts/): learn how the same passkey reproduces the same accounts.
+- [Secret vaults](/concepts/secret-vaults/): use passkey PRF output to encrypt a secret, useful for cases where the secret must come from elsewhere.


### PR DESCRIPTION
## Why

The page opened with a dense three-sentence paragraph a reader had to decode before reaching the first command, and the overview diagram repeated it in per-box subtitles. The opening is now a three-bullet list of what mera does, the diagram keeps only the step names and the mera/app ownership row, and the walkthrough prose drops the asides the code or the linked concept pages already carry.

Two claims also sharpened: the derivation path's meaning now lives in a `firstEthereumAccountPath` variable instead of a sentence under the code block, and the credential-pinning pointer names the app as the actor that stores the credential ID, since the library never writes to storage.

The last commit records what the proofread kept cutting as general rules in docs/AGENTS.md, so the next page starts from them.

## Notes for reviewers

`npm run check` and the docs build pass.