### PR TITLE
Simplify the concept pages and the viem recipe

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,17 +4,21 @@ Guidance for authoring content in this site (`src/content/docs/`). [site/WRITING
 
 ## Audience
 
-The reader is a strong software engineer who may know none of blockchain, cryptography, or WebAuthn. Build explanations bottom-up: start from concrete pieces the reader can hold ("32 random bytes", "a 12-word phrase"), then assemble them into the larger mechanism.
+The reader is a strong software engineer who may know none of blockchain, cryptography, or WebAuthn. On the page that owns a concept, build the explanation bottom-up: start from concrete pieces the reader can hold ("32 random bytes", "a 12-word phrase"), then assemble them into the larger mechanism.
 
-Define every complex concept or acronym on first mention in a page: one to three sentences, tied to the step the reader is in, linking the owning page for depth. Later mentions on the same page reuse the short name without re-explaining. The foundations concept page (`concepts/entropy-keys-and-accounts`) owns the blockchain background; glosses elsewhere link there rather than re-teaching it.
+## Concept ownership
 
-Reference pages are exempt: they state facts and link to the page that teaches. Getting started and recipes are exempt in the other direction: they link the owning concept page instead of defining inline.
+Each concept is taught on exactly one page. The foundations page (`concepts/entropy-keys-and-accounts`) owns the blockchain background, each concept page owns its title subject, and each reference page owns the exact behavior of its function.
+
+Every other page uses the term plainly and does not define it. A definition repeated at each mention is noise for the reader who knows the term and a detour for the one who does not. When a sentence cannot stand without the meaning, add a gloss of a few words at most ("the rpId, the domain the passkey is bound to").
+
+Link a term inline only when the reader needs the owning page to finish the current step. Otherwise the owning page belongs under "See also". Material that outgrows a gloss moves to the owning page.
 
 ## Information architecture
 
 The site follows the Diátaxis split (<https://diataxis.fr/>): each page does one job.
 
-- **Getting started** teaches one first success, end to end. Its lead states what the reader will do, not how the mechanism works. Each step links the owning page instead of explaining; a detail the reader does not need for the next step is a link, not a sentence.
+- **Getting started** teaches one first success, end to end. Its lead states what the reader will do, not how the mechanism works. Each step states what to do and leaves the mechanism to the owning page; a detail the reader does not need for the next step is cut.
 - **Concepts** explain how something works and why it is designed that way. No step-by-step instructions.
 - **Recipes** solve one task each. A recipe assumes a competent reader with a goal, states its prerequisites, and gets to the point.
 - **Reference** states facts about the public API, one exported function per page. Keep instructions, opinions, and long explanations out of it; link to them instead.
@@ -113,3 +117,4 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 5. No em dash anywhere in the diff.
 6. No banned vocabulary, no "not X, but Y".
 7. "Wallet" appears only next to wallet apps.
+8. No page defines a concept another page owns.

--- a/docs/src/assets/diagrams/trust-boundary.svg
+++ b/docs/src/assets/diagrams/trust-boundary.svg
@@ -69,9 +69,4 @@
   <text x="574" y="224" text-anchor="middle" class="d-sub">
     asks for user verification
   </text>
-
-  <text x="340" y="360" text-anchor="middle" class="d-note">
-    Any script on the page can see key material and sign with an unlocked
-    session.
-  </text>
 </svg>

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -6,15 +6,13 @@ description: How random bytes become a private key, an address, and a reproducib
 import DerivationPipeline from "../../../assets/diagrams/derivation-pipeline.svg";
 import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
 
-Readers who know [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) can skip to [Passkeys and the PRF extension](/concepts/passkeys-and-prf/).
-
 <DerivationPipeline />
 
 ## Keys, signatures, and accounts
 
 Entropy is randomness an attacker cannot predict, and 32 random bytes carry 256 bits of it.
 
-A private key is a 256-bit secret number. A one-way function computes the public key from it, so the public key is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
+A private key is a 256-bit secret number. A one-way function computes the public key from it, which is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
 
 A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key.
 
@@ -22,23 +20,23 @@ mera supports two signature schemes: secp256k1 on Ethereum and other EVM chains 
 
 ## Deterministic derivation
 
-A key-derivation function (KDF) turns one secret into others: the output looks random, and the same input always produces the same output. Because a KDF recomputes its outputs on demand, derived keys need no storage.
+A key-derivation function (KDF) turns one secret into others: the output looks random, but the same input always produces the same output. 
 
-A seed is the byte string a key tree starts from. BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, a scheme called hierarchical deterministic (HD) derivation, and a derivation path such as `m/44'/60'/0'/0/0` names one key in the tree. The same seed and path produce the same key on any machine, so one 32-byte value backs any number of accounts with nothing stored per account.
+A seed is the byte string a key tree starts from. BIP-32 (secp256k1) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) (Ed25519) extend one seed into a tree of child keys, a scheme called hierarchical deterministic (HD) derivation, and a derivation path such as `m/44'/60'/0'/0/0` names one key in the tree. The same seed and path produce the same key, so one 32-byte value backs any number of accounts with nothing stored per account.
 
 <Bip32Tree />
 
-Key material is any secret bytes in this pipeline: root entropy, a seed, a private key. Exposing key material exposes every key derived from it.
+
 
 ## Seed phrases
 
-BIP-39 maps entropy to a phrase of common words and back: 128 bits become 12 words, 256 bits become 24. The phrase is an encoding, adding no security of its own: anyone who reads the phrase can recover the entropy.
+BIP-39 maps entropy to a phrase of common words and back: 128 bits become 12 words, 256 bits become 24.
 
-A wallet app that follows the same standards (MetaMask and Phantom are two) turns an imported phrase back into the same accounts, which gives accounts built this way an exit path independent of any one library.
+A wallet app that follows the same standards turns an imported phrase back into the same accounts.
 
 ## Where mera fits
 
-mera supplies the root: a passkey ceremony returns 32 bytes of PRF output, secret bytes the passkey recomputes deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains how), and the app uses them as the entropy for this pipeline. Derivation, paths, and phrases are app-owned; the library returns entropy and signs.
+mera supplies the entropy for this pipeline: the PRF output of a passkey ceremony. [Passkey accounts](/concepts/passkey-accounts/) explains the account model built on it.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -3,11 +3,11 @@ title: Passkey accounts
 description: Accounts derived from a passkey's PRF output, with no stored secret.
 ---
 
