### PR TITLE
Validate the vault before the decryption prompt

### DIFF
--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -70,7 +70,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The vault is validated and copied before the assertion starts, so a malformed vault fails before any prompt. The transient PRF output is zeroed before the function finishes, even when decryption fails.
+The vault is copied before the assertion starts. The transient PRF output is zeroed before the function finishes, even when decryption fails.
 
 The WebAuthn challenge is generated internally.
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -62,15 +62,15 @@ WebAuthn timeout in milliseconds.
 
 ## Errors
 
+- [`VAULT_FORMAT_INVALID`](/reference/errors/#vault_format_invalid): the vault's required structure, version, or encoded data is invalid.
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.
-- [`INPUT_INVALID`](/reference/errors/#input_invalid): the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
 - [`DECRYPT_FAILED`](/reference/errors/#decrypt_failed): [AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed because the PRF output was wrong or the vault was modified.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes
 
-The vault is copied before the assertion starts. The transient PRF output is zeroed before the function finishes, even when decryption fails.
+The vault is validated and copied before the assertion starts, so a malformed vault fails before any prompt. The transient PRF output is zeroed before the function finishes, even when decryption fails.
 
 The WebAuthn challenge is generated internally.
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -49,7 +49,7 @@ Web Crypto is unavailable. In practice this means the page is running outside a 
 
 ### PRF_UNAVAILABLE
 
-The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. On the create path the passkey may already exist ([createPasskeyWithPrfOutput](/reference/create-passkey-with-prf-output/) documents that behavior). [Authenticator support](/authenticator-support/) lists tested compatible stacks.
+The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. [Authenticator support](/authenticator-support/) lists tested compatible stacks.
 
 ### SESSION_LOCKED
 
@@ -65,4 +65,4 @@ A caller-supplied value at a public boundary did not satisfy a length, range, en
 
 ### VAULT_FORMAT_INVALID
 
-Untrusted vault data (JSON text or an object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version. Thrown by [parseSecretVault](/reference/parse-secret-vault/), the boundary for stored vault data, and by [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/), which runs the same validation before the assertion.
+Untrusted vault data (JSON text or an object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version.

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -65,4 +65,4 @@ A caller-supplied value at a public boundary did not satisfy a length, range, en
 
 ### VAULT_FORMAT_INVALID
 
-Untrusted vault data (JSON text or an object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version. Thrown only by [parseSecretVault](/reference/parse-secret-vault/), the boundary for stored vault data.
+Untrusted vault data (JSON text or an object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version. Thrown by [parseSecretVault](/reference/parse-secret-vault/), the boundary for stored vault data, and by [decryptSecretVaultWithPasskey](/reference/decrypt-secret-vault-with-passkey/), which runs the same validation before the assertion.

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -465,9 +465,6 @@ type DecryptSecretVaultWithPasskeyOptions = {
  * Invokes `navigator.credentials.get()` and shows one user-verification
  * prompt. The assertion is restricted to the credential stored in the vault.
  *
- * The vault is validated with {@link parseSecretVault} and copied before the
- * assertion starts, so a malformed vault fails before any prompt.
- *
  * The internal PRF output is zeroed before the function finishes, even when
  * decryption fails.
  * @throws MeraError with code `VAULT_FORMAT_INVALID` when the vault's required structure, version, or encoded data is invalid.

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -353,9 +353,9 @@ type DecryptSecretVaultOptions = {
 /**
  * Decrypts the secret from a secret vault with a PRF output.
  *
- * Internal building block: the vault's `nonce` and `ciphertext` strings are
- * still decoded and validated here because a caller-built vault object can
- * bypass `parseSecretVault`.
+ * Internal building block: decoding the vault's `nonce` and `ciphertext`
+ * strings here doubles as validation for direct callers that skip
+ * `parseSecretVault`.
  *
  * @returns The decrypted secret bytes in a fresh allocation.
  * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url.
@@ -465,10 +465,13 @@ type DecryptSecretVaultWithPasskeyOptions = {
  * Invokes `navigator.credentials.get()` and shows one user-verification
  * prompt. The assertion is restricted to the credential stored in the vault.
  *
+ * The vault is validated with {@link parseSecretVault} and copied before the
+ * assertion starts, so a malformed vault fails before any prompt.
+ *
  * The internal PRF output is zeroed before the function finishes, even when
  * decryption fails.
+ * @throws MeraError with code `VAULT_FORMAT_INVALID` when the vault's required structure, version, or encoded data is invalid.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
- * @throws MeraError with code `INPUT_INVALID` when the vault contains an invalid credential ID, PRF salt, nonce, or ciphertext.
  * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
@@ -478,15 +481,16 @@ async function decryptSecretVaultWithPasskey({
   vault,
   timeout,
 }: DecryptSecretVaultWithPasskeyOptions): Promise<Uint8Array<ArrayBuffer>> {
+  const parsedVault = parseSecretVault(vault);
   const { prfOutput } = await getPasskeyPrfOutput({
     rpId,
-    credential: vault.credential,
-    prfSalt: base64UrlDecode(vault.prfSalt),
+    credential: parsedVault.credential,
+    prfSalt: base64UrlDecode(parsedVault.prfSalt),
     ...(timeout !== undefined ? { timeout } : {}),
   });
 
   try {
-    return await decryptSecretVault({ vault, prfOutput });
+    return await decryptSecretVault({ vault: parsedVault, prfOutput });
   } finally {
     prfOutput.fill(0);
   }

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -9,6 +9,7 @@ import {
   createSecretVaultWithExistingPasskey,
   createSecretVaultWithNewPasskey,
   decryptSecretVault,
+  decryptSecretVaultWithPasskey,
   parseSecretVault,
 } from "../dist/secret.js";
 import { expectError, withStubbedGlobal } from "./helpers.js";
@@ -286,6 +287,37 @@ test("decryptSecretVault fails with the wrong PRF output", async () => {
   await expect(
     decryptSecretVault({ vault, prfOutput: new Uint8Array(32).fill(1) }),
   ).rejects.toMatchObject({ code: "DECRYPT_FAILED" });
+});
+
+test("decryptSecretVaultWithPasskey rejects a malformed vault without prompting", async () => {
+  const vault = await createTestVault();
+  let asserted = false;
+  const navigator = {
+    credentials: {
+      async get() {
+        asserted = true;
+        throw new Error("assertion must not start");
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    await expect(
+      decryptSecretVaultWithPasskey({
+        rpId: "example.com",
+        vault: { ...vault, ciphertext: "!!!!" },
+      }),
+    ).rejects.toMatchObject({ code: "VAULT_FORMAT_INVALID" });
+
+    await expect(
+      decryptSecretVaultWithPasskey({
+        rpId: "example.com",
+        vault: { ...vault, nonce: "AQ" },
+      }),
+    ).rejects.toMatchObject({ code: "VAULT_FORMAT_INVALID" });
+  });
+
+  expect(asserted).toBe(false);
 });
 
 test("secret vault helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavailable", async () => {

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -308,13 +308,6 @@ test("decryptSecretVaultWithPasskey rejects a malformed vault without prompting"
         vault: { ...vault, ciphertext: "!!!!" },
       }),
     ).rejects.toMatchObject({ code: "VAULT_FORMAT_INVALID" });
-
-    await expect(
-      decryptSecretVaultWithPasskey({
-        rpId: "example.com",
-        vault: { ...vault, nonce: "AQ" },
-      }),
-    ).rejects.toMatchObject({ code: "VAULT_FORMAT_INVALID" });
   });
 
   expect(asserted).toBe(false);


### PR DESCRIPTION
## Problem

`decryptSecretVaultWithPasskey` decoded the vault's `nonce` and `ciphertext` only after the WebAuthn ceremony. A malformed hand-built vault (the case the internal `decryptSecretVault` doc explicitly tolerated) made the user complete a user-verification prompt and then failed with `INPUT_INVALID` and the decode's default "value must be base64url" message. Every other public input check in the library rejects before prompting. The reference page also claimed "The vault is copied before the assertion starts", which nothing implemented.

## Why parse-first is equivalent or better

The function now runs its vault through `parseSecretVault` before the assertion. Vaults that already went through `parseSecretVault` behave exactly as before, and the e2e round-trip (including the tamper case) still runs unchanged. Malformed vaults now fail before any prompt with `VAULT_FORMAT_INVALID` and proper field names — the code whose documented meaning ("untrusted vault data was malformed") matches this defect, and which the demo already maps to a friendly message. `INPUT_INVALID` became unreachable from this function, so its contract drops the code. The parse result is a fresh object, which makes the reference page's copy sentence true; it now reads "validated and copied".

New unit test pins the observable behavior: a vault with a bad `ciphertext` or wrong-length `nonce` rejects with `VAULT_FORMAT_INVALID` and `navigator.credentials.get` is never invoked.

Stacked PRs with the remaining review findings follow on this branch.