### PR TITLE
Extend the getting-started simplifications to the recipes and diagrams

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,7 +8,7 @@ The reader is a strong software engineer who may know none of blockchain, crypto
 
 Define every complex concept or acronym on first mention in a page: one to three sentences, tied to the step the reader is in, linking the owning page for depth. Later mentions on the same page reuse the short name without re-explaining. The foundations concept page (`concepts/entropy-keys-and-accounts`) owns the blockchain background; glosses elsewhere link there rather than re-teaching it.
 
-Reference pages are exempt: they state facts and link to the page that teaches. Getting started is exempt in the other direction: it links the owning concept page instead of defining inline.
+Reference pages are exempt: they state facts and link to the page that teaches. Getting started and recipes are exempt in the other direction: they link the owning concept page instead of defining inline.
 
 ## Information architecture
 

--- a/docs/src/assets/diagrams/derivation-pipeline.svg
+++ b/docs/src/assets/diagrams/derivation-pipeline.svg
@@ -29,12 +29,10 @@
 
   <!-- entropy and its BIP-39 phrase encoding -->
   <rect class="d-secret" x="30" y="24" width="220" height="56" rx="8" />
-  <text x="140" y="48" text-anchor="middle">Entropy</text>
-  <text x="140" y="67" text-anchor="middle" class="d-sub">32 random bytes</text>
+  <text x="140" y="57" text-anchor="middle">Entropy</text>
 
   <rect class="d-secret" x="400" y="24" width="210" height="56" rx="8" />
-  <text x="505" y="48" text-anchor="middle">Seed phrase</text>
-  <text x="505" y="67" text-anchor="middle" class="d-sub">12 or 24 words</text>
+  <text x="505" y="57" text-anchor="middle">Seed phrase</text>
 
   <path
     class="d-edge d-dashed"
@@ -43,53 +41,36 @@
     marker-end="url(#dp-arrow)"
   />
   <text x="325" y="42" text-anchor="middle" class="d-note">BIP-39</text>
-  <text x="325" y="74" text-anchor="middle" class="d-sub">
-    adds no security
-  </text>
 
   <!-- the derivation spine -->
   <path class="d-edge" d="M140 80 V126" marker-end="url(#dp-arrow)" />
   <text x="152" y="107" class="d-note">key derivation (KDF)</text>
 
   <rect class="d-secret" x="30" y="132" width="220" height="56" rx="8" />
-  <text x="140" y="156" text-anchor="middle">Seed</text>
-  <text x="140" y="175" text-anchor="middle" class="d-sub">
-    extends into a tree of keys
-  </text>
+  <text x="140" y="165" text-anchor="middle">Seed</text>
 
   <path class="d-edge" d="M140 188 V234" marker-end="url(#dp-arrow)" />
   <text x="152" y="205" class="d-note">BIP-32 / SLIP-0010 derivation</text>
   <text x="152" y="223" class="d-mono">m/44'/60'/0'/0/0</text>
 
   <rect class="d-secret" x="30" y="240" width="220" height="56" rx="8" />
-  <text x="140" y="264" text-anchor="middle">Private key</text>
-  <text x="140" y="283" text-anchor="middle" class="d-sub">
-    a 256-bit secret number
-  </text>
+  <text x="140" y="273" text-anchor="middle">Private key</text>
 
   <path class="d-edge" d="M140 296 V342" marker-end="url(#dp-arrow)" />
-  <text x="152" y="323" class="d-note">one-way: infeasible to reverse</text>
+  <text x="152" y="323" class="d-note">one-way function</text>
 
   <rect class="d-node" x="30" y="348" width="220" height="56" rx="8" />
-  <text x="140" y="372" text-anchor="middle">Public key</text>
-  <text x="140" y="391" text-anchor="middle" class="d-sub">safe to share</text>
+  <text x="140" y="381" text-anchor="middle">Public key</text>
 
   <path class="d-edge" d="M140 404 V450" marker-end="url(#dp-arrow)" />
-  <text x="152" y="431" class="d-note">a short encoding of the public key</text>
+  <text x="152" y="431" class="d-note">encoding</text>
 
   <rect class="d-node" x="30" y="456" width="220" height="56" rx="8" />
