### PR TITLE
Trim comments that document the language or the reviewer

### DIFF
--- a/src/chains/evm.ts
+++ b/src/chains/evm.ts
@@ -12,19 +12,18 @@ import type { EvmAddress } from "../types.js";
  */
 function getEvmAddress(publicKey: Uint8Array): EvmAddress {
   const uncompressed = normalizeSecp256k1PublicKey(publicKey);
-  const addressBytes = keccak_256(uncompressed.slice(1)).slice(-20);
+  const addressBytes = keccak_256(uncompressed.subarray(1)).slice(-20);
   return toChecksumAddress(bytesToHex(addressBytes));
 }
 
 // EIP-55: each lowercase hex nibble is uppercased iff the corresponding nibble
 // of keccak256(lowercase-hex-without-0x) is >= 8. Precondition: lowercaseHex is
-// already lowercase; mixed-case input would produce a wrong checksum.
+// the 20-byte address as 40 lowercase hex chars; mixed case would produce a
+// wrong checksum.
 function toChecksumAddress(lowercaseHex: string): EvmAddress {
   const hash = keccak_256(utf8ToBytes(lowercaseHex));
   let body = "";
-  for (const [i, hashByte] of hash
-    .subarray(0, lowercaseHex.length / 2)
-    .entries()) {
+  for (const [i, hashByte] of hash.subarray(0, 20).entries()) {
     const high = lowercaseHex.charAt(i * 2);
     const low = lowercaseHex.charAt(i * 2 + 1);
     body += hashByte >> 4 >= 8 ? high.toUpperCase() : high;

--- a/src/chains/solana.ts
+++ b/src/chains/solana.ts
@@ -2,8 +2,6 @@ import { base58 } from "@scure/base";
 import { MeraError } from "../errors.js";
 import type { SolanaAddress } from "../types.js";
 
-const ED25519_PUBLIC_KEY_LENGTH = 32;
-
 /**
  * Derives the base58-encoded Solana address for an Ed25519 public key.
  *
@@ -12,7 +10,7 @@ const ED25519_PUBLIC_KEY_LENGTH = 32;
  * @throws MeraError with code `INPUT_INVALID` when `publicKey` is not 32 bytes.
  */
 function getSolanaAddress(publicKey: Uint8Array): SolanaAddress {
-  if (publicKey.length !== ED25519_PUBLIC_KEY_LENGTH) {
+  if (publicKey.length !== 32) {
     throw new MeraError("INPUT_INVALID", "Ed25519 public key must be 32 bytes");
   }
 

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -81,14 +81,10 @@ function createSecp256k1SigningSession({
       // noble's "recovered" format is 65 bytes: the recovery ID, then r || s.
       const recovery = signature[0];
 
-      // A recovery ID of 2 or 3 requires the signature's r to be at least the
-      // curve order, which happens with probability about 2^-127, never in
-      // practice. Such a signature cannot be address-recovered from `r` and a
-      // parity bit alone, so fail loudly instead of returning an unusable
-      // recovery ID. The check also narrows the byte to the declared `0 | 1`.
-      // INPUT_INVALID is a stretch (the recovery ID is not caller-supplied),
-      // but a range constraint failed at a public boundary and the event is
-      // unreachable in practice, so it does not warrant its own code.
+      // A recovery ID of 2 or 3 requires r >= the curve order (probability
+      // about 2^-127) and cannot be address-recovered from a parity bit, so
+      // fail loudly instead of returning an unusable ID. The check also
+      // narrows the byte to the declared `0 | 1`.
       if (recovery !== 0 && recovery !== 1) {
         throw new MeraError(
           "INPUT_INVALID",

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,8 +114,7 @@ type LockableSession = {
   lock(): void;
   /**
    * Calls `lock`, so a `using` declaration locks the session when its scope
-   * exits. Sessions bound with `const` or `let` are unaffected; disposal runs
-   * only where a caller opts in with `using`.
+   * exits.
    */
   [Symbol.dispose](): void;
 };


### PR DESCRIPTION
A few comments and micro-constructs carried weight that does not serve the next reader. The `Symbol.dispose` doc's second sentence restated how `using` works in JavaScript rather than what the library does. The recovery-ID comment in `signDigest` spent three lines justifying the INPUT_INVALID error-code choice — reviewer-talk that belongs in PR discussion — while the kept lines still explain the mechanism (recovery 2 or 3 requires r at or above the curve order, ~2⁻¹²⁷, and cannot be address-recovered from a parity bit).

In the chains: `solana.ts` inlines a single-use length constant whose error message already says "32 bytes"; `evm.ts` swaps a copying `slice(1)` for `subarray(1)` and fixes the checksum loop bound to the 20 address bytes it always processes — the `lowercaseHex.length / 2` form implied variable-length input that never occurs, and the precondition comment now states the fixed shape.

No behavior changes; the existing address and signing tests cover every touched line.

Part of a series from the src/ simplification review; independent of the other PRs.