### PR TITLE
Reorder the Concepts sidebar to lead with library concepts

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -130,12 +130,17 @@ export default defineConfig({
         {
           label: "Concepts",
           items: [
-            "concepts/passkeys-and-prf",
-            "concepts/security-model",
             "concepts/passkey-accounts",
             "concepts/signing-sessions",
             "concepts/secret-vaults",
-            "concepts/entropy-keys-and-accounts",
+            "concepts/security-model",
+            {
+              label: "Foundations",
+              items: [
+                "concepts/passkeys-and-prf",
+                "concepts/entropy-keys-and-accounts",
+              ],
+            },
           ],
         },
         {


### PR DESCRIPTION
The Concepts sidebar opened with background material (Passkeys and the PRF extension) and buried the library's default pattern at position three, while the other background page (Entropy, keys, and accounts) sat last — the section mixed foundations and library concepts with no visible boundary.

The new order leads with the library's own concepts — passkey accounts, signing sessions, secret vaults, then the security model as the capstone over all three — and moves the two background pages into a Foundations subgroup at the end. Reading out of order stays safe: every library page already glosses foundation terms inline on first mention and links to the Foundations pages for depth.

Sidebar-only change; no page content moved. Verified with a full docs build and by inspecting the rendered sidebar HTML.