-A passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically ([Passkeys and PRF](/concepts/passkeys-and-prf/) explains the mechanism). Each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts. This is the default way to use mera.
+In mera's model, a passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically, so each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts.
 
 ## One salt, one stable output
 
-When the PRF salt is omitted, mera uses its [default salt](/reference/get-passkey-prf-output/). The same passkey and relying party then produce the same PRF output on every device the passkey syncs to. There is no stored secret; all state lives in the passkey. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
+The PRF takes a 32-byte salt as input to give the same passkey unrelated outputs. Mera uses a fixed salt. The same passkey and relying party then produce the same PRF output on every device the passkey syncs to. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## Losing the passkey
 
@@ -15,7 +15,7 @@ The account may be unrecoverable if the passkey is deleted, not synced, tied to 
 
 ## When the secret already exists
 
-Passkey accounts are rooted in the passkey itself, so an account that predates the passkey cannot become one. A [secret vault](/concepts/secret-vaults/) covers that case: it encrypts the existing recovery phrase or private key behind the same passkey ceremony.
+Passkey accounts are rooted in the passkey itself, so an account that predates the passkey cannot become one. Mera supports encrypting arbitrary secrets with Passkey's PRF output, described in [secret vault](/concepts/secret-vaults/). This is an advanced use case since it requires the app to store the encrypted blob.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -5,40 +5,33 @@ description: What a passkey is, what the PRF extension adds, and why its output 
 
 import PrfFunction from "../../../assets/diagrams/prf-function.svg";
 
-A passkey is a discoverable WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords. A credential is one such key pair, created at a website's request by an authenticator: a phone, a password manager, or a hardware key. The private half never leaves the authenticator. Discoverable means the authenticator finds the credential for a domain on its own, so signing in needs no username and no stored identifier.
+A passkey is a WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/) is the browser standard for signing in with key pairs instead of passwords. A credential is one such key pair, created at a website's request by an authenticator: a phone, a password manager, or a hardware key. The private key never leaves the authenticator.
 