-  <text x="140" y="480" text-anchor="middle">Address</text>
-  <text x="140" y="499" text-anchor="middle" class="d-sub">
-    safe to publish
-  </text>
+  <text x="140" y="489" text-anchor="middle">Address</text>
 
-  <!-- side note and legend -->
-  <text x="402" y="170" class="d-note">Only the entropy is unpredictable;</text>
-  <text x="402" y="190" class="d-note">everything after it is recomputed,</text>
-  <text x="402" y="210" class="d-note">never stored.</text>
-
-  <rect class="d-secret" x="402" y="292" width="14" height="14" rx="3" />
-  <text x="424" y="304" class="d-note">secret material</text>
-  <rect class="d-node" x="402" y="322" width="14" height="14" rx="3" />
-  <text x="424" y="334" class="d-note">safe to share</text>
+  <!-- legend -->
+  <rect class="d-secret" x="402" y="152" width="14" height="14" rx="3" />
+  <text x="424" y="164" class="d-note">secret material</text>
+  <rect class="d-node" x="402" y="182" width="14" height="14" rx="3" />
+  <text x="424" y="194" class="d-note">safe to share</text>
 </svg>

--- a/docs/src/assets/diagrams/first-vs-returning.svg
+++ b/docs/src/assets/diagrams/first-vs-returning.svg
@@ -30,7 +30,7 @@
   </defs>
 
   <!-- first visit -->
-  <rect class="d-zone" x="24" y="24" width="296" height="246" rx="10" />
+  <rect class="d-zone" x="24" y="24" width="296" height="216" rx="10" />
   <text x="38" y="46" class="d-sub">first visit</text>
 
   <rect class="d-node" x="48" y="56" width="248" height="56" rx="8" />
@@ -41,19 +41,13 @@
 
   <path class="d-edge" d="M172 112 V156" marker-end="url(#fr-arrow)" />
 
-  <rect class="d-node" x="48" y="160" width="248" height="80" rx="8" />
-  <text x="172" y="184" text-anchor="middle">Credential metadata</text>
-  <text x="172" y="203" text-anchor="middle" class="d-sub">
-    credentialId and transports
-  </text>
-  <text x="172" y="221" text-anchor="middle" class="d-sub">
-    no key material
-  </text>
+  <rect class="d-node" x="48" y="160" width="248" height="56" rx="8" />
+  <text x="172" y="193" text-anchor="middle">Credential metadata</text>
 
   <!-- the stored record feeds the later sign-in -->
   <path
     class="d-edge d-dashed"
-    d="M296 200 L378 92"
+    d="M296 188 L378 92"
     marker-end="url(#fr-arrow)"
   />
 
@@ -70,26 +64,19 @@
   <path class="d-edge" d="M508 112 V156" marker-end="url(#fr-arrow)" />
 
   <rect class="d-secret" x="384" y="160" width="248" height="56" rx="8" />
-  <text x="508" y="184" text-anchor="middle">PRF output</text>
-  <text x="508" y="203" text-anchor="middle" class="d-sub">32 bytes</text>
+  <text x="508" y="193" text-anchor="middle">PRF output</text>
 
   <path class="d-edge" d="M508 216 V260" marker-end="url(#fr-arrow)" />
   <text x="520" y="242" class="d-sub">BIP-39</text>
 
   <rect class="d-secret" x="384" y="264" width="248" height="56" rx="8" />
-  <text x="508" y="288" text-anchor="middle">Seed</text>
-  <text x="508" y="307" text-anchor="middle" class="d-sub">
-    held in memory for the session
-  </text>
+  <text x="508" y="297" text-anchor="middle">Seed</text>
 
   <path class="d-edge" d="M508 320 V364" marker-end="url(#fr-arrow)" />
-  <text x="520" y="346" class="d-sub">HD derivation by index</text>
+  <text x="520" y="346" class="d-sub">derivation by index</text>
 
   <rect class="d-secret" x="384" y="368" width="248" height="64" rx="8" />
-  <text x="508" y="394" text-anchor="middle">Signing sessions</text>
-  <text x="508" y="413" text-anchor="middle" class="d-sub">
-    EVM and Solana, numbered by index
-  </text>
+  <text x="508" y="405" text-anchor="middle">Signing sessions</text>
 
   <path class="d-edge" d="M508 432 V476" marker-end="url(#fr-arrow)" />
   <text x="520" y="458" class="d-mono">lock()</text>

