### PR TITLE
Move Secret vaults to the end of the Concepts section

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -132,8 +132,8 @@ export default defineConfig({
           items: [
             "concepts/passkey-accounts",
             "concepts/signing-sessions",
-            "concepts/secret-vaults",
             "concepts/security-model",
+            "concepts/secret-vaults",
             {
               label: "Foundations",
               items: [


### PR DESCRIPTION
Secret vaults is the advanced concept in the section, but it sat between Signing sessions and Security model, ahead of material a reader needs first. This moves it after Security model, so the section now reads in order of need: accounts, sessions, security model, then vaults. The Foundations subgroup still trails the section.