-**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another: after a domain migration, the old credential and everything derived from it are unreachable.
+**Passkeys are bound to a relying party ID.** The `rpId` is a domain, and a credential created under one rpId cannot be used under another.
 
-**Passkeys sync.** Platform authenticators, the credential stores built into an operating system or a password manager, replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs. Everything derived from the credential follows it to those devices.
+**Passkeys sync.** Platform authenticators, the credential stores built into an operating system or a password manager, replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs.
 
 ## User verification
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
 
-The requirement is not configurable. PRF is built on the [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) primitive of [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the protocol browsers use to talk to authenticators. An authenticator keeps two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it, so a setting could neither change the output nor skip the check.
+The requirement is not configurable. PRF is built on the [`hmac-secret`](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension) primitive of [CTAP](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the protocol browsers use to talk to authenticators. An authenticator keeps two PRFs per credential, one for user-verified requests and one for the rest. WebAuthn exposes only the user-verified PRF and overrides a weaker `userVerification` setting when evaluating it.
 
 ## The PRF extension
 
 The [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension) gives each credential a pseudorandom function: a function whose output looks random but is fully determined by its inputs. The caller passes a 32-byte salt with the ceremony and the authenticator returns 32 bytes.
 
-PRF output is determined by the credential, relying party ID, and salt. Those inputs produce the same 32 bytes on every synced device; a different salt produces unrelated output. Salts act as namespaces, which is why passkey accounts share one [fixed salt](/reference/get-passkey-prf-output/) while each secret vault gets a fresh random one.
+PRF output is determined by the credential, relying party ID, and salt. Those inputs produce the same 32 bytes on every synced device. Salts act as namespaces.
 
 <PrfFunction />
 
 ## Using the output
 
-The output appears only after user verification, and it never needs to be stored: the authenticator re-evaluates it on each ceremony. The output, unlike the credential's private key, leaves the authenticator and returns to the page ([security model](/concepts/security-model/)).
-
-mera returns the output and does nothing else with it. Passed to a [key-derivation scheme](/concepts/entropy-keys-and-accounts/), it produces a hierarchy of accounts: [passkey accounts](/concepts/passkey-accounts/), the default pattern. Used as [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation), it decrypts a [secret vault](/concepts/secret-vaults/), the advanced pattern for secrets that already exist.
+The output works as key material in two ways. Used as an encryption key, it locks data to the passkey: decrypting takes another ceremony. Used as a [derivation seed](/concepts/entropy-keys-and-accounts/), it recreates the same keys and accounts on every ceremony, so none of them are stored.
 
 ## Ceremonies and prompts
 
-A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential or runs an assertion, the call that uses an existing credential. Either kind can evaluate the PRF. mera runs both:
-
-- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) makes the credential and returns the PRF output.
-- [getPasskeyPrfOutput](/reference/get-passkey-prf-output/) asserts with an existing credential and returns the PRF output.
-
-Signing itself never prompts: it runs in a [signing session](/concepts/signing-sessions/) built from a ceremony's output.
+A ceremony is one WebAuthn call and one user-verification prompt. A ceremony either creates a credential (closest analogy is sign up) or runs an assertion (sign in).
 
 ## See also
 

--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -15,13 +15,11 @@ A secret vault holds one secret (a recovery phrase, a private key, any bytes), e
 
 Vaults encrypt with AES-256-GCM, a symmetric cipher: one key both encrypts and decrypts. The cipher authenticates what it encrypts, so tampering with the stored bytes makes decryption fail. For each secret, the vault functions derive the encryption key from the passkey's [PRF](/concepts/passkeys-and-prf/) evaluated against a fresh random 32-byte salt, and store that salt in the vault.
 
-The vault itself is ordinary JSON and can live in `localStorage`, on a backend, or in a sync service. Nothing it stores reveals the secret without the passkey.
-
 <VaultRoundtrip />
 
 ## When to use a vault
 
-The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Losing the passkey still loses access through mera, but any surviving copy of the secret restores the account. A passkey account, by contrast, is recoverable only through an export taken beforehand.
+The main case is migration: an account created elsewhere, with an existing recovery phrase or private key, moves to passkey sign-in by encrypting that secret once. Losing the passkey still loses access through mera, but any surviving copy of the secret restores the account.
 
 Where the vault lives, how it syncs, and how it survives device loss are design decisions the app owns. Losing every copy of both the vault and the secret loses the account.
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -5,11 +5,10 @@ description: What mera protects, what it cannot, and the risks left to the app.
 
 import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
-mera runs [passkey ceremonies](/concepts/passkeys-and-prf/#ceremonies-and-prompts), returns [entropy](/concepts/entropy-keys-and-accounts/) to the app, and holds signing keys in [lockable sessions](/concepts/signing-sessions/). All of it runs in the page, with software keys. The guarantees match a wallet app holding an imported seed phrase in the page.
+Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, it matches a wallet app holding an imported seed phrase in the page.
 
-- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session until `session.lock()`. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Locking sessions when idle and zeroing key material promptly shorten the exposure.
-- The passkey's own private key never leaves the authenticator. The PRF output does leave it, and every derived key is an ordinary value in page memory while in use.
-- Losing the passkey without a prior export loses the accounts derived from it. [Passkey accounts](/concepts/passkey-accounts/#losing-the-passkey) lists the ways a passkey is lost.
+- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Locking sessions when idle and zeroing key material promptly shorten the exposure.
+- Losing the passkey without a prior export loses the accounts derived from it.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.
 - The only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -7,7 +7,10 @@ import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
 A signing session holds a private key and signs with it until it is locked.
 
-Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages.
+Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/):
+
+- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/)
+- [createEd25519SigningSession](/reference/create-ed25519-signing-session/)
 
 ## Independent of passkeys
 

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -5,27 +5,23 @@ description: How a session owns its private key, why signing never prompts, and 
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds one private key and signs with it until it is locked.
+A signing session holds a private key and signs with it until it is locked.
 
-Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. A digest is the fixed-length hash of the content to sign. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages. Both hold and destroy the key the same way.
+Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/). [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) signs 32-byte digests. [createEd25519SigningSession](/reference/create-ed25519-signing-session/) signs arbitrary-length messages.
 
 ## Independent of passkeys
 
