### PR TITLE
Cut unactionable internal detail from public docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 - The root README is a nontechnical project overview. Installation, examples, compatibility, security details, API documentation, and the demo live on the documentation website.
 - Keep documentation prose neutral: name keys, secrets, and passkeys plainly ("the passkey", "one encrypted secret") rather than attributing them to the reader ("your passkey", "a secret you provide" / "you own").
 - Internal helpers with non-obvious invariants should have short `//` comments or full JSDoc.
-- Document observable behavior, not caller instructions: state what a function does to its inputs and outputs (for example, "the input is copied before use; the original buffer is not modified") rather than what the caller may or should do with them. Callers derive correct usage from the stated facts.
+- Document observable behavior, not caller instructions: state what a function does to its inputs and outputs rather than what the caller may or should do with them. Callers derive correct usage from the stated facts.
+- Omit behavior a reader assumes by default and facts a reader cannot act on: not modifying inputs, internal copies, internal zeroing. Silence implies the default; document the exceptions.
 - When a comment or doc gives a rationale, explain the mechanism, not just the claim: a reader should see *why* from the text (for example, "signing reads the buffer after an await, so copy it first") rather than having to reconstruct the cause.
 - For section-style JSDoc/TSDoc block tags, use one tag per semantic section and continue with paragraphs until the next block tag. Put the tag on its own line when the content is multi-sentence. Repeat only naturally repeatable tags such as `@param`, `@throws`, `@example`, and `@see`; do not repeat section-style tags such as `@remarks` just to split paragraphs.
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -47,7 +47,7 @@ A live `Ed25519SigningSession`.
 
 ### publicKey
 
-`Uint8Array`, the 32-byte Ed25519 public key. Derived from the same owned snapshot used for signing, so the two cannot diverge.
+`Uint8Array`, the 32-byte Ed25519 public key.
 
 ### signMessage(message)
 

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -50,14 +50,14 @@ Human-readable display name for the authenticator UI.
 - Type: `Uint8Array`
 - Optional; a fresh 32-byte random handle is generated per call when omitted
 
-User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). The generated handle is not correlated with an app account. Copied before use.
+User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). The generated handle is not correlated with an app account.
 
 ### options.prfSalt
 
 - Type: `Uint8Array`
 - Optional; defaults to mera's fixed salt
 
-32-byte PRF salt evaluated during creation or by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts). An explicit value supports custom PRF namespaces. It is copied before async WebAuthn work starts.
+32-byte PRF salt evaluated during creation or by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts). An explicit value supports custom PRF namespaces.
 
 ### options.timeout
 
@@ -68,7 +68,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Returns
 
-`Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`. The returned salt is a fresh copy.
+`Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -47,7 +47,7 @@ A live `Secp256k1SigningSession`.
 
 ### publicKey
 
-`Uint8Array`, 65 bytes, the uncompressed secp256k1 public key with the `0x04` prefix. Derived from the same owned snapshot used for signing, so the two cannot diverge.
+`Uint8Array`, 65 bytes, the uncompressed secp256k1 public key with the `0x04` prefix.
 
 ### signDigest(digest32)
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -76,10 +76,6 @@ WebAuthn timeout in milliseconds.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
-## Notes
-
-The secret and supplied credential metadata are copied before the ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
-
 ## See also
 
 - [createSecretVaultWithNewPasskey](/reference/create-secret-vault-with-new-passkey/): create the first vault together with a passkey.

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -72,8 +72,6 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 ## Notes
 
-The secret is copied before either ceremony begins. Internal secret and PRF-output copies are zeroed before the function finishes, even when it fails.
-
 If the fallback ceremony or vault encryption fails after creation, the passkey remains on the authenticator and the error does not contain its metadata.
 
 ## See also

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -70,8 +70,6 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-The vault is copied before the assertion starts. The transient PRF output is zeroed before the function finishes, even when decryption fails.
-
 The WebAuthn challenge is generated internally.
 
 ## See also

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -42,7 +42,7 @@ Credential metadata that restricts the assertion to one passkey: a `credentialId
 - Type: `Uint8Array`
 - Optional; defaults to mera's fixed salt
 
-PRF salt as 32 raw bytes. An explicit value supports custom PRF namespaces. It is copied before use.
+PRF salt as 32 raw bytes. An explicit value supports custom PRF namespaces.
 
 ### options.timeout
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -46,7 +46,7 @@ The AES-GCM ciphertext with its 16-byte authentication tag appended, base64url. 
 
 ## What is deliberately absent
 
