### PR TITLE
Cut rationale asides and misplaced rules from docs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -41,6 +41,8 @@ Fixed section order:
 8. `## Notes`: copy and zeroing semantics, determinism statements, caveats. Omit the section when there is nothing to say.
 9. `## See also`: related functions, the owning concept page, the recipe that uses it.
 
+Each section states its own kind of fact: what an input must be under Parameters, what comes back under Returns, what fails under Errors. A fact in the wrong section ("only version 1 vaults are accepted" under Returns) moves to the section that owns it, or out of the page when another section already carries it.
+
 Parameters use subheadings and lists, never wide tables. The content column is narrow; a five-column table does not survive it. Tables are reserved for genuinely tabular data, like the authenticator matrix.
 
 Source of truth is the JSDoc in `src/`. Write reference prose from it. When the JSDoc is silent, inspect the implementation and tests.
@@ -55,6 +57,8 @@ Source of truth is the JSDoc in `src/`. Write reference prose from it. When the 
 ## Voice
 
 The bar is simple, concise, and detailed at once: detail survives the cut, filler does not. Every sentence must add information a reader can act on; delete sentences that only set up, restate, or editorialize ("that choice is what makes this repeatable", "what happens next is the app's decision").
+
+Design rationale meets the same bar: keep the why only when it changes what the reader does. A sentence that explains the library to itself ("rejecting an unknown version keeps an old library from misreading newer data", "the two cases are indistinguishable by design") is filler next to the behavior it decorates. The same goes for restating a guarantee the adjacent text already carries.
 
 `site/WRITING.md` applies in full. The rules that carry the most weight here:
 
@@ -104,6 +108,8 @@ The bar is simple, concise, and detailed at once: detail survives the cut, fille
 - The sidebar in `astro.config.mjs` is hand-maintained. A sidebar slug without a page fails the build.
 - Plain `.md` unless the page imports a component; then `.mdx`.
 - Internal links are root-relative with a trailing slash: `/reference/errors/`. Link text is descriptive; no bare "here".
+- A link description states a fact the link title does not. "Security model: learn more about the security model" restates the title; "Security model: what mera protects, and the risks left to the app" adds one.
+- A bracketed name followed by parentheses, `[Symbol.dispose]()`, is markdown link syntax and renders as a link with an empty target. Escape the opening bracket: `\[Symbol.dispose]()`.
 - Link the first mention of a spec'd name on each page to its spec (BIP-32/BIP-39/BIP-44 to the bips repo, SLIP-0010 to the slips repo, WebAuthn to the W3C spec, CTAP and `hmac-secret` to the FIDO spec); later mentions on the page stay plain.
 - Never reference sections by number; name the thing and link it.
 - `npm run build` must pass before a PR.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -102,6 +102,6 @@ Without `credential`, the browser offers any discoverable passkey it holds for t
 ## Where next
 
 - [Send a transaction with viem](/recipes/send-a-transaction-with-viem/): from sign-in to a sent transaction.
-- [Passkey accounts](/concepts/passkey-accounts/): learn how the same passkey reproduces the same accounts.
+- [Passkey accounts](/concepts/passkey-accounts/): how the same passkey reproduces the same accounts.
 - [Secret vaults](/concepts/secret-vaults/): use passkey PRF output to encrypt a secret, useful for cases where the secret must come from elsewhere.
-- [Security model](/concepts/security-model/): learn more about mera's security model.
+- [Security model](/concepts/security-model/): what mera protects, and the risks left to the app.

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -50,7 +50,7 @@ Human-readable display name for the authenticator UI.
 - Type: `Uint8Array`
 - Optional; a fresh 32-byte random handle is generated per call when omitted
 
-User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit). The generated handle is not correlated with an app account.
+User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit).
 
 ### options.prfSalt
 