--- a/docs/src/assets/diagrams/session-lifecycle.svg
+++ b/docs/src/assets/diagrams/session-lifecycle.svg
@@ -1,8 +1,8 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="200 0 440 476"
+  viewBox="200 0 440 432"
   width="440"
-  height="476"
+  height="432"
   role="img"
   class="mera-diagram"
 >
@@ -28,21 +28,13 @@
   </defs>
 
   <rect class="d-secret" x="220" y="24" width="200" height="56" rx="8" />
-  <text x="320" y="48" text-anchor="middle">Private key</text>
-  <text x="320" y="67" text-anchor="middle" class="d-sub">
-    derived, decrypted, or imported
-  </text>
+  <text x="320" y="57" text-anchor="middle">Private key</text>
 
   <path class="d-edge" d="M320 80 V164" marker-end="url(#sl-arrow)" />
-  <text x="332" y="121" class="d-sub">
-    creating the session consumes the key
-  </text>
+  <text x="332" y="126" class="d-sub">create the session</text>
 
   <rect class="d-secret" x="220" y="168" width="200" height="64" rx="16" />
-  <text x="320" y="194" text-anchor="middle">Unlocked</text>
-  <text x="320" y="213" text-anchor="middle" class="d-sub">
-    holds the only copy of the key
-  </text>
+  <text x="320" y="205" text-anchor="middle">Unlocked</text>
 
   <path
     class="d-edge"
@@ -52,16 +44,8 @@
   <text x="490" y="203" class="d-sub">signs on request</text>
 
   <path class="d-edge" d="M320 232 V344" marker-end="url(#sl-arrow)" />
-  <text x="332" y="280" class="d-mono">lock()</text>
-  <text x="332" y="298" class="d-sub">zeroes the session's key copy</text>
+  <text x="332" y="292" class="d-mono">lock()</text>
 
   <rect class="d-node" x="220" y="348" width="200" height="64" rx="16" />
-  <text x="320" y="374" text-anchor="middle">Locked</text>
-  <text x="320" y="393" text-anchor="middle" class="d-sub">
-    permanent; there is no unlock
-  </text>
-
-  <text x="420" y="456" text-anchor="middle" class="d-note">
-    A new signature needs a new session.
-  </text>
+  <text x="320" y="385" text-anchor="middle">Locked</text>
 </svg>

--- a/docs/src/assets/diagrams/vault-roundtrip.svg
+++ b/docs/src/assets/diagrams/vault-roundtrip.svg
@@ -1,8 +1,8 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 680 500"
+  viewBox="0 0 680 468"
   width="680"
-  height="500"
+  height="468"
   role="img"
   class="mera-diagram"
 >
@@ -30,49 +30,27 @@
   </defs>
 
   <rect class="d-secret" x="60" y="24" width="240" height="56" rx="8" />
-  <text x="180" y="48" text-anchor="middle">Secret</text>
-  <text x="180" y="67" text-anchor="middle" class="d-sub">
-    a phrase, a key, any bytes
-  </text>
+  <text x="180" y="57" text-anchor="middle">Secret</text>
 
   <path class="d-edge" d="M180 80 V140" marker-end="url(#vr-arrow)" />
 
   <rect class="d-node" x="60" y="144" width="240" height="56" rx="8" />
-  <text x="180" y="168" text-anchor="middle">AES-256-GCM</text>
-  <text x="180" y="187" text-anchor="middle" class="d-sub">
-    authenticated encryption
-  </text>
+  <text x="180" y="177" text-anchor="middle">AES-256-GCM</text>
 
   <rect class="d-node" x="380" y="144" width="260" height="56" rx="8" />
-  <text x="510" y="168" text-anchor="middle">Passkey ceremony</text>
-  <text x="510" y="187" text-anchor="middle" class="d-sub">
-    a fresh random salt per secret
-  </text>
+  <text x="510" y="177" text-anchor="middle">Passkey ceremony</text>
 
   <path class="d-edge" d="M380 172 H308" marker-end="url(#vr-arrow)" />
-  <text x="344" y="162" text-anchor="middle" class="d-sub">PRF output</text>
-  <text x="344" y="188" text-anchor="middle" class="d-sub">32 bytes</text>
+  <text x="344" y="164" text-anchor="middle" class="d-sub">PRF output</text>
 
   <path class="d-edge" d="M180 200 V260" marker-end="url(#vr-arrow)" />