-The encryption key and the PRF output are never stored; both exist only transiently in memory. The rpId is also absent; the unlock assertion supplies it.
+The encryption key and the PRF output are never stored. The rpId is also absent; the unlock assertion supplies it.
 
 The credential ID and salt are stored but not authenticated: neither is supplied as AES-GCM additional authenticated data, so a vault is cryptographically bound to its PRF output only. This is why each secret needs a fresh salt: vaults that share a PRF output share an encryption key.
 

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -24,10 +24,7 @@ type CreatePasskeyWithPrfOutputOptions = {
    * fallback assertion can target the same relying party.
    */
   rp: PublicKeyCredentialRpEntity & { id: string };
-  /**
-   * User identity passed to WebAuthn. `id` is copied before async WebAuthn
-   * work starts.
-   */
+  /** User identity passed to WebAuthn. */
   user: {
     /**
      * User handle stored for the discoverable credential. Must be 1 to 64
@@ -45,7 +42,6 @@ type CreatePasskeyWithPrfOutputOptions = {
   /**
    * 32-byte PRF salt evaluated during creation, or by the fallback assertion.
    * Defaults to the fixed salt documented on {@link getPasskeyPrfOutput}.
-   * Copied before async WebAuthn work starts.
    */
   prfSalt?: Uint8Array;
 };
@@ -62,7 +58,7 @@ type GetPasskeyPrfOutputOptions = {
   credential?: PasskeyCredentialMetadata;
   /**
    * PRF salt as 32 raw bytes. Defaults to the fixed salt documented on
-   * {@link getPasskeyPrfOutput}. Copied before async WebAuthn work starts.
+   * {@link getPasskeyPrfOutput}.
    */
   prfSalt?: Uint8Array;
   /** WebAuthn timeout in milliseconds. Browser defaults apply when omitted. */

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -190,9 +190,7 @@ function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
  * invokes `navigator.credentials.get()`, which shows a second.
  *
  * A fresh random PRF salt is generated internally and stored in the returned
- * vault. `secret` is copied and validated before either ceremony starts. The
- * internal secret and PRF output are zeroed before the function finishes, even
- * when it fails.
+ * vault.
  *
  * If the fallback ceremony or vault encryption fails, the passkey from the
  * completed creation ceremony still exists on the authenticator, but the
@@ -237,9 +235,7 @@ async function createSecretVaultWithNewPasskey({
  * prompt.
  *
  * A fresh random PRF salt is generated internally and stored in the returned
- * vault. `secret` and `credential` are copied before the ceremony starts. The
- * internal secret and PRF output are zeroed before the function finishes, even
- * when it fails.
+ * vault.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `INPUT_INVALID` when `secret` is empty, or `credential.credentialId` is empty or not canonical base64url.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
@@ -420,9 +416,6 @@ type DecryptSecretVaultWithPasskeyOptions = {
  * @remarks
  * Invokes `navigator.credentials.get()` and shows one user-verification
  * prompt. The assertion is restricted to the credential stored in the vault.
- *
- * The internal PRF output is zeroed before the function finishes, even when
- * decryption fails.
  * @throws MeraError with code `VAULT_FORMAT_INVALID` when the vault's required structure, version, or encoded data is invalid.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not return a usable 32-byte PRF output.
  * @throws MeraError with code `DECRYPT_FAILED` when AES-GCM authentication fails.


### PR DESCRIPTION
Doc feedback flagged the parameter notes that say inputs are "copied before use": readers assume a function leaves its arguments alone, so these notes add nothing and imply other functions might mutate. Review of the same category turned up more statements a reader cannot act on: notes that internal copies are zeroed before a function returns, that a returned salt is a fresh copy, that a public key derives from the same internal snapshot, and that key material exists "only transiently in memory".

This PR removes them from the reference pages and the JSDoc they mirror. The test applied: does the statement change anything the caller does? Kept on that basis:

- "Copied into one session-owned snapshot" and `end()` zeroing — the caller decides when to zero their own buffer, and the recipes build on this.
- "The challenge/nonce/salt is generated internally" — explains why there is no such parameter.
- "The encryption key and the PRF output are never stored" — the vault alone cannot decrypt itself, so it is safe to store anywhere.

AGENTS.md used "the input is copied before use; the original buffer is not modified" as its model example for behavior docs, which is how these notes got written. The example is replaced with the rule above so a future docs pass does not regrow them.