-A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere. The step in between, turning 32 bytes of [entropy](/concepts/entropy-keys-and-accounts/) into a chain-specific private key, is app-owned by design. [Passkey accounts](/concepts/passkey-accounts/) and [secret vaults](/concepts/secret-vaults/) describe the two sources of [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation).
+A session's input is a raw private key, derived from PRF output, decrypted from a vault, or imported from elsewhere.
 
-Because a session never contacts an authenticator, signing never prompts: the one user-verification prompt happened in the [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) that produced the entropy, and it covers any number of signatures.
+A session uses an in-memory private key and doesn't contact an authenticator.
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session. An unlock path would mean the key still existed somewhere after `lock()`.
+Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session.
 
 Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
 <SessionLifecycle />
-
-## The open window
-
-Between construction and lock, a compromised runtime can request signatures without reading the key. The [security model](/concepts/security-model/) covers the runtime trust boundary in full.
 
 ## How long to keep a session
 
@@ -35,6 +31,6 @@ An app that signs frequently may keep the session active for a burst of work and
 
 ## See also
 
-- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) and [createEd25519SigningSession](/reference/create-ed25519-signing-session/): the exact copy, zeroing, and locking semantics.
+- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) and [createEd25519SigningSession](/reference/create-ed25519-signing-session/)
 - [toViemAccount](/reference/to-viem-account/): a viem account backed by a secp256k1 session.
 - [Getting started](/getting-started/): the ceremony-to-signature path in code.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -104,3 +104,4 @@ Without `credential`, the browser offers any discoverable passkey it holds for t
 - [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): from sign-in to a sent transaction.
 - [Passkey accounts](/concepts/passkey-accounts/): learn how the same passkey reproduces the same accounts.
 - [Secret vaults](/concepts/secret-vaults/): use passkey PRF output to encrypt a secret, useful for cases where the secret must come from elsewhere.
