### PR TITLE
Cap anvil memory with history pruning on the demo EVM network

### DIFF
--- a/demo/network/evm/server.mts
+++ b/demo/network/evm/server.mts
@@ -52,6 +52,12 @@ const MAX_BODY_BYTES = 128 * 1024;
 // Mixed mining mines transactions instantly and adds an interval block every
 // second, so the head timestamp, and with it the stock price, moves at the
 // finest pace a second-granular timestamp allows.
+// That pace also means anvil, which by default keeps every block and a state
+// snapshot per block in memory, grows without bound and gets killed by the
+// platform's memory cap within a day. The pruning flags cap it: keep only the
+// latest state and the last 256 blocks with transactions. Nothing reads
+// further back; the demo's oldest lookup is a receipt polled seconds after
+// the send.
 const anvil = spawn(
   "anvil",
   [
@@ -64,6 +70,9 @@ const anvil = spawn(
     "--mixed-mining",
     "--block-time",
     "1",
+    "--prune-history",
+    "--transaction-block-keeper",
+    "256",
   ],
   { stdio: ["ignore", "inherit", "inherit"] },
 );


### PR DESCRIPTION
The demo EVM network dies with out-of-memory about once a day. Railway's memory metric shows a sawtooth: from 0.3 GB at boot the container climbs to the 32 GB cap in under a day, gets killed, and starts over, resetting every demo balance each time.

The cause is the block rate. The network mines a block every second so the stock price moves smoothly, and anvil by default keeps every block, every receipt, and a state snapshot per block in memory forever. About 86,000 blocks a day walk into any cap; raising it only delays the crash.

The two pruning flags bound this: keep only the latest state and the last 256 blocks with transactions. Nothing reads further back — the demo's oldest lookup is `waitForTransactionReceipt`, polled seconds after the send, and the guard's own calls read balances at `latest` and the deploy receipt at boot. Verified locally that anvil boots with this flag set and answers `eth_chainId` and `eth_getBalance`.