--- a/docs/src/content/docs/reference/ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/ed25519-signing-session.md
@@ -25,7 +25,7 @@ Signs an arbitrary-length message and resolves to the 64-byte Ed25519 signature 
 
 Zeroes the session-owned private-key copy and permanently ends the session; later signing throws [`SESSION_ENDED`](/reference/errors/#session_ended).
 
-### [Symbol.dispose]()
+### \[Symbol.dispose]()
 
 Calls `end`, so a `using` declaration ends the session when its scope exits:
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -53,11 +53,11 @@ The authenticator did not enable PRF, or did not return a usable 32-byte PRF out
 
 ### SESSION_ENDED
 
-A signing call was made after the session's `end()`. An ended session never signs again; new signatures require a new session built from fresh key material.
+A signing call was made after the session's `end()`.
 
 ### DECRYPT_FAILED
 
-[AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed while decrypting a vault: wrong key material or a tampered nonce/ciphertext pair. The two cases are indistinguishable by design; GCM authenticates before it decrypts.
+[AES-GCM](/concepts/secret-vaults/#how-a-vault-works) authentication failed while decrypting a vault: wrong key material or a tampered nonce/ciphertext pair.
 
 ### INPUT_INVALID
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -35,7 +35,7 @@ Relying party ID for the [WebAuthn](https://www.w3.org/TR/webauthn-3/) [assertio
 - Type: `PasskeyCredentialMetadata`
 - Optional; when omitted, WebAuthn may choose any discoverable credential for the relying party
 
-Credential metadata that restricts the assertion to one passkey: a `credentialId` in canonical unpadded base64url, plus the `transports` reported when it was created. An empty `credentialId` is rejected rather than passed through, because WebAuthn would treat it as no restriction at all and silently widen the assertion to any discoverable passkey.
+Credential metadata that restricts the assertion to one passkey: a `credentialId` in canonical unpadded base64url, plus the `transports` reported when it was created.
 
 ### options.prfSalt
 
@@ -64,7 +64,7 @@ WebAuthn timeout in milliseconds.
 
 ## Notes
 
-When `prfSalt` is omitted, the default salt is used: `sha256("mera.prf.salt.v1")`. The salt will not change across library versions, and another implementation can reproduce the output from the same constant. The salt encodes no account selection; that happens in the derivation scheme the app applies to the PRF output.
+When `prfSalt` is omitted, the default salt is used: `sha256("mera.prf.salt.v1")`. The salt will not change across library versions, and another implementation can reproduce the output from the same constant.
 
 The assertion requires user verification, and the requirement is not configurable ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism).
 

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -38,7 +38,7 @@ A 32-byte Ed25519 public key.
 
 ## Returns
 
-A `SolanaAddress`, a branded `string` type. TypeScript cannot check base58 the way `0x${string}` covers EVM addresses, so only this function produces values of the type.
+A `SolanaAddress`, a branded `string` type.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -28,15 +28,11 @@ The secret vault as JSON text or an untrusted object. Strings are JSON-parsed fi
 
 ## Returns
 
-A validated `PasskeySecretVault`. Only version 1 vaults are accepted. The credential ID, PRF salt, nonce, and ciphertext are validated as canonical base64url and length-checked (salt 32 bytes, nonce 12 bytes, ciphertext at least the 16-byte GCM tag). Unknown fields are dropped: the returned object carries the v1 schema fields and nothing else.
+A validated `PasskeySecretVault`. Its credential ID, PRF salt, nonce, and ciphertext are canonical base64url with checked lengths (salt 32 bytes, nonce 12 bytes, ciphertext at least the 16-byte GCM tag). Unknown fields are dropped.
 
 ## Errors
 
 - [`VAULT_FORMAT_INVALID`](/reference/errors/#vault_format_invalid): the required structure, version, or encoded data is invalid. The underlying parse failure, when there is one, is attached as `cause`.
-
-## Notes
-
-Rejecting an unknown version keeps an old library from misreading data written by a newer format.
 
 ## See also
 

--- a/docs/src/content/docs/reference/secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/secp256k1-signing-session.md
@@ -25,7 +25,7 @@ Signs a 32-byte digest without prehashing it and resolves to a `Secp256k1Signatu
 
 Zeroes the session-owned private-key copy and permanently ends the session; later signing throws [`SESSION_ENDED`](/reference/errors/#session_ended).
 
-### [Symbol.dispose]()
+### \[Symbol.dispose]()
 
 Calls `end`, so a `using` declaration ends the session when its scope exits:
 

--- a/docs/src/content/docs/reference/secret-vault-format.md
+++ b/docs/src/content/docs/reference/secret-vault-format.md
@@ -22,7 +22,7 @@ A secret vault is a versioned JSON object containing one passkey-encrypted secre
 
 ### version
 
-Always `1`. [parseSecretVault](/reference/parse-secret-vault/) rejects anything else, including future versions it does not understand.
+Always `1`. [parseSecretVault](/reference/parse-secret-vault/) rejects anything else.
 
 ### credential.credentialId
 


### PR DESCRIPTION
Doc-review feedback flagged sentences that read as AI-generated filler: design-rationale asides a reader cannot act on, an input-acceptance rule sitting in a Returns section, and link descriptions that restate the link title. It also caught a dead link: the `[Symbol.dispose]()` member headings parse as markdown links with an empty target.

This PR cuts the filler, fixes the headings, and adds the generalized rules to docs/AGENTS.md (fact placement by section, design-rationale asides, link descriptions, bracket escaping) so review catches these before they land:

- **parse-secret-vault**: the Returns section now describes only the returned object; the version-1 rule and its rationale note are gone (the Errors section and the vault-format page still carry the version contract).
- **get-solana-address**: dropped the confusing "TypeScript cannot check base58…" type-system aside.
- **get-passkey-prf-output**, **errors**, **secret-vault-format**, **create-passkey-with-prf-output**: removed trailing "by design"-style rationale sentences whose load-bearing fact already stands in the adjacent text.
- **getting-started**: replaced two "learn…" link descriptions that restated the link titles.
- **Secp256k1SigningSession**, **Ed25519SigningSession**: escaped the `[Symbol.dispose]()` headings so they render as text instead of `<a href="">`.

Not visible in the diff: the source was grepped for JSDoc mirrors of every removed sentence; the only hit is an internal `//` comment in `src/passkey.ts` documenting the empty-credential-ID invariant, which stays per AGENTS.md. `npm run check` and the docs build pass.