+- [Security model](/concepts/security-model/): learn more about mera's security model.

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -64,16 +64,15 @@ const record =
 localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 ```
 
-## Hold a seed for the session
+## Create a seed from the PRF output
 
-Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed once, zero the output, and keep the seed in memory for the session: every account below derives from it without another ceremony.
+Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed.
 
 ```ts
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
 const seed = mnemonicToSeedSync(entropyToMnemonic(prfOutput, wordlist));
-prfOutput.fill(0);
 ```
 
 ## Derive numbered accounts
@@ -98,7 +97,7 @@ function deriveEvmAccount(seed: Uint8Array, index: number) {
 }
 ```
 
-Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the [Ed25519](/concepts/entropy-keys-and-accounts/) counterpart of BIP-32, and its derivation is a short chain of HMAC (keyed hash) calls:
+Solana uses [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), the Ed25519 counterpart of BIP-32, and its derivation is a short chain of HMAC (keyed hash) calls:
 
 ```ts
 import {
@@ -142,12 +141,6 @@ const accounts = [deriveEvmAccount(seed, 0), deriveSolanaAccount(seed, 0)];
 for (const account of accounts) {
   account.session.lock();
 }
-seed.fill(0);
 ```
 
-Sessions zero their own key copies on `lock()`. The seed is the app's buffer, so zeroing it is the app's job.
-
-## Pitfalls
-
-- **Do not change the derivation after launch.** Changing the mnemonic mapping or either path changes every account address.
-- **Accounts reproduce only under the same [rpId](/concepts/passkeys-and-prf/)**, the domain the passkey is bound to. A domain migration leaves them unreachable, with no error until someone tries to sign in. Give accounts an export path first. The phrase to show is `entropyToMnemonic` over the PRF output from a fresh sign-in ceremony, the same mapping the seed step uses ([Passkey accounts](/concepts/passkey-accounts/)).
+Locking zeroes private keys owned by the session.

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -5,7 +5,6 @@ description: Create numbered EVM and Solana accounts from one passkey ceremony, 
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";
 
-This recipe builds [passkey accounts](/concepts/passkey-accounts/), extending [Getting started](/getting-started/): numbered [EVM](/concepts/entropy-keys-and-accounts/) and Solana accounts, credential pinning, one passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) per session, and locking.
 
 Prerequisites:
 
@@ -26,11 +25,9 @@ const created = await createPasskeyWithPrfOutput({
   user: { name: "account@example.com", displayName: "Example account" },
 });
 
-// The seed comes from the sign-in ceremony below; this output is unused.
-created.prfOutput.fill(0);
 ```
 
-`user.id` is left to its default, a fresh 32-byte random handle, so every create call makes a distinct, parallel passkey.
+Every call creates a new passkey.
 
 ## Remember the credential
 
@@ -47,8 +44,6 @@ localStorage.setItem(
 ```
 
 `transports` is optional and only a hint: the browser uses it to reach the authenticator directly (a platform prompt for a platform passkey, a QR flow for a phone) instead of offering every option.
-
-A fresh device has no record, so sign-in falls back to a discoverable ceremony and the synced passkey still produces the same accounts.
 
 ## Sign in
 

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -31,7 +31,7 @@ Every call creates a new passkey.
 
 ## Remember the credential
 
-Store the credential metadata. It holds no key material; its only job is letting the next sign-in pin the exact passkey instead of showing every [discoverable credential](/concepts/passkeys-and-prf/) the authenticator holds for the domain.
+The app can store the credential metadata and pass it back on the next sign-in, so the browser reuses the same passkey instead of offering a choice.
 
 ```ts
 localStorage.setItem(

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -144,3 +144,9 @@ for (const account of accounts) {
 ```
 
 Locking zeroes private keys owned by the session.
+
+## See also
+
+- [Passkey accounts](/concepts/passkey-accounts/): the account model this recipe implements.
+- [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): sign and broadcast with a derived account.
+- [createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) and [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): the two ceremonies this recipe runs.

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -3,14 +3,7 @@ title: Send a transaction with viem
 description: Sign in with a passkey, derive the first EVM account, and send a transaction through viem.
 ---
 