-  <text x="192" y="234" class="d-sub">the salt is stored in the vault</text>
 
   <rect class="d-node" x="60" y="264" width="240" height="64" rx="8" />
-  <text x="180" y="290" text-anchor="middle">Vault JSON</text>
-  <text x="180" y="309" text-anchor="middle" class="d-sub">
-    localStorage, a backend, a sync service
-  </text>
+  <text x="180" y="301" text-anchor="middle">Vault JSON</text>
 
   <path class="d-edge" d="M180 328 V388" marker-end="url(#vr-arrow)" />
-  <text x="192" y="352" class="d-sub">unlock: the same ceremony with the</text>
-  <text x="192" y="370" class="d-sub">stored salt reproduces the key</text>
+  <text x="192" y="362" class="d-sub">unlock</text>
 
   <rect class="d-secret" x="60" y="392" width="240" height="56" rx="8" />
-  <text x="180" y="416" text-anchor="middle">Secret</text>
-  <text x="180" y="435" text-anchor="middle" class="d-sub">
-    only the ceremony recovers it
-  </text>
-
-  <text x="340" y="488" text-anchor="middle" class="d-note">
-    Tampering with the stored bytes makes decryption fail.
-  </text>
+  <text x="180" y="425" text-anchor="middle">Secret</text>
 </svg>

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -5,7 +5,12 @@ description: Create numbered EVM and Solana accounts from one passkey ceremony, 
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/): numbered EVM (Ethereum Virtual Machine) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking. It requires `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed, plus a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)). Seeds, derivation paths, and phrases are introduced in [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/).
+This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/): numbered [EVM](/concepts/entropy-keys-and-accounts/) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking.
+
+Prerequisites:
+
+- `@category-labs/mera`, `@scure/bip32`, `@scure/bip39`, and `@noble/hashes` installed.
+- A [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)).
 
 <FirstVsReturning />
 
@@ -21,8 +26,7 @@ const created = await createPasskeyWithPrfOutput({
   user: { name: "account@example.com", displayName: "Example account" },
 });
 
-// The seed comes from the sign-in ceremony below, so this flow never uses
-// the create-time PRF output; zero it right away.
+// The seed comes from the sign-in ceremony below; this output is unused.
 created.prfOutput.fill(0);
 ```
 
@@ -59,8 +63,7 @@ const { prfOutput, credentialId } = await getPasskeyPrfOutput({
   credential: known,
 });
 
-// The ceremony reports which credential was used; with no stored record,
-// the browser may have offered any discoverable passkey for the domain.
+// With no stored record, the browser may have used any discoverable passkey.
 const record =
   known?.credentialId === credentialId ? known : { credentialId };
 localStorage.setItem("app.derivedCredential", JSON.stringify(record));
@@ -68,7 +71,7 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 
 ## Hold a seed for the session
 
-Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, zero the output, and keep the seed in memory for the session. The seed is the one secret every account below derives from, so deriving account 3 later is pure HD (hierarchical deterministic) math with no further prompt.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, zero the output, and keep the seed in memory for the session: every account below derives from it without another ceremony.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
@@ -80,7 +83,7 @@ prfOutput.fill(0);
 
 ## Derive numbered accounts
 
