### PR TITLE
Tighten JSDoc across the library

### DIFF
--- a/src/chains/solana.ts
+++ b/src/chains/solana.ts
@@ -15,7 +15,7 @@ function getSolanaAddress(publicKey: Uint8Array): SolanaAddress {
   }
 
   // Mints the SolanaAddress brand: encoding 32 validated bytes is what the
-  // brand asserts, and a nominal brand cannot be produced without an assertion.
+  // brand asserts.
   return base58.encode(publicKey) as SolanaAddress;
 }
 

--- a/src/ed25519.ts
+++ b/src/ed25519.ts
@@ -7,12 +7,9 @@ import type {
 } from "./types.js";
 
 /**
- * Derives the 32-byte Ed25519 public key for a 32-byte Ed25519 private key.
+ * Derives the Ed25519 public key for a 32-byte private key (the seed).
  *
- * @param privateKey - A 32-byte Ed25519 private key (the seed).
- * @returns The 32-byte Ed25519 public key.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
- * @internal
  */
 function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array<ArrayBuffer> {
   if (privateKey.length !== 32) {
@@ -28,7 +25,7 @@ function getEd25519PublicKey(privateKey: Uint8Array): Uint8Array<ArrayBuffer> {
 /**
  * Creates a signing session from an Ed25519 private key.
  *
- * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
+ * @param options - Signing session inputs.
  * @returns A live Ed25519 signing session.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not 32 bytes.
  */

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -3,8 +3,8 @@ import { MeraError, type MeraErrorCode } from "./errors.js";
 
 /**
  * Copies bytes into a standalone `Uint8Array`.
- * @param value - Bytes to copy.
- * @returns A new `Uint8Array` with the same bytes as `value`.
+ *
+ * @internal
  */
 function copyBytes(value: Uint8Array): Uint8Array<ArrayBuffer> {
   return new Uint8Array(value);
@@ -13,8 +13,7 @@ function copyBytes(value: Uint8Array): Uint8Array<ArrayBuffer> {
 /**
  * Copies bytes into a standalone `ArrayBuffer` for Web APIs.
  *
- * @param value - Bytes to copy.
- * @returns A new `ArrayBuffer` with the same bytes as `value`.
+ * @internal
  */
 function asArrayBuffer(value: Uint8Array): ArrayBuffer {
   const output = new ArrayBuffer(value.byteLength);
@@ -25,8 +24,7 @@ function asArrayBuffer(value: Uint8Array): ArrayBuffer {
 /**
  * Encodes bytes as canonical unpadded base64url.
  *
- * @param value - Bytes to encode.
- * @returns Canonical unpadded base64url text.
+ * @internal
  */
 function base64UrlEncode(value: Uint8Array): string {
   return base64urlnopad.encode(value);
@@ -43,6 +41,7 @@ function base64UrlEncode(value: Uint8Array): string {
  * @param options.minByteLength - Minimum decoded length in bytes.
  * @returns Decoded bytes.
  * @throws MeraError with `options.code` when `value` uses invalid characters, invalid length, or non-canonical padding, or the decoded bytes violate `options.byteLength` or `options.minByteLength`.
+ * @internal
  */
 function base64UrlDecode(
   value: string,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -18,19 +18,11 @@ type MeraErrorCode =
   | "INPUT_INVALID"
   | "VAULT_FORMAT_INVALID";
 
-/** Error thrown by this package. `code` is the stable machine-readable category. */
+/** Error thrown by this package. */
 class MeraError extends Error {
-  /** Machine-readable category for the failure. */
+  /** Stable machine-readable category for the failure. */
   readonly code: MeraErrorCode;
 
-  /**
-   * Creates a package error with a stable error code.
-   *
-   * @param code - Machine-readable category for the failure.
-   * @param message - Human-readable error message.
-   * @param options - Optional error construction options.
-   * @param options.cause - Original cause for this error, when available.
-   */
   constructor(
     code: MeraErrorCode,
     message: string,
@@ -42,12 +34,7 @@ class MeraError extends Error {
   }
 }
 
-/**
- * Returns true when an unknown error is a `MeraError`.
- *
- * @param error - Value to check.
- * @returns `true` when `error` is a `MeraError`.
- */
+/** Returns `true` when `error` is a `MeraError`. */
 function isMeraError(error: unknown): error is MeraError {
   return error instanceof MeraError;
 }

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -17,22 +17,22 @@ import { randomBytes } from "./webcrypto.js";
 
 const DEFAULT_PRF_SALT = sha256(utf8ToBytes("mera.prf.salt.v1"));
 
-/** Inputs for creating a discoverable, user-verified passkey and obtaining its first WebAuthn PRF output in one call. */
+/** Inputs for creating a passkey and obtaining its first WebAuthn PRF output. */
 type CreatePasskeyWithPrfOutputOptions = {
   /**
    * Relying party identity passed to WebAuthn. `id` is required so the
    * fallback assertion can target the same relying party.
    */
   rp: PublicKeyCredentialRpEntity & { id: string };
-  /** User identity passed to WebAuthn. `id` is copied before use. */
+  /**
+   * User identity passed to WebAuthn. `id` is copied before async WebAuthn
+   * work starts.
+   */
   user: {
     /**
-     * User handle for the relying party. Must be 1 to 64 bytes when provided
-     * (WebAuthn's user-handle limit).
-     *
-     * This value is stored as the WebAuthn user handle for the discoverable
-     * credential. When omitted, a fresh 32-byte random handle is generated for
-     * each call. The generated handle is not correlated with an app account.
+     * User handle stored for the discoverable credential. Must be 1 to 64
+     * bytes when provided (WebAuthn's user-handle limit). When omitted, a
+     * fresh 32-byte random handle is generated for each call.
      */
     id?: Uint8Array;
     /** User name displayed or stored by the authenticator. */
@@ -44,7 +44,8 @@ type CreatePasskeyWithPrfOutputOptions = {
   timeout?: number;
   /**
    * 32-byte PRF salt evaluated during creation, or by the fallback assertion.
-   * Defaults to Mera's fixed salt. Copied before use.
+   * Defaults to the fixed salt documented on {@link getPasskeyPrfOutput}.
+   * Copied before async WebAuthn work starts.
    */
   prfSalt?: Uint8Array;
 };
@@ -53,11 +54,15 @@ type CreatePasskeyWithPrfOutputOptions = {
 type GetPasskeyPrfOutputOptions = {
   /** Relying party ID for the WebAuthn assertion. */
   rpId: string;
-  /** Credential metadata to restrict the assertion to one passkey. */
+  /**
+   * Credential metadata to restrict the assertion to one passkey. When
+   * omitted, WebAuthn may choose any discoverable credential for the relying
+   * party.
+   */
   credential?: PasskeyCredentialMetadata;
   /**
-   * PRF salt as 32 raw bytes. Defaults to Mera's fixed salt.
-   * Copied before use.
+   * PRF salt as 32 raw bytes. Defaults to the fixed salt documented on
+   * {@link getPasskeyPrfOutput}. Copied before async WebAuthn work starts.
    */
   prfSalt?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
@@ -79,30 +84,21 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
 
 /**
  * Creates a discoverable, user-verified passkey that requires WebAuthn PRF
- * support, and returns the first PRF output, falling back to
- * {@link getPasskeyPrfOutput} with the same salt only when the authenticator
- * does not evaluate PRF at create time.
+ * support and returns the first PRF output.
  *
- * @param options - Passkey creation inputs; fields are documented on {@link CreatePasskeyWithPrfOutputOptions}.
+ * @param options - Passkey creation inputs.
  * @returns Credential metadata and the first PRF output.
  * @remarks
  * Invokes `navigator.credentials.create()` and shows one user-verification
- * prompt. On authenticators that do not evaluate PRF during creation, also
- * invokes `navigator.credentials.get()`, which shows a second.
+ * prompt. On authenticators that do not evaluate PRF during creation, a
+ * fallback `navigator.credentials.get()` evaluates the same salt and shows a
+ * second prompt.
  *
  * WebAuthn challenges are generated internally.
  *
  * The credential is requested with fixed parameters: ES256 or RS256 key types,
  * attestation `"none"`, a required resident key, and required user
- * verification. User verification is the authenticator's local check; the
- * gesture depends on the platform (a biometric, a device PIN, or a password).
- * The requirement is not configurable ({@link getPasskeyPrfOutput} documents
- * the authenticator mechanism).
- *
- * When `prfSalt` is omitted, the default salt is used;
- * {@link getPasskeyPrfOutput} documents its value and stability.
- *
- * `prfSalt` is copied before async WebAuthn work starts.
+ * verification ({@link getPasskeyPrfOutput} explains the requirement).
  *
  * Any failure after the creation ceremony completes leaves the passkey on the
  * authenticator, but the thrown error does not carry its metadata.
@@ -207,9 +203,7 @@ async function createPasskeyWithPrfOutput({
 /**
  * Requests a passkey PRF evaluation and returns the first output.
  *
- * When `credential` is omitted, WebAuthn may choose any discoverable credential for the relying party.
- *
- * @param options - Passkey PRF request inputs; fields are documented on {@link GetPasskeyPrfOutputOptions}.
+ * @param options - Passkey PRF request inputs.
  * @returns The selected credential ID and first WebAuthn PRF output.
  * @remarks
  * Invokes `navigator.credentials.get()` and shows one user-verification
@@ -217,18 +211,18 @@ async function createPasskeyWithPrfOutput({
  *
  * The WebAuthn challenge is generated internally.
  *
- * When `prfSalt` is omitted, the default salt is used:
- * `sha256("mera.prf.salt.v1")`. This default will not change across
+ * The default salt is `sha256("mera.prf.salt.v1")` and will not change across
  * library versions. The PRF output is a deterministic function of the
- * credential, `rpId`, and salt: the same three inputs reproduce the same
- * output, and a different salt yields an unrelated output.
+ * credential, `rpId`, and salt; a different salt yields an unrelated output.
  *
  * The assertion requires user verification, and the requirement is not
- * configurable. Authenticators built on CTAP's `hmac-secret` keep two PRFs
- * per credential, one for user-verified requests and one for the rest;
- * WebAuthn exposes only the user-verified PRF and overrides a weaker
- * `userVerification` setting when evaluating it, so a configurable setting
- * could neither change the PRF output nor skip the check.
+ * configurable. User verification is the authenticator's local check; the
+ * gesture depends on the platform (a biometric, a device PIN, or a password).
+ * Authenticators built on CTAP's `hmac-secret` keep two PRFs per credential,
+ * one for user-verified requests and one for the rest; WebAuthn exposes only
+ * the user-verified PRF and overrides a weaker `userVerification` setting
+ * when evaluating it, so a configurable setting could neither change the PRF
+ * output nor skip the check.
  * @see {@link https://www.w3.org/TR/webauthn-3/#prf-extension | WebAuthn: the PRF extension}
  * @see {@link https://www.w3.org/TR/webauthn-3/#enumdef-userverificationrequirement | WebAuthn: UserVerificationRequirement}
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
@@ -321,8 +315,9 @@ async function getPasskeyPrfOutput({
 }
 
 /**
- * Builds credential metadata, copying `transports` so the result never aliases
- * a caller-owned array.
+ * Builds credential metadata with a copied `transports` array.
+ *
+ * @internal
  */
 function toCredentialMetadata(
   credentialId: string,
@@ -335,8 +330,6 @@ function toCredentialMetadata(
 }
 
 /**
- * Asserts that the WebAuthn credential API is available.
- *
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable.
  */
 function assertCredentialApiAvailable(): void {
@@ -348,8 +341,6 @@ function assertCredentialApiAvailable(): void {
 /**
  * Narrows a WebAuthn result to a public-key credential with extension results.
  *
- * @param credential - Credential returned by WebAuthn.
- * @returns The credential narrowed to the PRF-aware public-key credential shape.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn returned no usable public-key credential.
  */
 function assertPublicKeyCredential(
@@ -380,7 +371,7 @@ function assertPublicKeyCredential(
  * Authenticators surface PRF output inconsistently: most return an `ArrayBuffer`,
  * some return an `ArrayBufferView`, and others (notably the 1Password browser
  * extension) return a plain array of byte values. This normalizes all of them
- * into a fresh `Uint8Array` that never aliases the input.
+ * into a fresh `Uint8Array`.
  *
  * The typed forms are already constrained to bytes. A plain array-like is not,
  * so each element is validated as an integer in [0, 255] while it is copied; a
@@ -390,7 +381,6 @@ function assertPublicKeyCredential(
  * @throws MeraError with code `PRF_UNAVAILABLE` when the output is not exactly
  * 32 bytes, or a plain array-like contains a value that is not an integer in
  * [0, 255].
- * @internal
  */
 function copyPrfOutput(
   value: BufferSource | ArrayLike<number>,

--- a/src/secp256k1.ts
+++ b/src/secp256k1.ts
@@ -10,10 +10,8 @@ import type {
 /**
  * Derives an uncompressed secp256k1 public key from a 32-byte private key.
  *
- * @param privateKey - A 32-byte secp256k1 private key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
- * @internal
  */
 function getSecp256k1PublicKey(
   privateKey: Uint8Array,
@@ -32,7 +30,6 @@ function getSecp256k1PublicKey(
 /**
  * Converts a compressed or uncompressed secp256k1 public key to uncompressed form.
  *
- * @param publicKey - A compressed or uncompressed secp256k1 public key.
  * @returns A 65-byte public key with the `0x04` uncompressed prefix.
  * @throws MeraError with code `INPUT_INVALID` when the key length, prefix, or curve point is invalid.
  * @internal
@@ -52,7 +49,7 @@ function normalizeSecp256k1PublicKey(
 /**
  * Creates a signing session from a secp256k1 private key.
  *
- * @param options - Signing session inputs; fields are documented on {@link CreateSigningSessionOptions}.
+ * @param options - Signing session inputs.
  * @returns A live secp256k1 signing session.
  * @throws MeraError with code `INPUT_INVALID` when `privateKey` is not a valid secp256k1 scalar.
  */

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -33,8 +33,7 @@ const GCM_TAG_LENGTH = 16;
 // the same PRF output.
 const SECRET_ENCRYPTION_INFO = utf8ToBytes("mera.v1.encrypt.secret");
 
-// Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256. The
-// fixed info domain-separates this key from other uses of the same PRF output.
+// Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256.
 // asArrayBuffer snapshots the output before importKey's first await, preserving
 // the public copy guarantee while the 32-byte check validates the key material.
 async function deriveEncryptionKey(prfOutput: Uint8Array): Promise<CryptoKey> {
@@ -112,12 +111,11 @@ type CreateSecretVaultOptions = {
  * derived from the same PRF output.
  *
  * A vault is bound to its PRF output only, not to the credential ID or salt:
- * vaults encrypted with one reused PRF output share an encryption key, so the
- * orchestrators use a fresh salt for each secret.
+ * vaults encrypted with one reused PRF output share an encryption key, so each
+ * secret needs a fresh salt.
  *
- * Internal building block: inputs arrive validated and caller-owned. Byte
- * inputs are read in place and never zeroed here; the orchestrators own the
- * pre-ceremony snapshots and the zeroing.
+ * Inputs arrive validated and caller-owned. Byte inputs are read in place and
+ * never zeroed here; callers own the pre-ceremony snapshots and the zeroing.
  *
  * @returns A JSON-safe secret vault.
  * @throws MeraError with code `INPUT_INVALID` when the PRF output is not 32 bytes.
@@ -184,20 +182,17 @@ function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
 /**
  * Creates a passkey and encrypts one secret into a vault.
  *
- * A fresh random PRF salt is generated internally and stored in the returned
- * vault. The passkey creation may require a fallback assertion when the
- * authenticator does not evaluate PRF during creation.
- *
- * @param options - Passkey creation inputs and secret bytes; fields are documented on {@link CreateSecretVaultWithNewPasskeyOptions}.
+ * @param options - Passkey creation inputs and secret bytes.
  * @returns A JSON-safe secret vault containing the new credential metadata.
  * @remarks
  * Invokes `navigator.credentials.create()` and shows one user-verification
  * prompt. On authenticators that do not evaluate PRF during creation, also
  * invokes `navigator.credentials.get()`, which shows a second.
  *
- * `secret` is copied and validated before either ceremony starts. The internal
- * secret and PRF output are zeroed before the function finishes, even when it
- * fails.
+ * A fresh random PRF salt is generated internally and stored in the returned
+ * vault. `secret` is copied and validated before either ceremony starts. The
+ * internal secret and PRF output are zeroed before the function finishes, even
+ * when it fails.
  *
  * If the fallback ceremony or vault encryption fails, the passkey from the
  * completed creation ceremony still exists on the authenticator, but the
@@ -233,15 +228,13 @@ async function createSecretVaultWithNewPasskey({
 }
 
 /**
- * Evaluates an existing passkey against a fresh random salt and encrypts one
- * secret into a vault.
+ * Evaluates an existing passkey and encrypts one secret into a vault.
  *
- * @param options - Passkey assertion inputs and secret bytes; fields are documented on {@link CreateSecretVaultWithExistingPasskeyOptions}.
+ * @param options - Passkey assertion inputs and secret bytes.
  * @returns A JSON-safe secret vault containing the selected credential metadata.
  * @remarks
  * Invokes `navigator.credentials.get()` and shows one user-verification
- * prompt. When `credential` is omitted, WebAuthn may choose any discoverable
- * credential for the relying party.
+ * prompt.
  *
  * A fresh random PRF salt is generated internally and stored in the returned
  * vault. `secret` and `credential` are copied before the ceremony starts. The
@@ -294,7 +287,7 @@ async function createSecretVaultWithExistingPasskey({
 
 /** Inputs for decrypting a secret vault. */
 type DecryptSecretVaultOptions = {
-  /** Parsed secret vault. */
+  /** Secret vault to decrypt. */
   vault: PasskeySecretVault;
   /** WebAuthn PRF output for the vault's PRF salt. Must be exactly 32 bytes. */
   prfOutput: Uint8Array;
@@ -303,13 +296,12 @@ type DecryptSecretVaultOptions = {
 /**
  * Decrypts the secret from a secret vault with a PRF output.
  *
- * Internal building block: decoding the vault's `nonce` and `ciphertext`
- * strings here doubles as validation for direct callers that skip
- * `parseSecretVault`.
+ * Decoding the vault's `nonce` and `ciphertext` strings here doubles as
+ * validation for direct callers that skip `parseSecretVault`.
  *
  * @returns The decrypted secret bytes in a fresh allocation.
  * @throws MeraError with code `INPUT_INVALID` when `prfOutput` is not 32 bytes, or the vault's `nonce` or `ciphertext` is not valid base64url.
- * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
+ * @throws MeraError with code `DECRYPT_FAILED` when AES-GCM authentication fails.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @internal
  */
@@ -410,11 +402,11 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
   return { version: 1, credential, prfSalt, nonce, ciphertext };
 }
 
-/** Inputs for performing the passkey ceremony and decrypting a secret vault. */
+/** Inputs for decrypting a secret vault with a passkey. */
 type DecryptSecretVaultWithPasskeyOptions = {
   /** Relying party ID for the WebAuthn assertion. */
   rpId: string;
-  /** Parsed secret vault. */
+  /** Secret vault to decrypt. */
   vault: PasskeySecretVault;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */
   timeout?: number;
@@ -423,8 +415,8 @@ type DecryptSecretVaultWithPasskeyOptions = {
 /**
  * Performs the passkey assertion for a vault and decrypts its secret.
  *
- * @param options - Relying party and parsed vault; fields are documented on {@link DecryptSecretVaultWithPasskeyOptions}.
- * @returns The decrypted secret bytes. The returned buffer is a fresh allocation.
+ * @param options - Relying party ID and vault.
+ * @returns The decrypted secret bytes in a fresh allocation.
  * @remarks
  * Invokes `navigator.credentials.get()` and shows one user-verification
  * prompt. The assertion is restricted to the credential stored in the vault.
@@ -433,7 +425,7 @@ type DecryptSecretVaultWithPasskeyOptions = {
  * decryption fails.
  * @throws MeraError with code `VAULT_FORMAT_INVALID` when the vault's required structure, version, or encoded data is invalid.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
- * @throws MeraError with code `DECRYPT_FAILED` when authentication fails.
+ * @throws MeraError with code `DECRYPT_FAILED` when AES-GCM authentication fails.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,13 +1,10 @@
 import { copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
 
-/**
- * Session-owned signing key whose lifetime is gated by `end`, paired with the
- * public key derived from it.
- */
+/** Session-owned signing key whose lifetime is gated by `end`. */
 type SigningKey = {
   /**
-   * Returns the live session-owned key for immediate use.
+   * Returns the live session-owned key.
    *
    * @throws MeraError with code `SESSION_ENDED` after `end` has been called.
    */
@@ -19,16 +16,14 @@ type SigningKey = {
 };
 
 /**
- * Copies a private key into a signing key handle and derives its public key.
+ * Copies a private key into one session-owned snapshot and derives its public
+ * key.
  *
- * `privateKey` is copied into one session-owned snapshot. The snapshot is
- * zeroed by `end` or, when `derivePublicKey` throws, before the error is
- * rethrown.
+ * The snapshot is zeroed by `end` or, when `derivePublicKey` throws, before
+ * the error is rethrown.
  *
- * @param privateKey - Private key to copy into the signing key.
  * @param derivePublicKey - Derives the public key from the owned snapshot; a throw doubles as private-key validation.
- * @returns The signing key handle with its derived public key.
- * @throws Rethrows whatever `derivePublicKey` throws.
+ * @internal
  */
 function createSigningKey(
   privateKey: Uint8Array,
@@ -61,10 +56,8 @@ function createSigningKey(
 }
 
 /**
- * Returns the active private key, or throws once the session has ended.
+ * Returns the active private key.
  *
- * @param privateKey - Session-owned private key, or `undefined` after `end`.
- * @returns The live session-owned private key.
  * @throws MeraError with code `SESSION_ENDED` when `privateKey` is undefined.
  */
 function requireActive(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,22 +12,20 @@ declare const brand: unique symbol;
  * Nominal branding helper: tags `T` with a type-only discriminant.
  *
  * The symbol key is never exported, so branded values cannot be produced
- * structurally or read back as a property; only the library functions
- * documented on each branded type mint them. Nothing exists at runtime.
+ * structurally or read back as a property.
  */
 type Brand<T, Name extends string> = T & { readonly [brand]: Name };
 
 /**
  * A base58-encoded 32-byte Solana address.
  *
- * Branded nominal type: base58 has no structural shape the way `EvmAddress`
- * does, so values are produced by `getSolanaAddress`. The brand exists only
- * in the type system; at runtime the value is a plain string.
+ * Branded nominal type minted by `getSolanaAddress`; at runtime the value is
+ * a plain string.
  */
 type SolanaAddress = Brand<string, "SolanaAddress">;
 
 /**
- * WebAuthn authenticator transport metadata, including future browser transport values.
+ * WebAuthn authenticator transport.
  *
  * The `string & {}` arm accepts any string without collapsing the union to
  * plain `string`, so editors keep offering the known `AuthenticatorTransport`
@@ -43,7 +41,7 @@ type PasskeyCredentialMetadata = {
   readonly transports?: readonly PasskeyCredentialTransport[];
 };
 
-/** Result of a successful passkey assertion with the WebAuthn PRF extension. */
+/** Result of a passkey assertion with the WebAuthn PRF extension. */
 type PasskeyPrfResult = {
   /** Credential ID selected by the browser, as canonical unpadded base64url. */
   readonly credentialId: string;
@@ -54,8 +52,7 @@ type PasskeyPrfResult = {
 /** Result of creating a passkey together with its first PRF output. */
 type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
   /**
-   * PRF salt that WebAuthn evaluated, returned for protocol interoperability.
-   * Always 32 bytes and never aliases the caller input.
+   * PRF salt that WebAuthn evaluated. Always 32 bytes, in a fresh allocation.
    */
   readonly prfSalt: Uint8Array<ArrayBuffer>;
   /** First WebAuthn PRF output for `prfSalt`. Always 32 bytes. */
@@ -63,9 +60,8 @@ type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
 };
 
 /**
- * Versioned JSON-safe vault holding one arbitrary secret encrypted behind a passkey.
- *
- * The secret bytes are opaque to the library; callers decide what they mean.
+ * Versioned JSON-safe vault holding one secret encrypted behind a passkey.
+ * The secret bytes are opaque to the library.
  */
 type PasskeySecretVault = {
   /** Secret-vault format version. */
@@ -80,28 +76,30 @@ type PasskeySecretVault = {
   readonly ciphertext: string;
 };
 
-/** secp256k1 ECDSA signature returned by a signing session. */
+/** A secp256k1 ECDSA signature. */
 type Secp256k1Signature = {
   /** Compact 64-byte `r || s` ECDSA signature. */
   readonly compact: Uint8Array<ArrayBuffer>;
-  /** Recovery ID (0 or 1) for the signature. */
+  /** Recovery ID (the y-parity bit). */
   readonly recovery: 0 | 1;
 };
 
 /** Inputs for creating a curve signing session. */
 type CreateSigningSessionOptions = {
   /**
-   * Curve private key. Must be exactly 32 bytes; secp256k1 must also be a valid scalar.
+   * Curve private key. Must be exactly 32 bytes and, for secp256k1, a valid
+   * scalar.
    *
    * Copied into one session-owned snapshot.
    */
   privateKey: Uint8Array;
 };
 
-/** Members shared by every signing session: an explicit end and `using` disposal. */
+/** Members shared by every signing session. */
 type SigningSession = {
   /**
-   * Zeroes the session-owned private-key copy and permanently ends this session; later signing throws `SESSION_ENDED`.
+   * Zeroes the session-owned private-key copy; later signing throws
+   * `SESSION_ENDED`.
    */
   end(): void;
   /**
@@ -113,12 +111,12 @@ type SigningSession = {
 
 /** secp256k1 signing session that can sign 32-byte digests until `end` is called. */
 type Secp256k1SigningSession = SigningSession & {
-  /** Uncompressed secp256k1 public key for the session. */
+  /** 65-byte uncompressed secp256k1 public key for the session. */
   readonly publicKey: Uint8Array<ArrayBuffer>;
   /**
    * Signs a 32-byte digest without prehashing it.
    *
-   * @param digest32 - Exactly 32 bytes to sign.
+   * @param digest32 - The digest to sign.
    * @returns A compact secp256k1 ECDSA signature with its recovery ID.
    * @throws MeraError with code `INPUT_INVALID` when `digest32` is not 32 bytes.
    * @throws MeraError with code `SESSION_ENDED` after `end` has been called.
@@ -131,9 +129,9 @@ type Ed25519SigningSession = SigningSession & {
   /** 32-byte Ed25519 public key for the session. */
   readonly publicKey: Uint8Array<ArrayBuffer>;
   /**
-   * Signs an arbitrary-length message with Ed25519.
+   * Signs an arbitrary-length message.
    *
-   * @param message - Message bytes to sign. Hashing happens inside Ed25519 itself.
+   * @param message - The message to sign; hashing happens inside Ed25519 itself.
    * @returns A 64-byte Ed25519 signature (`R || s`).
    * @throws MeraError with code `SESSION_ENDED` after `end` has been called.
    */

--- a/src/viem.ts
+++ b/src/viem.ts
@@ -13,7 +13,7 @@ import { hashAuthorization } from "viem/utils";
 import { getEvmAddress } from "./chains/evm.js";
 import type { Secp256k1SigningSession } from "./types.js";
 
-/** Options accepted by `toViemAccount`. */
+/** Inputs for `toViemAccount`. */
 type ToViemAccountOptions = {
   /** viem nonce manager forwarded to the account for automatic nonce handling. */
   nonceManager?: NonceManager;
@@ -24,12 +24,12 @@ type ToViemAccountOptions = {
  *
  * Each signing method hashes its input with viem's own hashers and signs the
  * resulting 32-byte digest with `session.signDigest`, so signing never shows a
- * passkey prompt; the WebAuthn ceremony already ran when the session was
- * created. The account's `address` is the EIP-55 checksummed address of the
- * session key, and `publicKey` is the 65-byte uncompressed public key as hex.
+ * passkey prompt. The account's `address` is the EIP-55 checksummed address of
+ * the session key, and `publicKey` is the 65-byte uncompressed public key as
+ * hex.
  *
  * @param session - Live secp256k1 signing session that backs the account.
- * @param options - Adapter inputs; fields are documented on {@link ToViemAccountOptions}.
+ * @param options - Adapter inputs.
  * @returns A viem local account with `source: "mera"` implementing
  * `signTransaction` (honoring a custom `serializer`), `signMessage` (EIP-191),
  * `signTypedData` (EIP-712), `signAuthorization` (EIP-7702), and raw-hash

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -3,9 +3,8 @@ import { MeraError } from "./errors.js";
 /**
  * Returns cryptographically random bytes from Web Crypto.
  *
- * @param length - Number of random bytes to return.
- * @returns Cryptographically random bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
+ * @internal
  */
 function randomBytes(length: number): Uint8Array<ArrayBuffer> {
   const output = new Uint8Array(length);
@@ -18,6 +17,7 @@ function randomBytes(length: number): Uint8Array<ArrayBuffer> {
  *
  * @returns `globalThis.crypto` when Web Crypto is available.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
+ * @internal
  */
 function getCrypto(): Crypto {
   if (!globalThis.crypto?.subtle || !globalThis.crypto.getRandomValues) {


### PR DESCRIPTION
## Problem

A line-by-line review of the src JSDoc found three recurring problems. Facts lived in several homes — HKDF domain separation was stated three times in secret.ts, the PRF fallback twice inside single doc blocks, and the default salt, salt-copy, and user-verification explanations were split or repeated across both passkey functions — so copies could drift and every reader paid twice. Docs described other functions: type docs named their producers, and `toViemAccount` claimed "the WebAuthn ceremony already ran when the session was created," which is false — `createSecp256k1SigningSession` takes a raw key and never touches WebAuthn. And many tags carried no content: eight "fields are documented on {@link ...}" clauses restating the signature, `@param`/`@returns` lines restating names and types, and a constructor doc restating the platform `Error` contract.

## Change

Comment-only. Each fact now has one home — `getPasskeyPrfOutput` owns the default salt and the user-verification explanation, the shared `credential` field owns the omitted-credential behavior — every doc stays on its own subject, and the empty tags are gone. `DECRYPT_FAILED` now reads "AES-GCM authentication fails" so it cannot be read as a passkey failure, and `@internal` marks exactly the exports outside the public API.

## Review focus

- errors.ts: the `MeraError` constructor doc is deleted and `isMeraError` is a one-line summary. The removed tags held no content, but this is the one place the PR spends the keep-structured-JSDoc convention.
- viem.ts: confirm the remaining "signing never shows a passkey prompt" reads as anchored to the mechanism (viem hashes locally, the session signs the digest), not to a passkey assumption.

The docs-site reference pages are hand-written, not mirrored from this JSDoc; nothing here contradicts them.