-This recipe turns a passkey sign-in into a sent transaction. [viem](https://viem.sh) is a TypeScript client library for [EVM](/concepts/entropy-keys-and-accounts/) chains; [toViemAccount](/reference/to-viem-account/) adapts a [signing session](/concepts/signing-sessions/) into the account shape viem accepts, so viem signs and broadcasts while the key stays in the session.
-
-Prerequisites:
-
-- `@category-labs/mera`, `viem`, `@scure/bip32`, and `@scure/bip39` installed.
-- A [PRF](/concepts/passkeys-and-prf/)-capable authenticator ([authenticator support](/authenticator-support/)).
-- An existing passkey ([Create passkey accounts](/recipes/create-passkey-accounts/) covers the first visit).
-- Test funds on the sending address.
+Mera exports an adapter function [toViemAccount](/reference/to-viem-account/) that adapts a [signing session](/concepts/signing-sessions/) into the account shape [viem](https://viem.sh) accepts, so viem signs and broadcasts while the key is owned by the session.
 
 ## Sign in
 
@@ -21,8 +14,6 @@ const rpId = location.hostname;
 
 const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 ```
-
-The call runs one ceremony, the only prompt in this recipe. [Create passkey accounts](/recipes/create-passkey-accounts/) shows pinning the sign-in to a stored credential ID.
 
 ## Derive the key
 
@@ -36,7 +27,6 @@ import { wordlist } from "@scure/bip39/wordlists/english.js";
 const firstEthereumAccountPath = "m/44'/60'/0'/0/0";
 
 const seed = mnemonicToSeedSync(entropyToMnemonic(prfOutput, wordlist));
-prfOutput.fill(0);
 
 const node = HDKey.fromMasterSeed(seed).derive(firstEthereumAccountPath);
 if (node.privateKey === null) throw new Error("derivation produced no key");
@@ -53,7 +43,6 @@ import { toViemAccount } from "@category-labs/mera/viem";
 const session = createSecp256k1SigningSession({
   privateKey: node.privateKey,
 });
-seed.fill(0);
 
 const account = toViemAccount(session);
 ```
@@ -79,15 +68,7 @@ const hash = await client.sendTransaction({
 session.lock();
 ```
 
-`http()` with no URL uses the chain's default public RPC endpoint. Production apps pass a dedicated RPC URL.
-
-`sendTransaction` fills the missing transaction fields from the RPC, signs through the session, broadcasts, and resolves to the transaction hash. Confirmation is a separate query. viem's `waitForTransactionReceipt` on a public client covers it.
-
-## Pitfalls
-
-- **The derivation must match the app's other sign-in paths.** A different mapping or path reaches a different address.
-- **A locked session rejects every viem signing method** with [`SESSION_LOCKED`](/reference/errors/#session_locked): the account holds no key of its own and cannot sign without the session.
-- **Concurrent transactions can be assigned the same nonce**, the per-account counter that orders transactions, and the chain accepts only one of them. viem's nonce manager assigns nonces in sequence. Pass it through [toViemAccount](/reference/to-viem-account/) options.
+`sendTransaction` fills the missing transaction fields from the RPC, signs through the session and broadcasts.
 
 ## See also
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -3,27 +3,12 @@ title: Encrypt an existing secret with a passkey
 description: Encrypt an existing secret into a passkey-protected vault and unlock it later.
 ---
 
-A [secret vault](/concepts/secret-vaults/) encrypts one [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. This recipe validates a phrase, stores its vault, and decrypts it with explicit zeroing.
+A [secret vault](/concepts/secret-vaults/) encrypts a [recovery phrase](/concepts/entropy-keys-and-accounts/#seed-phrases), private key, or other byte string behind a passkey. This recipe encrypts a phrase and unlocks it later.
 
 Prerequisites:
 
-- `@category-labs/mera` and `@scure/bip39` installed.
+- `@category-labs/mera` installed.
 - A place to keep vault JSON (`localStorage` here; a backend or sync service works the same).
-
-## Validate the phrase
-
-A real app reads the phrase from a form field. The library never interprets the secret, so validation is app code:
-
-```ts
-import { validateMnemonic } from "@scure/bip39";
-import { wordlist } from "@scure/bip39/wordlists/english.js";
-
-const phrase =
-  "legal winner thank year wave sausage worth useful legal winner thank yellow";
-if (!validateMnemonic(phrase, wordlist)) {
-  throw new Error("Not a valid recovery phrase.");
-}
-```
 
 ## Create and persist the vault
 
@@ -34,6 +19,8 @@ import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
 
 const rpId = location.hostname;
 
+const phrase =
+  "legal winner thank year wave sausage worth useful legal winner thank yellow";
 const secret = new TextEncoder().encode(phrase);
 try {
   const vault = await createSecretVaultWithNewPasskey({
@@ -79,7 +66,3 @@ async function unlockPhrase(): Promise<string> {
 
 The phrase is a standard BIP-39 mnemonic, so key derivation from here is the same derivation passkey accounts use: one seed, then per-index paths. [Create passkey accounts](/recipes/create-passkey-accounts/) has both curves. Pass it `mnemonicToSeedSync(phrase)` instead of a PRF-derived seed and zero the seed after the sessions exist.
 
-## Pitfalls
-
-- **A second secret needs its own ceremony and vault.** [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/) generates the fresh salt and stores it in the new vault.
-- **The vault JSON is the only ciphertext copy.** Losing the storage loses the account unless the person still holds the phrase elsewhere.

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -55,4 +55,10 @@ async function unlockPhrase(): Promise<string> {
 
 `parseSecretVault` is the boundary for the untrusted stored JSON.
 
+## See also
+
+- [Secret vaults](/concepts/secret-vaults/): how a vault works and when to use one.
+- [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): encrypt another secret with the same passkey.
+- [Secret vault format](/reference/secret-vault-format/): the stored JSON, field by field.
+
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -22,16 +22,13 @@ const rpId = location.hostname;
 const phrase =
   "legal winner thank year wave sausage worth useful legal winner thank yellow";
 const secret = new TextEncoder().encode(phrase);
-try {
-  const vault = await createSecretVaultWithNewPasskey({
-    rp: { id: rpId, name: "Example" },
-    user: { name: "account@example.com", displayName: "Example account" },
-    secret,
-  });
-  localStorage.setItem("app.vault", JSON.stringify(vault));
-} finally {
-  secret.fill(0);
-}
+
+const vault = await createSecretVaultWithNewPasskey({
+  rp: { id: rpId, name: "Example" },
+  user: { name: "account@example.com", displayName: "Example account" },
+  secret,
+});
+localStorage.setItem("app.vault", JSON.stringify(vault));
 ```
 
 A private key is encrypted the same way: pass its raw bytes as `secret` instead of encoded text.
@@ -52,17 +49,10 @@ async function unlockPhrase(): Promise<string> {
 
   const vault = parseSecretVault(raw);
   const secret = await decryptSecretVaultWithPasskey({ rpId, vault });
-  try {
-    return new TextDecoder().decode(secret);
-  } finally {
-    secret.fill(0);
-  }
+  return new TextDecoder().decode(secret);
 }
 ```
 
 `parseSecretVault` is the boundary for the untrusted stored JSON.
 
-## Derive signing sessions
-
-The phrase is a standard BIP-39 mnemonic, so key derivation from here is the same derivation passkey accounts use: one seed, then per-index paths. [Create passkey accounts](/recipes/create-passkey-accounts/) has both curves. Pass it `mnemonicToSeedSync(phrase)` instead of a PRF-derived seed and zero the seed after the sessions exist.
 


### PR DESCRIPTION
The concept pages repeated one another: the security boundary and ceremony mechanics were restated on several pages, the PRF salt was used before being defined, and general WebAuthn/PRF concepts were tied to library patterns. The viem recipe front-loaded prerequisites and pitfalls that its linked pages cover.

This pass:

- defines the PRF salt before first use and names mera's salt plainly as a fixed salt;
- reframes the PRF page's "Using the output" around the output's two general uses, encryption and key derivation, following the PRF spec's own motivating example;
- cuts paragraphs that restate what the security model, the recipes, or the reference pages own;
- trims the viem recipe to the sign-in-to-transaction path;
- adds a security-model link to getting started's "Where next".

`npm run check` and the docs build pass.