-EVM accounts follow [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) over the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path, the MetaMask convention. BIP-44 fixes the path shape `m/44'/coin'/account'/change/index`, and 60 is Ethereum's registered coin type:
+EVM accounts follow [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) over the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path:
 
 ```ts
 import {
@@ -90,7 +93,8 @@ import {
 import { HDKey } from "@scure/bip32";
 
 function deriveEvmAccount(seed: Uint8Array, index: number) {
-  const node = HDKey.fromMasterSeed(seed).derive(`m/44'/60'/0'/0/${index}`);
+  const ethereumAccountPath = `m/44'/60'/0'/0/${index}`;
+  const node = HDKey.fromMasterSeed(seed).derive(ethereumAccountPath);
   if (node.privateKey === null) throw new Error("derivation produced no key");
   const session = createSecp256k1SigningSession({
     privateKey: node.privateKey,
@@ -99,7 +103,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32. The path is `m/44'/501'/{index}'/0'`, the one Phantom and Solflare use, and 501 is Solana's registered coin type. A hardened step is one that requires the parent private key, and Ed25519 supports only hardened steps, so the implementation is a short chain of HMAC (keyed hash) calls:
+Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32, and its derivation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {
@@ -111,8 +115,10 @@ import { sha512 } from "@noble/hashes/sha2.js";
 import { utf8ToBytes } from "@noble/hashes/utils.js";
 
 function deriveSolanaSeed(seed: Uint8Array, index: number): Uint8Array {
+  // The SLIP-0010 path m/44'/501'/{index}'/0'; every step is hardened.
+  const solanaAccountPath = [44, 501, index, 0];
   let i = hmac(sha512, utf8ToBytes("ed25519 seed"), seed);
-  for (const step of [44, 501, index, 0]) {
+  for (const step of solanaAccountPath) {
     const data = new Uint8Array(1 + 32 + 4);
     data.set(i.slice(0, 32), 1);
     new DataView(data.buffer).setUint32(33, (step + 0x80000000) >>> 0, false);

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -3,9 +3,14 @@ title: Send a transaction with viem
 description: Sign in with a passkey, derive the first EVM account, and send a transaction through viem.
 ---
 
-This recipe turns a passkey sign-in into a sent transaction. Prerequisites: `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed, a [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)), an existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit), and test funds on the sending address.
+This recipe turns a passkey sign-in into a sent transaction. [viem](https://viem.sh) is a TypeScript client library for [EVM](/concepts/entropy-keys-and-accounts/) chains; [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session.
 
-[viem](https://viem.sh) is a TypeScript client library for EVM chains (chains that run the Ethereum Virtual Machine). [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session.
+Prerequisites:
+
+- `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed.
+- A [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)).
+- An existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit).
+- Test funds on the sending address.
 
 ## Sign in
 
@@ -21,17 +26,19 @@ The call runs one ceremony, the only prompt in this recipe. [Create passkey acco
 
 ## Derive the key
 
-The seed comes from the same mapping [Create passkey accounts](/recipes/create-passkey-accounts/) uses: the PRF output becomes [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) entropy, the seed feeds [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki), and `m/44'/60'/0'/0/0` is the [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) Ethereum path ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces the standards).
+The seed and path come from the same mapping [Create passkey accounts](/recipes/create-passkey-accounts/) uses ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces the standards).
 
 ```ts
 import { HDKey } from "@scure/bip32";
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
+const firstEthereumAccountPath = "m/44'/60'/0'/0/0";
+
 const seed = mnemonicToSeedSync(entropyToMnemonic(prfOutput, wordlist));
 prfOutput.fill(0);
 
-const node = HDKey.fromMasterSeed(seed).derive("m/44'/60'/0'/0/0");
+const node = HDKey.fromMasterSeed(seed).derive(firstEthereumAccountPath);
 if (node.privateKey === null) throw new Error("derivation produced no key");
 ```
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,7 +3,12 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing. It requires `@category-labs/mera` and `@scure/bip39` installed, and a place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
+A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
+
+Prerequisites:
+
+- `@category-labs/mera` and `@scure/bip39` installed.
+- A place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
 
 ## Validate the phrase
 
@@ -42,7 +47,7 @@ try {
 }
 ```
 
-The `finally` zeroes the caller-owned encoded phrase. A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text.
+A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text.
 
 ## Unlock
 


### PR DESCRIPTION
## Why

The getting-started proofread (#237) settled a set of rules: prerequisites as a list rather than a dense opening paragraph, links to the owning concept page instead of inline definitions, path literals named in code instead of explained in prose, no claims that exist to impress, and no diagram subtitles that restate the page. The recipes and the remaining diagrams still had every one of those patterns; this PR applies the same pass to them and extends the docs/AGENTS.md link-instead-of-define exemption from getting started to recipes, since they drifted the same way.

Diagram subtitle cuts keep node step names, edge transform names, zone labels, and the accessible `<title>` descriptions; only rows repeating page prose are gone. Verified each of the four edited diagrams renders correctly in the built site.

## Notes for reviewers

The Solana derivation section no longer defines hardened steps or names Phantom and Solflare; the SLIP-0010 path now lives as a named variable with a one-line comment in the code block. If that trimmed too much context for the recipe, that hunk is easy to soften independently.