### PR TITLE
docs: add a signing sessions card to the landing list

### DIFF
--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -25,14 +25,19 @@ const features = [
     text: "A web app and its native iOS or Android counterpart can use the same passkey to restore the same accounts.",
   },
   {
-    title: "Works with existing accounts",
-    link: "/concepts/secret-vaults/",
-    text: "Encrypt a recovery phrase or private key once, then decrypt it with the passkey.",
+    title: "Signing without prompts",
+    link: "/concepts/signing-sessions/",
+    text: "A session keeps the key ready, so signing needs no prompt until the session ends.",
   },
   {
     title: "The authenticator is the key store",
     link: "/concepts/security-model/",
     text: "Passkey providers store, sync, and guard credentials, so the app needs no custody backend, MPC setup, or smart-account contracts.",
+  },
+  {
+    title: "Works with existing accounts",
+    link: "/concepts/secret-vaults/",
+    text: "Encrypt a recovery phrase or private key once, then decrypt it with the passkey.",
   },
 ];
 ---


### PR DESCRIPTION
## Why

The landing list sold onboarding, cross-platform reach, existing accounts, and the key store, but said nothing about signing. A reader could finish the page without learning that a session signs on its own, which is the reason the one onboarding prompt stays one prompt.

The new card sits at 03, right after "Creating an account is a passkey prompt", so the reader meets the session while that single prompt is still in view. "Works with existing accounts" keeps its copy and link and moves to 05.

## Notes for reviewers

The copy went through a few rounds. "one prompt instead of one each" was wrong: signing never prompts, so there is no per-signature prompt to reduce. The card now states the mechanism (the session holds the key) and its bound (until the session ends), matching [Signing sessions](docs/src/content/docs/concepts/signing-sessions.mdx).

Rendered on the dev server at 1440px:

![landing.png](https://github.com/user-attachments/assets/bdd6dbaf-7e75-4278-8795-f371f3302a82)