### PR TITLE
Address docs review feedback

### DIFF
--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Entropy, keys, and accounts
+title: Keys and accounts
 description: How random bytes become a private key, an address, and a reproducible family of accounts.
 ---
 
@@ -10,9 +10,7 @@ import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
 
 ## Keys, signatures, and accounts
 
-Entropy is randomness an attacker cannot predict, and 32 random bytes carry 256 bits of it.
-
-A private key is a 256-bit secret number. A one-way function computes the public key from it, which is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
+A private key is a 256-bit secret number, far too large to guess. A one-way function computes the public key from it, which is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
 
 A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key.
 
@@ -30,13 +28,13 @@ A seed is the byte string a key tree starts from. BIP-32 (secp256k1) and [SLIP-0
 
 ## Seed phrases
 
-BIP-39 maps entropy to a phrase of common words and back: 128 bits become 12 words, 256 bits become 24.
+BIP-39 maps random bytes to a phrase of common words and back: 128 bits become 12 words, 256 bits become 24.
 
 A wallet app that follows the same standards turns an imported phrase back into the same accounts.
 
 ## Where mera fits
 
-mera supplies the entropy for this pipeline: the PRF output of a passkey ceremony. [Passkey accounts](/concepts/passkey-accounts/) explains the account model built on it.
+mera supplies the random bytes this pipeline starts from: the PRF output of a passkey ceremony. [Passkey accounts](/concepts/passkey-accounts/) explains the account model built on it.
 
 ## See also
 

--- a/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
+++ b/docs/src/content/docs/concepts/entropy-keys-and-accounts.mdx
@@ -10,7 +10,7 @@ import Bip32Tree from "../../../assets/diagrams/bip32-tree.svg";
 
 ## Keys, signatures, and accounts
 
-A private key is a 256-bit secret number, far too large to guess. A one-way function computes the public key from it, which is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
+A private key is a 256-bit secret number. A one-way function computes the public key from it, which is safe to share. A signature is computed from a message and a private key and verified with the public key alone. A valid signature proves the key's holder approved that exact message.
 
 A blockchain account is the state a chain tracks for one key pair: a balance and a transaction history. The address is a short encoding of the public key.
 

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -15,7 +15,7 @@ What if a seed phrase or another secret already exists, and the goal is passkey 
 
 ## See also
 
-- [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): the derivation pipeline the app runs on the PRF output.
+- [Keys and accounts](/concepts/entropy-keys-and-accounts/): the derivation pipeline the app runs on the PRF output.
 - [Create passkey accounts](/recipes/create-passkey-accounts/): the pattern in code, with numbered accounts and credential pinning.
 - [Secret vaults](/concepts/secret-vaults/): the advanced pattern for secrets that exist on their own.
 - [getPasskeyPrfOutput](/reference/get-passkey-prf-output/): the ceremony and the fixed salt behind the stability.

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -3,19 +3,15 @@ title: Passkey accounts
 description: Accounts derived from a passkey's PRF output, with no stored secret.
 ---
 
-In mera's model, a passkey account is a blockchain account whose keys derive from a passkey's PRF output, the 32 secret bytes a passkey returns deterministically, so each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts.
-
-## One salt, one stable output
-
-The PRF takes a 32-byte salt as input to give the same passkey unrelated outputs. Mera uses a fixed salt. The same passkey and relying party then produce the same PRF output on every device the passkey syncs to. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
+In mera's model, a passkey account is a blockchain account whose keys derive from a passkey's [PRF output](/concepts/passkeys-and-prf/), the 32 secret bytes a passkey returns deterministically. Mera evaluates the PRF with a fixed salt, so each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts on every device the passkey syncs to, with no secret stored anywhere. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## Losing the passkey
 
-The account may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's rpId after a domain migration. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works.
+The accounts may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's rpId after a domain migration. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works.
 
 ## When the secret already exists
 
-Passkey accounts are rooted in the passkey itself, so an account that predates the passkey cannot become one. Mera supports encrypting arbitrary secrets with Passkey's PRF output, described in [secret vault](/concepts/secret-vaults/). This is an advanced use case since it requires the app to store the encrypted blob.
+What if a seed phrase or another secret already exists, and the goal is passkey access to it? Passkey accounts are rooted in the passkey itself, so an account that predates the passkey cannot become one. The app can instead lock the existing secret to the passkey with a [secret vault](/concepts/secret-vaults/).
 
 ## See also
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -35,6 +35,6 @@ A ceremony is one WebAuthn call and one user-verification prompt. A ceremony eit
 
 ## See also
 
-- [Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/): what the 32 bytes become once the app holds them.
+- [Keys and accounts](/concepts/entropy-keys-and-accounts/): what the 32 bytes become once the app holds them.
 - [Authenticator support](/authenticator-support/): which stacks deliver PRF today.
 - [Getting started](/getting-started/): the ceremony-to-signature path in code.

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -5,10 +5,10 @@ description: What mera protects, what it cannot, and the risks left to the app.
 
 import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
-Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, it matches a wallet app holding an imported seed phrase in the page.
+Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, mera's security model matches that of a wallet browser extension like MetaMask or Phantom: whatever the wallet signs with, a seed phrase, a private key, or an access token for a remote signer, lives in script memory.
 
-- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with a live session. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Ending sessions when idle and zeroing key material promptly shorten the exposure.
-- Losing the passkey without a prior export loses the accounts derived from it.
+- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with a live session. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Ending sessions when idle and zeroing key material promptly reduce the exposure.
+- Losing access to the passkey without a backup or export also loses access to the accounts derived from it.
 - A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.
 - The only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -8,7 +8,7 @@ import GettingStartedOverview from "../../assets/diagrams/getting-started-overvi
 What mera does:
 
 - Create a passkey and get 32 secret bytes from it through the [PRF extension](/concepts/passkeys-and-prf/).
-- Use those bytes as [entropy](/concepts/entropy-keys-and-accounts/) to derive accounts.
+- [Derive accounts](/concepts/entropy-keys-and-accounts/) from those bytes.
 - Sign with a [signing session](/concepts/signing-sessions/).
 
 <GettingStartedOverview />
@@ -50,7 +50,7 @@ mera uses a stable PRF salt for this call, so a later sign-in reproduces the sam
 
 ## Derive an account
 
-The PRF output is entropy, the root of every account. This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
+The PRF output is the root of every account. This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
 
 ```ts
 import { HDKey } from "@scure/bip32";

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -17,7 +17,7 @@ const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 
 ## Derive the key
 
-The seed and path come from the same mapping [Create passkey accounts](/recipes/create-passkey-accounts/) uses ([Entropy, keys, and accounts](/concepts/entropy-keys-and-accounts/) introduces the standards).
+The seed and path come from the same mapping [Create passkey accounts](/recipes/create-passkey-accounts/) uses ([Keys and accounts](/concepts/entropy-keys-and-accounts/) introduces the standards).
 
 ```ts
 import { HDKey } from "@scure/bip32";


### PR DESCRIPTION
Addresses the latest docs review round. Three complaints drove the changes:

- **The security model comparison was vague.** "It matches a wallet app" now names MetaMask and Phantom, and the compared secret is generalized past a seed phrase: whatever the wallet signs with, including a remote signer's access token, lives in script memory. The passkey-loss bullet now says what is actually lost (access, absent a backup or export).
- **The passkey accounts page restated other pages.** The reviewer suggested deleting it; it stays because it is the only page that defines the library's core concept, but each section now keeps only what no other page states: the definition plus the fixed PRF salt, the ways a passkey gets lost, and the boundary that an existing account cannot become a passkey account (now opened with the motivating question and handed off to the secret vaults page).
- **The entropy lesson read as filler.** The docs now state the property directly (a 256-bit key is far too large to guess) and say "random bytes" where they meant entropy. The page is retitled "Keys and accounts"; its slug is unchanged so existing links keep working.