### PR TITLE
Explain the transports cast at the WebAuthn boundary

### DIFF
--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -301,6 +301,10 @@ async function getPasskeyPrfOutput({
           type: "public-key",
           ...(allowCredential.transports !== undefined
             ? {
+                // The library's transport type admits future strings beyond
+                // lib.dom's closed AuthenticatorTransport union. The cast is
+                // safe: transports are hints, and WebAuthn ignores values it
+                // does not recognize.
                 transports:
                   allowCredential.transports as AuthenticatorTransport[],
               }


### PR DESCRIPTION
`getPasskeyPrfOutput` casts the library's `PasskeyCredentialTransport[]` — which deliberately admits future transport strings via `string & {}` — to lib.dom's closed `AuthenticatorTransport` union when building `allowCredentials`. That is an unchecked cast at a wire boundary, exactly where a reader would expect runtime validation, so the absence of a check deserves a stated reason.

A comment, not a check, is the right fix: transports are hints, and WebAuthn clients ignore values they do not recognize, so a non-standard string cannot break the assertion — rejecting unknown strings at runtime would defeat the type's purpose of passing future transports through. The new four-line comment states that mechanism at the cast site.

Follow-up from a second review of the src/ simplification pass; independent of the other open PRs.