### PR TITLE
Rename the destructive session lock() to end()

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Accounts on any chain and platform, from a passkey.
 
-mera is an experimental TypeScript library for building passkey accounts. It gives applications authenticator-bound entropy and lockable signing sessions while leaving account derivation, recovery, storage, and product flows under application control.
+mera is an experimental TypeScript library for building passkey accounts. It gives applications authenticator-bound entropy and signing sessions that zero their keys when ended, while leaving account derivation, recovery, storage, and product flows under application control.
 
 Developers can use mera to:
 

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -33,7 +33,7 @@ type Account = {
  *
  * The account's key is derived at connect and the BIP-39 seed it came from
  * is zeroed before connect returns, so the wallet holds no secret beyond the
- * account's signing session. `lock()` zeroes that session's key.
+ * account's signing session. `lock()` ends that session, zeroing its key.
  */
 type ConnectedWallet = {
   mode: AccountMode;
@@ -85,7 +85,7 @@ function buildPasskeyWallet(
     mode: "passkey",
     credentialId,
     account,
-    lock: () => account.session.lock(),
+    lock: () => account.session.end(),
   };
 }
 
@@ -187,7 +187,7 @@ function vaultWalletFromPhrase(phrase: string): ConnectedWallet {
   return {
     mode: "vault",
     account,
-    lock: () => account.session.lock(),
+    lock: () => account.session.end(),
   };
 }
 
@@ -261,8 +261,8 @@ function describeError(error: unknown): string {
         return "This browser or authenticator doesn't support the WebAuthn PRF extension this demo needs.";
       case "DECRYPT_FAILED":
         return "Couldn't unlock the account with that passkey.";
-      case "SESSION_LOCKED":
-        return "The session is locked. Connect again.";
+      case "SESSION_ENDED":
+        return "The session has ended. Connect again.";
       case "CRYPTO_UNAVAILABLE":
         return "This browser doesn't provide the Web Crypto APIs this demo needs.";
       case "PASSKEY_OPERATION_FAILED":

--- a/docs/src/assets/diagrams/first-vs-returning.svg
+++ b/docs/src/assets/diagrams/first-vs-returning.svg
@@ -13,7 +13,7 @@
     getPasskeyPrfOutput signs in using the stored metadata. The PRF output
     becomes the seed through BIP-39, held in memory for the session, and HD
     derivation by index produces the EVM and Solana signing sessions, ended by
-    lock().
+    end().
   </title>
   <defs>
     <marker
@@ -79,5 +79,5 @@
   <text x="508" y="405" text-anchor="middle">Signing sessions</text>
 
   <path class="d-edge" d="M508 432 V476" marker-end="url(#fr-arrow)" />
-  <text x="520" y="458" class="d-mono">lock()</text>
+  <text x="520" y="458" class="d-mono">end()</text>
 </svg>

--- a/docs/src/assets/diagrams/session-lifecycle.svg
+++ b/docs/src/assets/diagrams/session-lifecycle.svg
@@ -8,10 +8,10 @@
 >
   <title>
     The signing session lifecycle. A private key, derived, decrypted, or
-    imported, is consumed when the session is created. The unlocked session
-    holds the only copy of the key and signs on request. Calling lock() zeroes
-    the session's key copy; the locked state is permanent, and a new signature
-    needs a new session.
+    imported, is consumed when the session is created. The live session holds
+    the only copy of the key and signs on request. Calling end() zeroes the
+    session's key copy; the ended state is permanent, and a new signature needs
+    a new session.
   </title>
   <defs>
     <marker
@@ -34,7 +34,7 @@
   <text x="332" y="126" class="d-sub">create the session</text>
 
   <rect class="d-secret" x="220" y="168" width="200" height="64" rx="16" />
-  <text x="320" y="205" text-anchor="middle">Unlocked</text>
+  <text x="320" y="205" text-anchor="middle">Live</text>
 
   <path
     class="d-edge"
@@ -44,8 +44,8 @@
   <text x="490" y="203" class="d-sub">signs on request</text>
 
   <path class="d-edge" d="M320 232 V344" marker-end="url(#sl-arrow)" />
-  <text x="332" y="292" class="d-mono">lock()</text>
+  <text x="332" y="292" class="d-mono">end()</text>
 
   <rect class="d-node" x="220" y="348" width="200" height="64" rx="16" />
-  <text x="320" y="385" text-anchor="middle">Locked</text>
+  <text x="320" y="385" text-anchor="middle">Ended</text>
 </svg>

--- a/docs/src/assets/diagrams/trust-boundary.svg
+++ b/docs/src/assets/diagrams/trust-boundary.svg
@@ -8,11 +8,11 @@
 >
   <title>
     The trust boundary. The page contains the app, which derives keys from PRF
-    output and decides when to lock sessions, and mera, which copies the bytes
-    it is given and zeroes its own copies. The authenticator sits outside the
-    page, reachable only through WebAuthn ceremonies: it holds the passkey and
-    PRF, the key never leaves, and it asks for user verification. Any script on
-    the page can see key material and sign with an unlocked session.
+    output and decides when to end sessions, and mera, which copies the bytes it
+    is given and zeroes its own copies. The authenticator sits outside the page,
+    reachable only through WebAuthn ceremonies: it holds the passkey and PRF,
+    the key never leaves, and it asks for user verification. Any script on the
+    page can see key material and sign with a live session.
   </title>
   <defs>
     <marker
@@ -37,7 +37,7 @@
     derives keys from PRF output
   </text>
   <text x="222" y="153" text-anchor="middle" class="d-sub">
-    decides when to lock sessions
+    decides when to end sessions
   </text>
 
   <rect class="d-node" x="48" y="200" width="348" height="80" rx="8" />

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -7,7 +7,7 @@ import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
 Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, it matches a wallet app holding an imported seed phrase in the page.
 
-- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with an unlocked session. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Locking sessions when idle and zeroing key material promptly shorten the exposure.
+- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with a live session. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Ending sessions when idle and zeroing key material promptly shorten the exposure.
 - Losing the passkey without a prior export loses the accounts derived from it.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.
@@ -18,5 +18,5 @@ Mera runs in the page JS code, the keys it produces and derives are software key
 ## See also
 
 - [Passkeys and the PRF extension](/concepts/passkeys-and-prf/)
-- [Signing sessions](/concepts/signing-sessions/): what an unlocked session exposes and when to lock it.
+- [Signing sessions](/concepts/signing-sessions/): what a live session exposes and when to end it.
 - [Errors](/reference/errors/): every failure the library signals, by code.

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -1,11 +1,11 @@
 ---
 title: Signing sessions
-description: How a session owns its private key, why signing never prompts, and what locking destroys.
+description: How a session owns its private key, why signing never prompts, and what ending a session destroys.
 ---
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";
 
-A signing session holds a private key and signs with it until it is locked.
+A signing session holds a private key and signs with it until `end` is called.
 
 Two constructors exist, one per [signature scheme](/concepts/entropy-keys-and-accounts/):
 
@@ -20,17 +20,17 @@ A session uses an in-memory private key and doesn't contact an authenticator.
 
 ## The lifecycle
 
-Construction copies the key into a session-owned snapshot. Locking zeroes the session's copy and is permanent. A locked session throws on signing, and new signatures require a new session.
+Construction copies the key into a session-owned snapshot. Ending the session zeroes that copy and is permanent. An ended session throws on signing, and new signatures require a new session.
 
-Sessions also support `using` declarations: disposal calls `lock()` when the scope exits, so a session can be bound to a block instead of a manual call.
+Sessions also support `using` declarations: disposal calls `end()` when the scope exits, so a session can be bound to a block instead of a manual call.
 
 <SessionLifecycle />
 
 ## How long to keep a session
 
-After `lock()`, the next signature needs fresh key material, and both sources (reproducing a derived key, decrypting a vault) start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
+After `end()`, the next signature needs fresh key material, and both sources (reproducing a derived key, decrypting a vault) start with a ceremony and its prompt. Session lifetime is a trade-off between that prompt and the open window.
 
-An app that signs frequently may keep the session active for a burst of work and lock it when the burst ends. Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, lock it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
+An app that signs frequently may keep the session for a burst of work and end it when the burst finishes. Apps that sign occasionally are better served by holding no session at all: create one just to read the public key, end it, zero the private key, and identify the account by its address. The next signature then starts with a fresh ceremony.
 
 ## See also
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -9,7 +9,7 @@ What mera does:
 
 - Create a passkey and get 32 secret bytes from it through the [PRF extension](/concepts/passkeys-and-prf/).
 - Use those bytes as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts.
-- Sign with a lockable [signing session](/concepts/signing-sessions/).
+- Sign with a [signing session](/concepts/signing-sessions/).
 
 <GettingStartedOverview />
 
@@ -82,7 +82,7 @@ const address = getEvmAddress(session.publicKey);
 const digest = new Uint8Array(32);
 const signature = await session.signDigest(digest);
 
-session.lock();
+session.end();
 ```
 
 ## Sign back in

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -135,15 +135,15 @@ Build the account list from these helpers:
 const accounts = [deriveEvmAccount(seed, 0), deriveSolanaAccount(seed, 0)];
 ```
 
-## Lock everything
+## End the sessions
 
 ```ts
 for (const account of accounts) {
-  account.session.lock();
+  account.session.end();
 }
 ```
 
-Locking zeroes private keys owned by the session.
+Ending a session zeroes the private keys it owns.
 
 ## See also
 

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -65,7 +65,7 @@ const hash = await client.sendTransaction({
   value: parseEther("0.01"),
 });
 
-session.lock();
+session.end();
 ```
 
 `sendTransaction` fills the missing transaction fields from the RPC, signs through the session and broadcasts.

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -1,9 +1,9 @@
 ---
 title: createEd25519SigningSession
-description: Creates a lockable signing session from an Ed25519 private key.
+description: Creates a signing session from an Ed25519 private key.
 ---
 
-Creates a lockable signing session from an [Ed25519](/concepts/entropy-keys-and-accounts/) private key.
+Creates a signing session from an [Ed25519](/concepts/entropy-keys-and-accounts/) private key.
 
 ## Import
 
@@ -27,7 +27,7 @@ const session = createEd25519SigningSession({ privateKey });
 const address = getSolanaAddress(session.publicKey);
 const signature = await session.signMessage(message);
 
-session.lock();
+session.end();
 ```
 
 ## Parameters
@@ -43,7 +43,7 @@ Ed25519 private key (the 32-byte seed). Copied into one session-owned snapshot.
 
 ## Returns
 
-An `Ed25519SigningSession`, unlocked.
+A live `Ed25519SigningSession`.
 
 ### publicKey
 
@@ -53,18 +53,18 @@ An `Ed25519SigningSession`, unlocked.
 
 Signs an arbitrary-length message and resolves to the 64-byte Ed25519 signature (`R || s`). Hashing happens inside Ed25519 itself; the caller passes the raw message, never a digest.
 
-### lock()
+### end()
 
-Zeroes the session-owned private-key copy and permanently locks the session; later signing throws [`SESSION_LOCKED`](/reference/errors/#session_locked).
+Zeroes the session-owned private-key copy and permanently ends the session; later signing throws [`SESSION_ENDED`](/reference/errors/#session_ended).
 
 ### [Symbol.dispose]()
 
-Calls `lock`, so a `using` declaration locks the session when its scope exits.
+Calls `end`, so a `using` declaration ends the session when its scope exits.
 
 ## Errors
 
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `privateKey` is not 32 bytes.
-- [`SESSION_LOCKED`](/reference/errors/#session_locked): `signMessage` was called after `lock`.
+- [`SESSION_ENDED`](/reference/errors/#session_ended): `signMessage` was called after `end`.
 
 ## See also
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -1,9 +1,9 @@
 ---
 title: createSecp256k1SigningSession
-description: Creates a lockable signing session from a secp256k1 private key.
+description: Creates a signing session from a secp256k1 private key.
 ---
 
-Creates a lockable signing session from a [secp256k1](/concepts/entropy-keys-and-accounts/) private key.
+Creates a signing session from a [secp256k1](/concepts/entropy-keys-and-accounts/) private key.
 
 ## Import
 
@@ -27,7 +27,7 @@ const session = createSecp256k1SigningSession({ privateKey });
 const address = getEvmAddress(session.publicKey);
 const { compact, recovery } = await session.signDigest(digest32);
 
-session.lock();
+session.end();
 ```
 
 ## Parameters
@@ -43,7 +43,7 @@ secp256k1 private key. Must be exactly 32 bytes and a valid scalar, an integer i
 
 ## Returns
 
-A `Secp256k1SigningSession`, unlocked.
+A live `Secp256k1SigningSession`.
 
 ### publicKey
 
@@ -53,25 +53,25 @@ A `Secp256k1SigningSession`, unlocked.
 
 Signs a 32-byte digest without prehashing it and resolves to a `Secp256k1Signature`: `compact` (64 bytes, `r || s`, low-S: `s` lies in the lower half of the curve order) plus `recovery` (0 or 1).
 
-### lock()
+### end()
 
-Zeroes the session-owned private-key copy and permanently locks the session; later signing throws [`SESSION_LOCKED`](/reference/errors/#session_locked).
+Zeroes the session-owned private-key copy and permanently ends the session; later signing throws [`SESSION_ENDED`](/reference/errors/#session_ended).
 
 ### [Symbol.dispose]()
 
-Calls `lock`, so a `using` declaration locks the session when its scope exits:
+Calls `end`, so a `using` declaration ends the session when its scope exits:
 
 ```ts
 {
   using session = createSecp256k1SigningSession({ privateKey });
   await session.signDigest(digest32);
-} // locked here
+} // ended here
 ```
 
 ## Errors
 
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `privateKey` is not a valid secp256k1 scalar, or `digest32` is not 32 bytes.
-- [`SESSION_LOCKED`](/reference/errors/#session_locked): `signDigest` was called after `lock`.
+- [`SESSION_ENDED`](/reference/errors/#session_ended): `signDigest` was called after `end`.
 
 ## Notes
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -51,9 +51,9 @@ Web Crypto is unavailable. In practice this means the page is running outside a 
 
 The authenticator did not enable PRF, or did not return a usable 32-byte PRF output. [Authenticator support](/authenticator-support/) lists tested compatible stacks.
 
-### SESSION_LOCKED
+### SESSION_ENDED
 
-A signing call was made after the session's `lock()`. Locking is permanent; new signatures require a new session built from fresh key material.
+A signing call was made after the session's `end()`. An ended session never signs again; new signatures require a new session built from fresh key material.
 
 ### DECRYPT_FAILED
 

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -12,8 +12,8 @@ Types are documented on the pages of the functions that produce or accept them.
 
 ## Signing sessions
 
-- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): creates a lockable signing session from a secp256k1 private key.
-- [createEd25519SigningSession](/reference/create-ed25519-signing-session/): creates a lockable signing session from an Ed25519 private key.
+- [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/): creates a signing session from a secp256k1 private key.
+- [createEd25519SigningSession](/reference/create-ed25519-signing-session/): creates a signing session from an Ed25519 private key.
 - [toViemAccount](/reference/to-viem-account/): adapts a secp256k1 signing session into a viem local account.
 
 ## Secret vault

--- a/docs/src/content/docs/reference/to-viem-account.md
+++ b/docs/src/content/docs/reference/to-viem-account.md
@@ -34,7 +34,7 @@ const hash = await client.sendTransaction({
   value: parseEther("0.01"),
 });
 
-session.lock();
+session.end();
 ```
 
 ## Parameters
@@ -46,7 +46,7 @@ The session is positional; `options` is a `ToViemAccountOptions` and may be omit
 - Type: `Secp256k1SigningSession`
 - Required
 
-Unlocked secp256k1 signing session that backs the account. [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) produces one.
+Live secp256k1 signing session that backs the account. [createSecp256k1SigningSession](/reference/create-secp256k1-signing-session/) produces one.
 
 ### options.nonceManager
 
@@ -89,7 +89,7 @@ Signs a 32-byte hash directly, with no additional hashing, and resolves to the 6
 
 ## Errors
 
-- [`SESSION_LOCKED`](/reference/errors/#session_locked): any signing method rejects with this after `session.lock()`.
+- [`SESSION_ENDED`](/reference/errors/#session_ended): any signing method rejects with this after `session.end()`.
 - [`INPUT_INVALID`](/reference/errors/#input_invalid): `sign` rejects with this when `hash` is not exactly 32 bytes.
 
 ## Notes

--- a/site/index.html
+++ b/site/index.html
@@ -440,7 +440,7 @@
         <p>
           Developers face a version of this too. A payments app, trading app, or
           game still has to ship the key layer first: generate keys, store them,
-          gate their use, lock them when idle, recover them when a device is
+          gate their use, zero them when idle, recover them when a device is
           lost. All of it has to work before the first feature ships. None of it
           sets the app apart, and getting it wrong costs user funds.
         </p>
@@ -466,7 +466,7 @@
           device's secure hardware, gated by a biometric, PIN, or password, and
           synced by the platform. It ships with every phone, laptop, and
           browser. For the user that means no phrase and no password; for the
-          developer it means generation, storage, locking, and cross-device sync
+          developer it means generation, storage, gating, and cross-device sync
           are the platform's job. Crypto adopted passkeys through smart
           accounts, where the passkey signs and a contract on the chain
           verifies.
@@ -647,8 +647,8 @@ clientDataJSON
           authenticator-bound entropy and signs with keys the application hands
           it; how entropy becomes keys (the KDF, the paths, the account model)
           belongs to the application. A session keeps key bytes in memory and
-          zeroes them on <code>session.lock()</code>. One ceremony per session
-          is enough: one user-verification check, then any number of signatures.
+          zeroes them on <code>session.end()</code>. One ceremony per session is
+          enough: one user-verification check, then any number of signatures.
         </p>
 
         <p>
@@ -1051,7 +1051,7 @@ const address = getEvmAddress(session.publicKey)</code></pre>
             <strong>The app stores less key material.</strong>
             The passkey-account pattern stores no app-owned secret. The
             secret-vault pattern stores a vault blob that still needs the
-            passkey ceremony, and locking is one call.
+            passkey ceremony, and ending the session is one call.
           </li>
           <li>
             <strong>Passkey accounts have no chain infrastructure.</strong>

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -26,16 +26,16 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array<ArrayBuffer> {
 }
 
 /**
- * Creates a lockable signing session from an Ed25519 private key.
+ * Creates a signing session from an Ed25519 private key.
  *
  * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
- * @returns An unlocked Ed25519 signing session.
+ * @returns A live Ed25519 signing session.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
  */
 function createEd25519SigningSession({
   privateKey,
 }: CreateSigningSessionOptions): Ed25519SigningSession {
-  const { use, lock, publicKey } = createSigningKey(
+  const { use, end, publicKey } = createSigningKey(
     privateKey,
     getEd25519PublicKey,
   );
@@ -45,8 +45,8 @@ function createEd25519SigningSession({
     async signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
       return new Uint8Array(ed25519.sign(message, use()));
     },
-    lock,
-    [Symbol.dispose]: lock,
+    end,
+    [Symbol.dispose]: end,
   };
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,7 +4,7 @@
  * - `PASSKEY_OPERATION_FAILED`: WebAuthn failed, was cancelled, returned an unexpected credential, or the credential API is unavailable.
  * - `CRYPTO_UNAVAILABLE`: the page is not in a secure context, or the runtime lacks Web Crypto.
  * - `PRF_UNAVAILABLE`: the authenticator did not enable or return a usable 32-byte WebAuthn PRF output.
- * - `SESSION_LOCKED`: a signing call was made after `lock()`.
+ * - `SESSION_ENDED`: a signing call was made after `end()`.
  * - `DECRYPT_FAILED`: AES-GCM authentication failed (wrong key or tampered nonce/ciphertext).
  * - `INPUT_INVALID`: a caller-supplied value at a public boundary did not satisfy a length, range, encoding, or curve (scalar or point) constraint.
  * - `VAULT_FORMAT_INVALID`: untrusted vault data (JSON or object) was malformed, missing required fields, used a non-canonical encoding, or declared an unsupported version.
@@ -13,7 +13,7 @@ type MeraErrorCode =
   | "PASSKEY_OPERATION_FAILED"
   | "CRYPTO_UNAVAILABLE"
   | "PRF_UNAVAILABLE"
-  | "SESSION_LOCKED"
+  | "SESSION_ENDED"
   | "DECRYPT_FAILED"
   | "INPUT_INVALID"
   | "VAULT_FORMAT_INVALID";

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -50,16 +50,16 @@ function normalizeSecp256k1PublicKey(
 }
 
 /**
- * Creates a lockable signing session from a secp256k1 private key.
+ * Creates a signing session from a secp256k1 private key.
  *
  * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
- * @returns An unlocked secp256k1 signing session.
+ * @returns A live secp256k1 signing session.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
  */
 function createSecp256k1SigningSession({
   privateKey,
 }: CreateSigningSessionOptions): Secp256k1SigningSession {
-  const { use, lock, publicKey } = createSigningKey(
+  const { use, end, publicKey } = createSigningKey(
     privateKey,
     getSecp256k1PublicKey,
   );
@@ -71,8 +71,8 @@ function createSecp256k1SigningSession({
         throw new MeraError("INPUT_INVALID", "Digest must be 32 bytes");
       }
 
-      const unlockedKey = use();
-      const signature = secp256k1.sign(digest32, unlockedKey, {
+      const activeKey = use();
+      const signature = secp256k1.sign(digest32, activeKey, {
         format: "recovered",
         lowS: true,
         prehash: false,
@@ -97,8 +97,8 @@ function createSecp256k1SigningSession({
         recovery,
       };
     },
-    lock,
-    [Symbol.dispose]: lock,
+    end,
+    [Symbol.dispose]: end,
   };
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,32 +2,32 @@ import { copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
 
 /**
- * Session-owned signing key whose lifetime is gated by `lock`, paired with the
+ * Session-owned signing key whose lifetime is gated by `end`, paired with the
  * public key derived from it.
  */
 type SigningKey = {
   /**
    * Returns the live session-owned key for immediate use.
    *
-   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
+   * @throws MeraError with code `SESSION_ENDED` after `end` has been called.
    */
   use(): Uint8Array<ArrayBuffer>;
-  /** Zeroes the session-owned key and permanently locks this handle. */
-  lock(): void;
+  /** Zeroes the session-owned key; later `use` calls throw. */
+  end(): void;
   /** Public key derived from the session-owned key. */
   readonly publicKey: Uint8Array<ArrayBuffer>;
 };
 
 /**
- * Copies a private key into a lockable signing key and derives its public key.
+ * Copies a private key into a signing key handle and derives its public key.
  *
  * `privateKey` is copied into one session-owned snapshot. The snapshot is
- * zeroed by `lock` or, when `derivePublicKey` throws, before the error is
+ * zeroed by `end` or, when `derivePublicKey` throws, before the error is
  * rethrown.
  *
  * @param privateKey - Private key to copy into the signing key.
  * @param derivePublicKey - Derives the public key from the owned snapshot; a throw doubles as private-key validation.
- * @returns The lockable signing key with its derived public key.
+ * @returns The signing key handle with its derived public key.
  * @throws Rethrows whatever `derivePublicKey` throws.
  */
 function createSigningKey(
@@ -44,9 +44,9 @@ function createSigningKey(
 
     return {
       use(): Uint8Array<ArrayBuffer> {
-        return requireUnlocked(activePrivateKey);
+        return requireActive(activePrivateKey);
       },
-      lock(): void {
+      end(): void {
         if (activePrivateKey !== undefined) {
           activePrivateKey.fill(0);
           activePrivateKey = undefined;
@@ -61,17 +61,17 @@ function createSigningKey(
 }
 
 /**
- * Returns the active private key, or throws once the session has been locked.
+ * Returns the active private key, or throws once the session has ended.
  *
- * @param privateKey - Session-owned private key, or `undefined` after `lock`.
+ * @param privateKey - Session-owned private key, or `undefined` after `end`.
  * @returns The live session-owned private key.
- * @throws MeraError with code `SESSION_LOCKED` when `privateKey` is undefined.
+ * @throws MeraError with code `SESSION_ENDED` when `privateKey` is undefined.
  */
-function requireUnlocked(
+function requireActive(
   privateKey: Uint8Array<ArrayBuffer> | undefined,
 ): Uint8Array<ArrayBuffer> {
   if (privateKey === undefined) {
-    throw new MeraError("SESSION_LOCKED", "Signing session is locked");
+    throw new MeraError("SESSION_ENDED", "Signing session has ended");
   }
 
   return privateKey;

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,7 @@ type PasskeySecretVault = {
   readonly ciphertext: string;
 };
 
-/** secp256k1 ECDSA signature returned by an unlocked signing session. */
+/** secp256k1 ECDSA signature returned by a signing session. */
 type Secp256k1Signature = {
   /** Compact 64-byte `r || s` ECDSA signature. */
   readonly compact: Uint8Array<ArrayBuffer>;
@@ -88,7 +88,7 @@ type Secp256k1Signature = {
   readonly recovery: 0 | 1;
 };
 
-/** Inputs for creating a lockable curve signing session. */
+/** Inputs for creating a curve signing session. */
 type CreateSigningSessionOptions = {
   /**
    * Curve private key. Must be exactly 32 bytes; secp256k1 must also be a valid scalar.
@@ -98,21 +98,21 @@ type CreateSigningSessionOptions = {
   privateKey: Uint8Array;
 };
 
-/** Members shared by every signing session: an explicit lock and `using` disposal. */
-type LockableSession = {
+/** Members shared by every signing session: an explicit end and `using` disposal. */
+type SigningSession = {
   /**
-   * Zeroes the session-owned private-key copy and permanently locks this session; later signing throws `SESSION_LOCKED`.
+   * Zeroes the session-owned private-key copy and permanently ends this session; later signing throws `SESSION_ENDED`.
    */
-  lock(): void;
+  end(): void;
   /**
-   * Calls `lock`, so a `using` declaration locks the session when its scope
+   * Calls `end`, so a `using` declaration ends the session when its scope
    * exits.
    */
   [Symbol.dispose](): void;
 };
 
-/** secp256k1 signing session that can sign 32-byte digests until `lock` is called. */
-type Secp256k1SigningSession = LockableSession & {
+/** secp256k1 signing session that can sign 32-byte digests until `end` is called. */
+type Secp256k1SigningSession = SigningSession & {
   /** Uncompressed secp256k1 public key for the session. */
   readonly publicKey: Uint8Array<ArrayBuffer>;
   /**
@@ -121,13 +121,13 @@ type Secp256k1SigningSession = LockableSession & {
    * @param digest32 - Exactly 32 bytes to sign.
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
    * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
-   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
+   * @throws MeraError with code `SESSION_ENDED` after `end` has been called.
    */
   signDigest(digest32: Uint8Array): Promise<Secp256k1Signature>;
 };
 
-/** Ed25519 signing session that can sign messages until `lock` is called. */
-type Ed25519SigningSession = LockableSession & {
+/** Ed25519 signing session that can sign messages until `end` is called. */
+type Ed25519SigningSession = SigningSession & {
   /** 32-byte Ed25519 public key for the session. */
   readonly publicKey: Uint8Array<ArrayBuffer>;
   /**
@@ -135,7 +135,7 @@ type Ed25519SigningSession = LockableSession & {
    *
    * @param message - Message bytes to sign. Hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
-   * @throws MeraError with code `SESSION_LOCKED` after `lock` has been called.
+   * @throws MeraError with code `SESSION_ENDED` after `end` has been called.
    */
   signMessage(message: Uint8Array): Promise<Uint8Array<ArrayBuffer>>;
 };

--- a/src/viem.ts
+++ b/src/viem.ts
@@ -28,14 +28,14 @@ type ToViemAccountOptions = {
  * created. The account's `address` is the EIP-55 checksummed address of the
  * session key, and `publicKey` is the 65-byte uncompressed public key as hex.
  *
- * @param session - Unlocked secp256k1 signing session that backs the account.
+ * @param session - Live secp256k1 signing session that backs the account.
  * @param options - Adapter inputs; fields are documented on {@link ToViemAccountOptions}.
  * @returns A viem local account with `source: "mera"` implementing
  * `signTransaction` (honoring a custom `serializer`), `signMessage` (EIP-191),
  * `signTypedData` (EIP-712), `signAuthorization` (EIP-7702), and raw-hash
  * `sign`.
- * @throws MeraError with code `SESSION_LOCKED`, rejected from every signing
- * method after `session.lock()` has been called.
+ * @throws MeraError with code `SESSION_ENDED`, rejected from every signing
+ * method after `session.end()` has been called.
  * @throws MeraError with code `INPUT_INVALID`, rejected from `sign` when
  * `hash` is not exactly 32 bytes.
  */

--- a/test/ed25519-session.test.ts
+++ b/test/ed25519-session.test.ts
@@ -11,7 +11,7 @@ const RFC_PUBLIC_KEY = hexToBytes(
   "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
 );
 
-test("signs messages and locks the session", async () => {
+test("signs messages and ends the session", async () => {
   const buffer = new Uint8Array(RFC_SECRET);
   const session = createEd25519SigningSession({ privateKey: buffer });
   const message = new TextEncoder().encode("mera demo");
@@ -23,10 +23,10 @@ test("signs messages and locks the session", async () => {
   expect(signature).toHaveLength(64);
   expect(ed25519.verify(signature, message, session.publicKey)).toBe(true);
 
-  session.lock();
+  session.end();
 
   await expect(session.signMessage(message)).rejects.toMatchObject({
-    code: "SESSION_LOCKED",
+    code: "SESSION_ENDED",
   });
 });
 
@@ -41,7 +41,7 @@ test("rejects a wrong-length private key and leaves the caller's buffer unmodifi
   expect(buffer).toEqual(new Uint8Array(31).fill(7));
 });
 
-test("a using declaration locks the session when its scope exits", async () => {
+test("a using declaration ends the session when its scope exits", async () => {
   let escaped: ReturnType<typeof createEd25519SigningSession> | undefined;
 
   {
@@ -54,7 +54,7 @@ test("a using declaration locks the session when its scope exits", async () => {
 
   await expect(
     escaped.signMessage(new TextEncoder().encode("mera demo")),
-  ).rejects.toMatchObject({ code: "SESSION_LOCKED" });
+  ).rejects.toMatchObject({ code: "SESSION_ENDED" });
 });
 
 test("signs the message bytes read at call time, not later mutations", async () => {

--- a/test/secp256k1-session.test.ts
+++ b/test/secp256k1-session.test.ts
@@ -8,7 +8,7 @@ const PRIVATE_KEY_ONE = hexToBytes(
   "0000000000000000000000000000000000000000000000000000000000000001",
 );
 
-test("signs 32-byte digests and locks the session", async () => {
+test("signs 32-byte digests and ends the session", async () => {
   const buffer = new Uint8Array(PRIVATE_KEY_ONE);
   const session = createSecp256k1SigningSession({ privateKey: buffer });
   const digest = new Uint8Array(32).fill(1);
@@ -30,10 +30,10 @@ test("signs 32-byte digests and locks the session", async () => {
     }),
   ).toBe(true);
 
-  session.lock();
+  session.end();
 
   await expect(session.signDigest(digest)).rejects.toMatchObject({
-    code: "SESSION_LOCKED",
+    code: "SESSION_ENDED",
   });
 });
 
@@ -65,7 +65,7 @@ test("rejects an invalid scalar and leaves the caller's buffer unmodified", () =
   );
 });
 
-test("a using declaration locks the session when its scope exits", async () => {
+test("a using declaration ends the session when its scope exits", async () => {
   let escaped: ReturnType<typeof createSecp256k1SigningSession> | undefined;
 
   {
@@ -78,7 +78,7 @@ test("a using declaration locks the session when its scope exits", async () => {
 
   await expect(
     escaped.signDigest(new Uint8Array(32).fill(1)),
-  ).rejects.toMatchObject({ code: "SESSION_LOCKED" });
+  ).rejects.toMatchObject({ code: "SESSION_ENDED" });
 });
 
 test("signs the digest bytes read at call time, not later mutations", async () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -13,7 +13,7 @@ test("derives the public key from the stored private-key snapshot", () => {
   const original = new Uint8Array(privateKey);
   let snapshot: Uint8Array | undefined;
 
-  const { use, lock, publicKey } = createSigningKey(privateKey, (value) => {
+  const { use, end, publicKey } = createSigningKey(privateKey, (value) => {
     snapshot = value;
     const derived = new Uint8Array(value);
     privateKey.fill(9);
@@ -27,9 +27,9 @@ test("derives the public key from the stored private-key snapshot", () => {
   expect(snapshot?.buffer).toBeInstanceOf(ArrayBuffer);
   expect(publicKey).toEqual(original);
   expect(use()).toEqual(original);
-  lock();
+  end();
   expect(snapshot).toEqual(new Uint8Array(4));
-  expectError(() => use(), "SESSION_LOCKED");
+  expectError(() => use(), "SESSION_ENDED");
 });
 
 test("zeroes the stored private-key snapshot when validation fails", () => {

--- a/test/viem-account.test.ts
+++ b/test/viem-account.test.ts
@@ -39,7 +39,7 @@ test("exposes the session key as a local account", () => {
   expect(typeof account.sign).toBe("function");
   expect(typeof account.signAuthorization).toBe("function");
 
-  session.lock();
+  session.end();
 });
 
 test("signMessage produces an EIP-191 signature that recovers the address", async () => {
@@ -172,12 +172,12 @@ test("signAuthorization signs an EIP-7702 authorization", async () => {
   );
 });
 
-test("signing rejects with SESSION_LOCKED after the session is locked", async () => {
+test("signing rejects with SESSION_ENDED after the session has ended", async () => {
   const { session, account } = createAccount();
-  session.lock();
+  session.end();
 
   await expect(account.signMessage({ message: "x" })).rejects.toMatchObject({
-    code: "SESSION_LOCKED",
+    code: "SESSION_ENDED",
   });
 });
 


### PR DESCRIPTION
## Why

`lock()` names the method that zeroes a signing session's private key, but a lock implies a matching unlock. The method is one-way — after it runs, signing throws forever and a new signature needs a new session — so the docs had to patch the name with "permanently locks". `end()` says what happens: an ended session cannot be un-ended.

The rename carries the rest of the vocabulary with it: the public error code becomes `SESSION_ENDED`, the shared base type becomes `SigningSession`, and "lockable"/"unlocked"/"locking" prose becomes plain session language across the docs site, diagrams, README, demo, and landing page. The error code is a public API break; the package is at 0.1.0 and unreleased.

## Notes for reviewers

- The demo keeps its app-level `wallet.lock()` and `"locked"`/`"unlocked"` account statuses on purpose: at that level a locked wallet can be unlocked again by reconnecting, so the name is accurate. Only direct calls into the library changed.
- Vault "unlock" wording (decrypting a secret vault) is a different lifecycle and is untouched.
- Beyond CI: the demo typechecks against the rebuilt `dist`, and the docs site builds cleanly with the renamed `#session_ended` anchors.