### PR TITLE
Replace the Advanced badge with plain text and say why vaults are advanced

### DIFF
--- a/docs/src/content/docs/concepts/secret-vaults.mdx
+++ b/docs/src/content/docs/concepts/secret-vaults.mdx
@@ -2,14 +2,12 @@
 title: Secret vaults
 description: Passkey-encrypted storage for one existing secret, and when to use them.
 sidebar:
-  badge:
-    text: Advanced
-    variant: default
+  label: Secret vaults (advanced)
 ---
 
 import VaultRoundtrip from "../../../assets/diagrams/vault-roundtrip.svg";
 
-A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey.
+A secret vault holds one secret (a recovery phrase, a private key, any bytes), encrypted so that only a passkey [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) can decrypt it. Vaults cover the cases where [key material](/concepts/entropy-keys-and-accounts/#deterministic-derivation) must come from outside the passkey. They are the advanced pattern because the app must store the encrypted vault itself.
 
 ## How a vault works
 


### PR DESCRIPTION
Reviewer feedback on the docs: the Advanced badge on the Secret vaults sidebar entry is loud, and the page never says what earns the tag.

The badge is now plain text in the sidebar label ("Secret vaults (advanced)"), set via `sidebar.label` so the page title is unchanged. The intro now states the reason up front: the app must store the encrypted vault itself. The detail (where it lives, syncing, device loss) stays in "When to use a vault".