### PR TITLE
Add search suggestions to the docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -122,6 +122,7 @@ export default defineConfig({
         Footer: "./src/components/Footer.astro",
         Header: "./src/components/Header.astro",
         Hero: "./src/components/Hero.astro",
+        Search: "./src/components/Search.astro",
         ThemeProvider: "./src/components/ThemeProvider.astro",
         ThemeSelect: "./src/components/ThemeSelect.astro",
       },

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -1,0 +1,623 @@
+---
+import { getCollection } from "astro:content";
+import project from "virtual:starlight/project-context";
+import { withBasePath } from "../base-path";
+
+const pagefindTranslations = {
+  placeholder: Astro.locals.t("search.label"),
+  ...Object.fromEntries(
+    Object.entries(Astro.locals.t.all())
+      .filter(([key]) => key.startsWith("pagefind."))
+      .map(([key, value]) => [key.replace("pagefind.", ""), value]),
+  ),
+};
+
+const dataAttributes: DOMStringMap = {
+  "data-translations": JSON.stringify(pagefindTranslations),
+};
+if (project.trailingSlash === "never") dataAttributes["data-strip-trailing-slash"] = "";
+
+// Pages suggested in the search modal when the query is empty. Titles and
+// descriptions come from each page's frontmatter, so this list only needs the
+// slug; a stale title cannot drift from the page it links to.
+const suggestedSlugs = [
+  "concepts/passkey-accounts",
+  "concepts/signing-sessions",
+  "recipes/create-passkey-accounts",
+  "recipes/send-a-transaction-with-viem",
+];
+
+const docs = await getCollection("docs");
+const suggestions = suggestedSlugs
+  .map((slug) => {
+    const entry = docs.find((d) => d.id === slug);
+    if (!entry) return undefined;
+    return {
+      href: withBasePath(`/${slug}/`),
+      title: entry.data.title,
+      description: entry.data.description ?? "",
+    };
+  })
+  .filter(
+    (s): s is { href: string; title: string; description: string } => Boolean(s),
+  );
+---
+
+<site-search class={Astro.props.class} {...dataAttributes}>
+  <button
+    data-open-modal
+    disabled
+    aria-label={Astro.locals.t("search.label")}
+    aria-keyshortcuts="Control+K"
+  >
+    <svg
+      class="search-icon"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      ><path
+        d="M21.71 20.29 18 16.61A9 9 0 1 0 16.61 18l3.68 3.68a.999.999 0 0 0 1.42 0 1 1 0 0 0 0-1.39ZM11 18a7 7 0 1 1 0-14 7 7 0 0 1 0 14Z"
+      ></path>
+    </svg>
+    <span class="sl-hidden md:sl-block" aria-hidden="true"
+      >{Astro.locals.t("search.label")}</span
+    >
+    <kbd class="sl-hidden md:sl-flex" style="display: none;">
+      <kbd>{Astro.locals.t("search.ctrlKey")}</kbd><kbd>K</kbd>
+    </kbd>
+  </button>
+
+  <dialog style="padding:0" aria-label={Astro.locals.t("search.label")}>
+    <div class="dialog-frame sl-flex">
+      <button data-close-modal class="sl-flex md:sl-hidden">
+        {Astro.locals.t("search.cancelLabel")}
+      </button>
+      {
+        import.meta.env.DEV ? (
+          <div style="margin: auto; text-align: center; white-space: pre-line;" dir="ltr">
+            <p>{Astro.locals.t("search.devWarning")}</p>
+          </div>
+        ) : (
+          <div class="search-container">
+            <div id="starlight__search" />
+            <div
+              id="starlight__search-suggestions"
+              class="search-suggestions"
+              data-suggestions
+            >
+              <p class="suggestions-label">Suggested pages</p>
+              <ul class="suggestions-list">
+                {suggestions.map((s) => (
+                  <li>
+                    <a class="suggestion" href={s.href}>
+                      <span class="suggestion-title">{s.title}</span>
+                      <span class="suggestion-excerpt">{s.description}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )
+      }
+    </div>
+  </dialog>
+</site-search>
+
+{
+  /**
+   * This is intentionally inlined to avoid briefly showing an invalid shortcut.
+   * Purposely using the deprecated `navigator.platform` property to detect Apple devices, as the
+   * user agent is spoofed by some browsers when opening the devtools.
+   */
+}
+<script is:inline>
+  (() => {
+    const openBtn = document.querySelector("button[data-open-modal]");
+    const shortcut = openBtn?.querySelector("kbd");
+    if (!openBtn || !(shortcut instanceof HTMLElement)) return;
+    const platformKey = shortcut.querySelector("kbd");
+    if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+      platformKey.textContent = "⌘";
+      openBtn.setAttribute("aria-keyshortcuts", "Meta+K");
+    }
+    shortcut.style.display = "";
+  })();
+</script>
+
+<script>
+  import { pagefindUserConfig } from "virtual:starlight/pagefind-config";
+
+  class SiteSearch extends HTMLElement {
+    constructor() {
+      super();
+      const openBtn = this.querySelector<HTMLButtonElement>(
+        "button[data-open-modal]",
+      )!;
+      const closeBtn = this.querySelector<HTMLButtonElement>(
+        "button[data-close-modal]",
+      )!;
+      const dialog = this.querySelector("dialog")!;
+      const dialogFrame = this.querySelector(".dialog-frame")!;
+
+      /** Close the modal if a user clicks on a link or outside of the modal. */
+      const onClick = (event: MouseEvent) => {
+        const isLink = "href" in (event.target || {});
+        if (
+          isLink ||
+          (document.body.contains(event.target as Node) &&
+            !dialogFrame.contains(event.target as Node))
+        ) {
+          closeModal();
+        }
+      };
+
+      const suggestionsEl = this.querySelector<HTMLElement>(
+        "#starlight__search-suggestions",
+      );
+
+      // Show the suggested pages only while the query is empty. Once the user
+      // types, hand the panel to Pagefind and hide the suggestions.
+      const updateSuggestions = () => {
+        const input = this.querySelector<HTMLInputElement>(
+          "#starlight__search input",
+        );
+        const empty = !input || input.value.trim() === "";
+        suggestionsEl?.classList.toggle("is-hidden", !empty);
+      };
+
+      const openModal = (event?: MouseEvent) => {
+        dialog.showModal();
+        document.body.toggleAttribute("data-search-modal-open", true);
+        this.querySelector("input")?.focus();
+        event?.stopPropagation();
+        window.addEventListener("click", onClick);
+        updateSuggestions();
+      };
+
+      const closeModal = () => dialog.close();
+
+      openBtn.addEventListener("click", openModal);
+      openBtn.disabled = false;
+      closeBtn.addEventListener("click", closeModal);
+
+      dialog.addEventListener("close", () => {
+        document.body.toggleAttribute("data-search-modal-open", false);
+        window.removeEventListener("click", onClick);
+      });
+
+      // Listen for `ctrl + k` and `cmd + k` keyboard shortcuts.
+      window.addEventListener("keydown", (e) => {
+        if ((e.metaKey === true || e.ctrlKey === true) && e.key === "k") {
+          dialog.open ? closeModal() : openModal();
+          e.preventDefault();
+        }
+      });
+
+      let translations = {};
+      try {
+        translations = JSON.parse(this.dataset.translations || "{}");
+      } catch {}
+
+      const shouldStrip = this.dataset.stripTrailingSlash !== undefined;
+      const stripTrailingSlash = (path: string) =>
+        path.replace(/(.)\/(#.*)?$/, "$1$2");
+      const formatURL = shouldStrip
+        ? stripTrailingSlash
+        : (path: string) => path;
+
+      window.addEventListener("DOMContentLoaded", () => {
+        if (import.meta.env.DEV) return;
+        const onIdle = window.requestIdleCallback || ((cb) => setTimeout(cb, 1));
+        onIdle(async () => {
+          // @ts-expect-error: Missing types for @pagefind/default-ui package.
+          const { PagefindUI } = await import("@pagefind/default-ui");
+          new PagefindUI({
+            ...pagefindUserConfig,
+            element: "#starlight__search",
+            baseUrl: import.meta.env.BASE_URL,
+            bundlePath: import.meta.env.BASE_URL.replace(/\/$/, "") + "/pagefind/",
+            showImages: false,
+            translations,
+            showSubResults: true,
+            processResult: (
+              result: { url: string; sub_results: Array<{ url: string }> },
+            ) => {
+              result.url = formatURL(result.url);
+              result.sub_results = result.sub_results.map((sub_result) => {
+                sub_result.url = formatURL(sub_result.url);
+                return sub_result;
+              });
+            },
+          });
+
+          // PagefindUI creates the input synchronously, so wire it up now.
+          const input = this.querySelector<HTMLInputElement>(
+            "#starlight__search input",
+          );
+          input?.addEventListener("input", updateSuggestions);
+          updateSuggestions();
+        });
+      });
+    }
+  }
+  customElements.define("site-search", SiteSearch);
+</script>
+
+<style>
+  @layer starlight.core {
+    site-search {
+      display: contents;
+    }
+    button[data-open-modal] {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: 0;
+      background-color: transparent;
+      color: var(--sl-color-gray-1);
+      cursor: pointer;
+      height: 2.5rem;
+      font-size: var(--sl-text-xl);
+    }
+
+    @media (min-width: 50rem) {
+      button[data-open-modal] {
+        border: 1px solid var(--sl-color-gray-5);
+        border-radius: 0.5rem;
+        padding-inline-start: 0.75rem;
+        padding-inline-end: 0.5rem;
+        background-color: var(--sl-color-black);
+        color: var(--sl-color-gray-2);
+        font-size: var(--sl-text-sm);
+        width: 100%;
+        max-width: 22rem;
+      }
+      button[data-open-modal]:hover {
+        border-color: var(--sl-color-gray-2);
+        color: var(--sl-color-white);
+      }
+
+      button[data-open-modal] > :last-child {
+        margin-inline-start: auto;
+      }
+    }
+
+    button > kbd {
+      border-radius: 0.25rem;
+      font-size: var(--sl-text-2xs);
+      gap: 0.25em;
+      padding-inline: 0.375rem;
+      background-color: var(--sl-color-gray-6);
+    }
+
+    kbd {
+      font-family: var(--__sl-font);
+    }
+
+    .search-icon {
+      width: 1em;
+      height: 1em;
+    }
+
+    dialog {
+      margin: 0;
+      background-color: var(--sl-color-gray-6);
+      border: 1px solid var(--sl-color-gray-5);
+      width: 100%;
+      max-width: 100%;
+      height: 100%;
+      max-height: 100%;
+      box-shadow: var(--sl-shadow-lg);
+    }
+    dialog[open] {
+      display: flex;
+    }
+
+    dialog::backdrop {
+      background-color: var(--sl-color-backdrop-overlay);
+      -webkit-backdrop-filter: blur(0.25rem);
+      backdrop-filter: blur(0.25rem);
+    }
+
+    .dialog-frame {
+      position: relative;
+      overflow: auto;
+      flex-direction: column;
+      flex-grow: 1;
+      gap: 1rem;
+      padding: 1rem;
+    }
+
+    button[data-close-modal] {
+      position: absolute;
+      z-index: 1;
+      align-items: center;
+      align-self: flex-end;
+      height: calc(64px * var(--pagefind-ui-scale));
+      padding: 0.25rem;
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+      color: var(--sl-color-text-accent);
+    }
+
+    #starlight__search {
+      --pagefind-ui-primary: var(--sl-color-text);
+      --pagefind-ui-text: var(--sl-color-gray-2);
+      --pagefind-ui-font: var(--__sl-font);
+      --pagefind-ui-background: var(--sl-color-black);
+      --pagefind-ui-border: var(--sl-color-gray-5);
+      --pagefind-ui-border-width: 1px;
+      --pagefind-ui-tag: var(--sl-color-gray-5);
+      --sl-search-cancel-space: 5rem;
+    }
+
+    :root[data-theme="light"] #starlight__search {
+      --pagefind-ui-tag: var(--sl-color-gray-6);
+    }
+
+    .search-suggestions {
+      margin-top: 1.25rem;
+    }
+    .search-suggestions.is-hidden {
+      display: none;
+    }
+    .suggestions-label {
+      margin: 0 0 0.5rem;
+      color: var(--sl-color-gray-2);
+      font-size: var(--sl-text-sm);
+      font-weight: 600;
+    }
+    .suggestions-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .suggestions-list > li + li {
+      margin-top: 1px;
+    }
+    .suggestion {
+      display: block;
+      padding: 0.9375rem 1.25rem;
+      padding-inline-start: 3.75rem;
+      text-decoration: none;
+      background-color: var(--sl-color-black);
+      outline: 1px solid transparent;
+      outline-offset: -1px;
+    }
+    .suggestion:hover,
+    .suggestion:focus-within {
+      outline-color: var(--sl-color-accent-high);
+      background-color: var(--sl-color-accent-low);
+    }
+    .suggestion-title {
+      display: block;
+      color: var(--sl-color-white);
+      font-weight: 600;
+    }
+    .suggestion-excerpt {
+      display: block;
+      margin-top: 0.25rem;
+      color: var(--sl-color-gray-2);
+      font-size: var(--sl-text-sm);
+      overflow-wrap: anywhere;
+    }
+
+    @media (min-width: 50rem) {
+      #starlight__search {
+        --sl-search-cancel-space: 0px;
+      }
+
+      dialog {
+        margin: 4rem auto auto;
+        border-radius: 0.5rem;
+        width: 90%;
+        max-width: 40rem;
+        height: max-content;
+        min-height: 15rem;
+        max-height: calc(100% - 8rem);
+      }
+
+      .dialog-frame {
+        padding: 1.5rem;
+      }
+    }
+  }
+</style>
+
+<style is:global>
+  @import url("@pagefind/default-ui/css/ui.css") layer(starlight.core);
+
+  @layer starlight.core {
+    [data-search-modal-open] {
+      overflow: hidden;
+    }
+
+    #starlight__search {
+      --sl-search-result-spacing: calc(1.25rem * var(--pagefind-ui-scale));
+      --sl-search-result-pad-inline-start: calc(3.75rem * var(--pagefind-ui-scale));
+      --sl-search-result-pad-inline-end: calc(1.25rem * var(--pagefind-ui-scale));
+      --sl-search-result-pad-block: calc(0.9375rem * var(--pagefind-ui-scale));
+      --sl-search-result-nested-pad-block: calc(0.625rem * var(--pagefind-ui-scale));
+      --sl-search-corners: calc(0.3125rem * var(--pagefind-ui-scale));
+      --sl-search-page-icon-size: calc(1.875rem * var(--pagefind-ui-scale));
+      --sl-search-page-icon-inline-start: calc(
+        (var(--sl-search-result-pad-inline-start) - var(--sl-search-page-icon-size)) / 2
+      );
+      --sl-search-tree-diagram-size: calc(2.5rem * var(--pagefind-ui-scale));
+      --sl-search-tree-diagram-inline-start: calc(
+        (var(--sl-search-result-pad-inline-start) - var(--sl-search-tree-diagram-size)) / 2
+      );
+    }
+
+    #starlight__search .pagefind-ui__form::before {
+      --pagefind-ui-text: var(--sl-color-gray-1);
+      opacity: 1;
+    }
+
+    #starlight__search .pagefind-ui__search-input {
+      color: var(--sl-color-white);
+      font-weight: 400;
+      width: calc(100% - var(--sl-search-cancel-space));
+    }
+
+    #starlight__search input:focus {
+      --pagefind-ui-border: var(--sl-color-accent);
+    }
+
+    #starlight__search .pagefind-ui__search-clear {
+      inset-inline-end: var(--sl-search-cancel-space);
+      width: calc(60px * var(--pagefind-ui-scale));
+      padding: 0;
+      background-color: transparent;
+      overflow: hidden;
+    }
+    #starlight__search .pagefind-ui__search-clear:focus {
+      outline: 1px solid var(--sl-color-accent);
+    }
+    #starlight__search .pagefind-ui__search-clear::before {
+      content: "";
+      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m13.41 12 6.3-6.29a1 1 0 1 0-1.42-1.42L12 10.59l-6.29-6.3a1 1 0 0 0-1.42 1.42l6.3 6.29-6.3 6.29a1 1 0 0 0 .33 1.64 1 1 0 0 0 1.09-.22l6.29-6.3 6.29 6.3a1 1 0 0 0 1.64-.33 1 1 0 0 0-.22-1.09L13.41 12Z'/%3E%3C/svg%3E")
+        center / 50% no-repeat;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m13.41 12 6.3-6.29a1 1 0 1 0-1.42-1.42L12 10.59l-6.29-6.3a1 1 0 0 0-1.42 1.42l6.3 6.29-6.3 6.29a1 1 0 0 0 .33 1.64 1 1 0 0 0 1.09-.22l6.29-6.3 6.29 6.3a1 1 0 0 0 1.64-.33 1 1 0 0 0-.22-1.09L13.41 12Z'/%3E%3C/svg%3E")
+        center / 50% no-repeat;
+      background-color: var(--sl-color-text-accent);
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    #starlight__search .pagefind-ui__results > * + * {
+      margin-top: var(--sl-search-result-spacing);
+    }
+    #starlight__search .pagefind-ui__result {
+      border: 0;
+      padding: 0;
+    }
+
+    #starlight__search .pagefind-ui__result-nested {
+      position: relative;
+      padding: var(--sl-search-result-nested-pad-block) var(--sl-search-result-pad-inline-end);
+      padding-inline-start: var(--sl-search-result-pad-inline-start);
+    }
+
+    #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
+    #starlight__search .pagefind-ui__result-nested {
+      position: relative;
+      background-color: var(--sl-color-black);
+    }
+
+    #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):hover,
+    #starlight__search
+      .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):focus-within,
+    #starlight__search .pagefind-ui__result-nested:hover,
+    #starlight__search .pagefind-ui__result-nested:focus-within {
+      outline: 1px solid var(--sl-color-accent-high);
+    }
+
+    #starlight__search
+      .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):focus-within,
+    #starlight__search .pagefind-ui__result-nested:focus-within {
+      background-color: var(--sl-color-accent-low);
+    }
+
+    #starlight__search .pagefind-ui__result-thumb,
+    #starlight__search .pagefind-ui__result-inner {
+      margin-top: 0;
+    }
+
+    #starlight__search .pagefind-ui__result-inner > :first-child {
+      border-radius: var(--sl-search-corners) var(--sl-search-corners) 0 0;
+    }
+    #starlight__search .pagefind-ui__result-inner > :last-child {
+      border-radius: 0 0 var(--sl-search-corners) var(--sl-search-corners);
+    }
+
+    #starlight__search .pagefind-ui__result-inner > .pagefind-ui__result-title {
+      padding: var(--sl-search-result-pad-block) var(--sl-search-result-pad-inline-end);
+      padding-inline-start: var(--sl-search-result-pad-inline-start);
+    }
+    #starlight__search .pagefind-ui__result-inner > .pagefind-ui__result-title::before {
+      content: "";
+      position: absolute;
+      inset-block: 0;
+      inset-inline-start: var(--sl-search-page-icon-inline-start);
+      width: var(--sl-search-page-icon-size);
+      background: var(--sl-color-gray-3);
+      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath d='M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3V8l-6-6a1 1 0 0 0-1 0H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V9Zm-6-4 3 3h-2a1 1 0 0 1-1-1V5Zm4 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z'/%3E%3C/svg%3E")
+        center no-repeat;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath d='M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3V8l-6-6a1 1 0 0 0-1 0H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V9Zm-6-4 3 3h-2a1 1 0 0 1-1-1V5Zm4 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z'/%3E%3C/svg%3E")
+        center no-repeat;
+    }
+
+    #starlight__search .pagefind-ui__result-inner {
+      align-items: stretch;
+      gap: 1px;
+    }
+
+    #starlight__search .pagefind-ui__result-link {
+      position: unset;
+      --pagefind-ui-text: var(--sl-color-white);
+      font-weight: 600;
+    }
+
+    #starlight__search .pagefind-ui__result-link:hover {
+      text-decoration: none;
+    }
+
+    #starlight__search .pagefind-ui__result-nested .pagefind-ui__result-link::before {
+      content: unset;
+    }
+
+    #starlight__search .pagefind-ui__result-nested::before {
+      content: "";
+      position: absolute;
+      inset-block: 0;
+      inset-inline-start: var(--sl-search-tree-diagram-inline-start);
+      width: var(--sl-search-tree-diagram-size);
+      background: var(--sl-color-gray-4);
+      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000m6-988H8'/%3E%3C/svg%3E")
+        0% 0% / 100% no-repeat;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000m6-988H8'/%3E%3C/svg%3E")
+        0% 0% / 100% no-repeat;
+    }
+    #starlight__search .pagefind-ui__result-nested:last-of-type::before {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
+    }
+
+    /* Flip page and tree icons around the vertical axis when in an RTL layout. */
+    [dir="rtl"] .pagefind-ui__result-title::before,
+    [dir="rtl"] .pagefind-ui__result-nested::before {
+      transform: matrix(-1, 0, 0, 1, 0, 0);
+    }
+
+    #starlight__search .pagefind-ui__result-link::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
+
+    #starlight__search .pagefind-ui__result-excerpt {
+      font-size: calc(1rem * var(--pagefind-ui-scale));
+      overflow-wrap: anywhere;
+    }
+
+    #starlight__search mark {
+      color: var(--sl-color-gray-2);
+      background-color: transparent;
+      font-weight: 600;
+    }
+
+    #starlight__search .pagefind-ui__filter-value::before {
+      border-color: var(--sl-color-text-invert);
+    }
+
+    #starlight__search .pagefind-ui__result-tags {
+      background-color: var(--sl-color-black);
+      margin-top: 0;
+      padding: var(--sl-search-result-nested-pad-block) var(--sl-search-result-pad-inline-end);
+    }
+  }
+</style>

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -1,21 +1,7 @@
 ---
 import { getCollection } from "astro:content";
-import project from "virtual:starlight/project-context";
+import Default from "@astrojs/starlight/components/Search.astro";
 import { withBasePath } from "../base-path";
-
-const pagefindTranslations = {
-  placeholder: Astro.locals.t("search.label"),
-  ...Object.fromEntries(
-    Object.entries(Astro.locals.t.all())
-      .filter(([key]) => key.startsWith("pagefind."))
-      .map(([key, value]) => [key.replace("pagefind.", ""), value]),
-  ),
-};
-
-const dataAttributes: DOMStringMap = {
-  "data-translations": JSON.stringify(pagefindTranslations),
-};
-if (project.trailingSlash === "never") dataAttributes["data-strip-trailing-slash"] = "";
 
 // Pages suggested in the search modal when the query is empty. Titles and
 // descriptions come from each page's frontmatter, so this list only needs the
@@ -28,340 +14,84 @@ const suggestedSlugs = [
 ];
 
 const docs = await getCollection("docs");
-const suggestions = suggestedSlugs
-  .map((slug) => {
-    const entry = docs.find((d) => d.id === slug);
-    if (!entry) return undefined;
-    return {
-      href: withBasePath(`/${slug}/`),
-      title: entry.data.title,
-      description: entry.data.description ?? "",
-    };
-  })
-  .filter(
-    (s): s is { href: string; title: string; description: string } => Boolean(s),
-  );
+const suggestions = suggestedSlugs.map((slug) => {
+  const entry = docs.find((doc) => doc.id === slug);
+  if (!entry) {
+    throw new Error(`Suggested page "${slug}" is not in the docs collection.`);
+  }
+  return {
+    href: withBasePath(`/${slug}/`),
+    title: entry.data.title,
+    description: entry.data.description ?? "",
+  };
+});
 ---
 
-<site-search class={Astro.props.class} {...dataAttributes}>
-  <button
-    data-open-modal
-    disabled
-    aria-label={Astro.locals.t("search.label")}
-    aria-keyshortcuts="Control+K"
-  >
-    <svg
-      class="search-icon"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden="true"
-      ><path
-        d="M21.71 20.29 18 16.61A9 9 0 1 0 16.61 18l3.68 3.68a.999.999 0 0 0 1.42 0 1 1 0 0 0 0-1.39ZM11 18a7 7 0 1 1 0-14 7 7 0 0 1 0 14Z"
-      ></path>
-    </svg>
-    <span class="sl-hidden md:sl-block" aria-hidden="true"
-      >{Astro.locals.t("search.label")}</span
-    >
-    <kbd class="sl-hidden md:sl-flex" style="display: none;">
-      <kbd>{Astro.locals.t("search.ctrlKey")}</kbd><kbd>K</kbd>
-    </kbd>
-  </button>
+<!--
+  Reuse Starlight's default Search (button, modal, Pagefind wiring) and inject a
+  suggestions panel into the modal's empty state. The panel is rendered hidden,
+  moved into the dialog's `.search-container` by the script below, and hidden
+  again by CSS as soon as the query is non-empty.
+-->
+<Default />
 
-  <dialog style="padding:0" aria-label={Astro.locals.t("search.label")}>
-    <div class="dialog-frame sl-flex">
-      <button data-close-modal class="sl-flex md:sl-hidden">
-        {Astro.locals.t("search.cancelLabel")}
-      </button>
-      {
-        import.meta.env.DEV ? (
-          <div style="margin: auto; text-align: center; white-space: pre-line;" dir="ltr">
-            <p>{Astro.locals.t("search.devWarning")}</p>
-          </div>
-        ) : (
-          <div class="search-container">
-            <div id="starlight__search" />
-            <div
-              id="starlight__search-suggestions"
-              class="search-suggestions"
-              data-suggestions
-            >
-              <p class="suggestions-label">Suggested pages</p>
-              <ul class="suggestions-list">
-                {suggestions.map((s) => (
-                  <li>
-                    <a class="suggestion" href={s.href}>
-                      <span class="suggestion-title">{s.title}</span>
-                      <span class="suggestion-excerpt">{s.description}</span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        )
-      }
-    </div>
-  </dialog>
-</site-search>
-
-{
-  /**
-   * This is intentionally inlined to avoid briefly showing an invalid shortcut.
-   * Purposely using the deprecated `navigator.platform` property to detect Apple devices, as the
-   * user agent is spoofed by some browsers when opening the devtools.
-   */
-}
-<script is:inline>
-  (() => {
-    const openBtn = document.querySelector("button[data-open-modal]");
-    const shortcut = openBtn?.querySelector("kbd");
-    if (!openBtn || !(shortcut instanceof HTMLElement)) return;
-    const platformKey = shortcut.querySelector("kbd");
-    if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
-      platformKey.textContent = "⌘";
-      openBtn.setAttribute("aria-keyshortcuts", "Meta+K");
+<div class="search-suggestions" data-suggestions hidden>
+  <p class="suggestions-label">Suggested pages</p>
+  <ul class="suggestions-list">
+    {
+      suggestions.map((s) => (
+        <li>
+          <a class="suggestion" href={s.href}>
+            <span class="suggestion-title">{s.title}</span>
+            <span class="suggestion-excerpt">{s.description}</span>
+          </a>
+        </li>
+      ))
     }
-    shortcut.style.display = "";
-  })();
-</script>
+  </ul>
+</div>
 
 <script>
-  import { pagefindUserConfig } from "virtual:starlight/pagefind-config";
+  (() => {
+    const panel = document.querySelector<HTMLElement>("[data-suggestions]");
+    // `#starlight__search` is the stable hook Starlight's own Search component
+    // renders Pagefind into; its parent is the modal's content container.
+    const container =
+      document.querySelector<HTMLElement>("#starlight__search")?.parentElement;
+    if (!panel || !container) return;
 
-  class SiteSearch extends HTMLElement {
-    constructor() {
-      super();
-      const openBtn = this.querySelector<HTMLButtonElement>(
-        "button[data-open-modal]",
-      )!;
-      const closeBtn = this.querySelector<HTMLButtonElement>(
-        "button[data-close-modal]",
-      )!;
-      const dialog = this.querySelector("dialog")!;
-      const dialogFrame = this.querySelector(".dialog-frame")!;
-
-      /** Close the modal if a user clicks on a link or outside of the modal. */
-      const onClick = (event: MouseEvent) => {
-        const isLink = "href" in (event.target || {});
-        if (
-          isLink ||
-          (document.body.contains(event.target as Node) &&
-            !dialogFrame.contains(event.target as Node))
-        ) {
-          closeModal();
-        }
-      };
-
-      const suggestionsEl = this.querySelector<HTMLElement>(
-        "#starlight__search-suggestions",
-      );
-
-      // Show the suggested pages only while the query is empty. Once the user
-      // types, hand the panel to Pagefind and hide the suggestions.
-      const updateSuggestions = () => {
-        const input = this.querySelector<HTMLInputElement>(
-          "#starlight__search input",
-        );
-        const empty = !input || input.value.trim() === "";
-        suggestionsEl?.classList.toggle("is-hidden", !empty);
-      };
-
-      const openModal = (event?: MouseEvent) => {
-        dialog.showModal();
-        document.body.toggleAttribute("data-search-modal-open", true);
-        this.querySelector("input")?.focus();
-        event?.stopPropagation();
-        window.addEventListener("click", onClick);
-        updateSuggestions();
-      };
-
-      const closeModal = () => dialog.close();
-
-      openBtn.addEventListener("click", openModal);
-      openBtn.disabled = false;
-      closeBtn.addEventListener("click", closeModal);
-
-      dialog.addEventListener("close", () => {
-        document.body.toggleAttribute("data-search-modal-open", false);
-        window.removeEventListener("click", onClick);
-      });
-
-      // Listen for `ctrl + k` and `cmd + k` keyboard shortcuts.
-      window.addEventListener("keydown", (e) => {
-        if ((e.metaKey === true || e.ctrlKey === true) && e.key === "k") {
-          dialog.open ? closeModal() : openModal();
-          e.preventDefault();
-        }
-      });
-
-      let translations = {};
-      try {
-        translations = JSON.parse(this.dataset.translations || "{}");
-      } catch {}
-
-      const shouldStrip = this.dataset.stripTrailingSlash !== undefined;
-      const stripTrailingSlash = (path: string) =>
-        path.replace(/(.)\/(#.*)?$/, "$1$2");
-      const formatURL = shouldStrip
-        ? stripTrailingSlash
-        : (path: string) => path;
-
-      window.addEventListener("DOMContentLoaded", () => {
-        if (import.meta.env.DEV) return;
-        const onIdle = window.requestIdleCallback || ((cb) => setTimeout(cb, 1));
-        onIdle(async () => {
-          // @ts-expect-error: Missing types for @pagefind/default-ui package.
-          const { PagefindUI } = await import("@pagefind/default-ui");
-          new PagefindUI({
-            ...pagefindUserConfig,
-            element: "#starlight__search",
-            baseUrl: import.meta.env.BASE_URL,
-            bundlePath: import.meta.env.BASE_URL.replace(/\/$/, "") + "/pagefind/",
-            showImages: false,
-            translations,
-            showSubResults: true,
-            processResult: (
-              result: { url: string; sub_results: Array<{ url: string }> },
-            ) => {
-              result.url = formatURL(result.url);
-              result.sub_results = result.sub_results.map((sub_result) => {
-                sub_result.url = formatURL(sub_result.url);
-                return sub_result;
-              });
-            },
-          });
-
-          // PagefindUI creates the input synchronously, so wire it up now.
-          const input = this.querySelector<HTMLInputElement>(
-            "#starlight__search input",
-          );
-          input?.addEventListener("input", updateSuggestions);
-          updateSuggestions();
-        });
-      });
-    }
-  }
-  customElements.define("site-search", SiteSearch);
+    // Move the panel into the modal, below the Pagefind input. Whether it shows
+    // is left to CSS, which reads Pagefind's own state.
+    panel.hidden = false;
+    container.append(panel);
+  })();
 </script>
 
 <style>
   @layer starlight.core {
-    site-search {
-      display: contents;
-    }
-    button[data-open-modal] {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      border: 0;
-      background-color: transparent;
-      color: var(--sl-color-gray-1);
-      cursor: pointer;
-      height: 2.5rem;
-      font-size: var(--sl-text-xl);
-    }
-
-    @media (min-width: 50rem) {
-      button[data-open-modal] {
-        border: 1px solid var(--sl-color-gray-5);
-        border-radius: 0.5rem;
-        padding-inline-start: 0.75rem;
-        padding-inline-end: 0.5rem;
-        background-color: var(--sl-color-black);
-        color: var(--sl-color-gray-2);
-        font-size: var(--sl-text-sm);
-        width: 100%;
-        max-width: 22rem;
-      }
-      button[data-open-modal]:hover {
-        border-color: var(--sl-color-gray-2);
-        color: var(--sl-color-white);
-      }
-
-      button[data-open-modal] > :last-child {
-        margin-inline-start: auto;
-      }
-    }
-
-    button > kbd {
-      border-radius: 0.25rem;
-      font-size: var(--sl-text-2xs);
-      gap: 0.25em;
-      padding-inline: 0.375rem;
-      background-color: var(--sl-color-gray-6);
-    }
-
-    kbd {
-      font-family: var(--__sl-font);
-    }
-
-    .search-icon {
-      width: 1em;
-      height: 1em;
-    }
-
-    dialog {
-      margin: 0;
-      background-color: var(--sl-color-gray-6);
-      border: 1px solid var(--sl-color-gray-5);
-      width: 100%;
-      max-width: 100%;
-      height: 100%;
-      max-height: 100%;
-      box-shadow: var(--sl-shadow-lg);
-    }
-    dialog[open] {
-      display: flex;
-    }
-
-    dialog::backdrop {
-      background-color: var(--sl-color-backdrop-overlay);
-      -webkit-backdrop-filter: blur(0.25rem);
-      backdrop-filter: blur(0.25rem);
-    }
-
-    .dialog-frame {
-      position: relative;
-      overflow: auto;
-      flex-direction: column;
-      flex-grow: 1;
-      gap: 1rem;
-      padding: 1rem;
-    }
-
-    button[data-close-modal] {
-      position: absolute;
-      z-index: 1;
-      align-items: center;
-      align-self: flex-end;
-      height: calc(64px * var(--pagefind-ui-scale));
-      padding: 0.25rem;
-      border: 0;
-      background: transparent;
-      cursor: pointer;
-      color: var(--sl-color-text-accent);
-    }
-
-    #starlight__search {
-      --pagefind-ui-primary: var(--sl-color-text);
-      --pagefind-ui-text: var(--sl-color-gray-2);
-      --pagefind-ui-font: var(--__sl-font);
-      --pagefind-ui-background: var(--sl-color-black);
-      --pagefind-ui-border: var(--sl-color-gray-5);
-      --pagefind-ui-border-width: 1px;
-      --pagefind-ui-tag: var(--sl-color-gray-5);
-      --sl-search-cancel-space: 5rem;
-    }
-
-    :root[data-theme="light"] #starlight__search {
-      --pagefind-ui-tag: var(--sl-color-gray-6);
-    }
-
-    .search-suggestions {
-      margin-top: 1.25rem;
-    }
-    .search-suggestions.is-hidden {
+    /* Pagefind suppresses its clear button while the query is empty, so its
+       absence marks a query worth handing the panel back to Pagefind for.
+       Reading that class beats reading the input: Pagefind's clear button
+       rewrites the value without firing an `input` event. */
+    :global(
+      #starlight__search:has(
+          .pagefind-ui__search-clear:not(.pagefind-ui__suppressed)
+        )
+    )
+      ~ .search-suggestions {
       display: none;
+    }
+
+    /* Match the metrics Starlight derives for Pagefind's result rows, so the
+       panel and the results it gives way to sit on the same grid. Starlight
+       declares those on `#starlight__search`, which the panel is a sibling of,
+       so recompute them from the scale Pagefind sets on `:root`. */
+    .search-suggestions {
+      --suggestion-pad-block: calc(0.9375rem * var(--pagefind-ui-scale));
+      --suggestion-pad-inline-end: calc(1.25rem * var(--pagefind-ui-scale));
+      --suggestion-pad-inline-start: calc(3.75rem * var(--pagefind-ui-scale));
+      --suggestion-corners: calc(0.3125rem * var(--pagefind-ui-scale));
+      margin-top: 1.25rem;
     }
     .suggestions-label {
       margin: 0 0 0.5rem;
@@ -379,12 +109,18 @@ const suggestions = suggestedSlugs
     }
     .suggestion {
       display: block;
-      padding: 0.9375rem 1.25rem;
-      padding-inline-start: 3.75rem;
+      padding: var(--suggestion-pad-block) var(--suggestion-pad-inline-end);
+      padding-inline-start: var(--suggestion-pad-inline-start);
       text-decoration: none;
       background-color: var(--sl-color-black);
       outline: 1px solid transparent;
       outline-offset: -1px;
+    }
+    .suggestions-list > li:first-child .suggestion {
+      border-radius: var(--suggestion-corners) var(--suggestion-corners) 0 0;
+    }
+    .suggestions-list > li:last-child .suggestion {
+      border-radius: 0 0 var(--suggestion-corners) var(--suggestion-corners);
     }
     .suggestion:hover,
     .suggestion:focus-within {
@@ -394,230 +130,15 @@ const suggestions = suggestedSlugs
     .suggestion-title {
       display: block;
       color: var(--sl-color-white);
+      font-size: calc(21px * var(--pagefind-ui-scale));
       font-weight: 600;
     }
     .suggestion-excerpt {
       display: block;
       margin-top: 0.25rem;
       color: var(--sl-color-gray-2);
-      font-size: var(--sl-text-sm);
-      overflow-wrap: anywhere;
-    }
-
-    @media (min-width: 50rem) {
-      #starlight__search {
-        --sl-search-cancel-space: 0px;
-      }
-
-      dialog {
-        margin: 4rem auto auto;
-        border-radius: 0.5rem;
-        width: 90%;
-        max-width: 40rem;
-        height: max-content;
-        min-height: 15rem;
-        max-height: calc(100% - 8rem);
-      }
-
-      .dialog-frame {
-        padding: 1.5rem;
-      }
-    }
-  }
-</style>
-
-<style is:global>
-  @import url("@pagefind/default-ui/css/ui.css") layer(starlight.core);
-
-  @layer starlight.core {
-    [data-search-modal-open] {
-      overflow: hidden;
-    }
-
-    #starlight__search {
-      --sl-search-result-spacing: calc(1.25rem * var(--pagefind-ui-scale));
-      --sl-search-result-pad-inline-start: calc(3.75rem * var(--pagefind-ui-scale));
-      --sl-search-result-pad-inline-end: calc(1.25rem * var(--pagefind-ui-scale));
-      --sl-search-result-pad-block: calc(0.9375rem * var(--pagefind-ui-scale));
-      --sl-search-result-nested-pad-block: calc(0.625rem * var(--pagefind-ui-scale));
-      --sl-search-corners: calc(0.3125rem * var(--pagefind-ui-scale));
-      --sl-search-page-icon-size: calc(1.875rem * var(--pagefind-ui-scale));
-      --sl-search-page-icon-inline-start: calc(
-        (var(--sl-search-result-pad-inline-start) - var(--sl-search-page-icon-size)) / 2
-      );
-      --sl-search-tree-diagram-size: calc(2.5rem * var(--pagefind-ui-scale));
-      --sl-search-tree-diagram-inline-start: calc(
-        (var(--sl-search-result-pad-inline-start) - var(--sl-search-tree-diagram-size)) / 2
-      );
-    }
-
-    #starlight__search .pagefind-ui__form::before {
-      --pagefind-ui-text: var(--sl-color-gray-1);
-      opacity: 1;
-    }
-
-    #starlight__search .pagefind-ui__search-input {
-      color: var(--sl-color-white);
-      font-weight: 400;
-      width: calc(100% - var(--sl-search-cancel-space));
-    }
-
-    #starlight__search input:focus {
-      --pagefind-ui-border: var(--sl-color-accent);
-    }
-
-    #starlight__search .pagefind-ui__search-clear {
-      inset-inline-end: var(--sl-search-cancel-space);
-      width: calc(60px * var(--pagefind-ui-scale));
-      padding: 0;
-      background-color: transparent;
-      overflow: hidden;
-    }
-    #starlight__search .pagefind-ui__search-clear:focus {
-      outline: 1px solid var(--sl-color-accent);
-    }
-    #starlight__search .pagefind-ui__search-clear::before {
-      content: "";
-      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m13.41 12 6.3-6.29a1 1 0 1 0-1.42-1.42L12 10.59l-6.29-6.3a1 1 0 0 0-1.42 1.42l6.3 6.29-6.3 6.29a1 1 0 0 0 .33 1.64 1 1 0 0 0 1.09-.22l6.29-6.3 6.29 6.3a1 1 0 0 0 1.64-.33 1 1 0 0 0-.22-1.09L13.41 12Z'/%3E%3C/svg%3E")
-        center / 50% no-repeat;
-      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m13.41 12 6.3-6.29a1 1 0 1 0-1.42-1.42L12 10.59l-6.29-6.3a1 1 0 0 0-1.42 1.42l6.3 6.29-6.3 6.29a1 1 0 0 0 .33 1.64 1 1 0 0 0 1.09-.22l6.29-6.3 6.29 6.3a1 1 0 0 0 1.64-.33 1 1 0 0 0-.22-1.09L13.41 12Z'/%3E%3C/svg%3E")
-        center / 50% no-repeat;
-      background-color: var(--sl-color-text-accent);
-      display: block;
-      width: 100%;
-      height: 100%;
-    }
-
-    #starlight__search .pagefind-ui__results > * + * {
-      margin-top: var(--sl-search-result-spacing);
-    }
-    #starlight__search .pagefind-ui__result {
-      border: 0;
-      padding: 0;
-    }
-
-    #starlight__search .pagefind-ui__result-nested {
-      position: relative;
-      padding: var(--sl-search-result-nested-pad-block) var(--sl-search-result-pad-inline-end);
-      padding-inline-start: var(--sl-search-result-pad-inline-start);
-    }
-
-    #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
-    #starlight__search .pagefind-ui__result-nested {
-      position: relative;
-      background-color: var(--sl-color-black);
-    }
-
-    #starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):hover,
-    #starlight__search
-      .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):focus-within,
-    #starlight__search .pagefind-ui__result-nested:hover,
-    #starlight__search .pagefind-ui__result-nested:focus-within {
-      outline: 1px solid var(--sl-color-accent-high);
-    }
-
-    #starlight__search
-      .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):focus-within,
-    #starlight__search .pagefind-ui__result-nested:focus-within {
-      background-color: var(--sl-color-accent-low);
-    }
-
-    #starlight__search .pagefind-ui__result-thumb,
-    #starlight__search .pagefind-ui__result-inner {
-      margin-top: 0;
-    }
-
-    #starlight__search .pagefind-ui__result-inner > :first-child {
-      border-radius: var(--sl-search-corners) var(--sl-search-corners) 0 0;
-    }
-    #starlight__search .pagefind-ui__result-inner > :last-child {
-      border-radius: 0 0 var(--sl-search-corners) var(--sl-search-corners);
-    }
-
-    #starlight__search .pagefind-ui__result-inner > .pagefind-ui__result-title {
-      padding: var(--sl-search-result-pad-block) var(--sl-search-result-pad-inline-end);
-      padding-inline-start: var(--sl-search-result-pad-inline-start);
-    }
-    #starlight__search .pagefind-ui__result-inner > .pagefind-ui__result-title::before {
-      content: "";
-      position: absolute;
-      inset-block: 0;
-      inset-inline-start: var(--sl-search-page-icon-inline-start);
-      width: var(--sl-search-page-icon-size);
-      background: var(--sl-color-gray-3);
-      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath d='M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3V8l-6-6a1 1 0 0 0-1 0H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V9Zm-6-4 3 3h-2a1 1 0 0 1-1-1V5Zm4 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z'/%3E%3C/svg%3E")
-        center no-repeat;
-      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 24 24'%3E%3Cpath d='M9 10h1a1 1 0 1 0 0-2H9a1 1 0 0 0 0 2Zm0 2a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2H9Zm11-3V8l-6-6a1 1 0 0 0-1 0H7a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V9Zm-6-4 3 3h-2a1 1 0 0 1-1-1V5Zm4 14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5v3a3 3 0 0 0 3 3h3v9Zm-3-3H9a1 1 0 0 0 0 2h6a1 1 0 0 0 0-2Z'/%3E%3C/svg%3E")
-        center no-repeat;
-    }
-
-    #starlight__search .pagefind-ui__result-inner {
-      align-items: stretch;
-      gap: 1px;
-    }
-
-    #starlight__search .pagefind-ui__result-link {
-      position: unset;
-      --pagefind-ui-text: var(--sl-color-white);
-      font-weight: 600;
-    }
-
-    #starlight__search .pagefind-ui__result-link:hover {
-      text-decoration: none;
-    }
-
-    #starlight__search .pagefind-ui__result-nested .pagefind-ui__result-link::before {
-      content: unset;
-    }
-
-    #starlight__search .pagefind-ui__result-nested::before {
-      content: "";
-      position: absolute;
-      inset-block: 0;
-      inset-inline-start: var(--sl-search-tree-diagram-inline-start);
-      width: var(--sl-search-tree-diagram-size);
-      background: var(--sl-color-gray-4);
-      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000m6-988H8'/%3E%3C/svg%3E")
-        0% 0% / 100% no-repeat;
-      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000m6-988H8'/%3E%3C/svg%3E")
-        0% 0% / 100% no-repeat;
-    }
-    #starlight__search .pagefind-ui__result-nested:last-of-type::before {
-      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
-      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
-    }
-
-    /* Flip page and tree icons around the vertical axis when in an RTL layout. */
-    [dir="rtl"] .pagefind-ui__result-title::before,
-    [dir="rtl"] .pagefind-ui__result-nested::before {
-      transform: matrix(-1, 0, 0, 1, 0, 0);
-    }
-
-    #starlight__search .pagefind-ui__result-link::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-    }
-
-    #starlight__search .pagefind-ui__result-excerpt {
       font-size: calc(1rem * var(--pagefind-ui-scale));
       overflow-wrap: anywhere;
-    }
-
-    #starlight__search mark {
-      color: var(--sl-color-gray-2);
-      background-color: transparent;
-      font-weight: 600;
-    }
-
-    #starlight__search .pagefind-ui__filter-value::before {
-      border-color: var(--sl-color-text-invert);
-    }
-
-    #starlight__search .pagefind-ui__result-tags {
-      background-color: var(--sl-color-black);
-      margin-top: 0;
-      padding: var(--sl-search-result-nested-pad-block) var(--sl-search-result-pad-inline-end);
     }
   }
 </style>

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -1,6 +1,6 @@
 ---
 title: Passkey accounts
-description: Accounts derived from a passkey's PRF output, with no stored secret.
+description: Accounts derived from a passkey with no stored secret.
 ---
 
 In mera's model, a passkey account is a blockchain account whose keys derive from a passkey's [PRF output](/concepts/passkeys-and-prf/), the 32 secret bytes a passkey returns deterministically. Mera evaluates the PRF with a fixed salt, so each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts on every device the passkey syncs to, with no secret stored anywhere. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Signing sessions
-description: How a session owns its private key, why signing never prompts, and what ending a session destroys.
+description: A private key held in memory for signing until the session ends.
 ---
 
 import SessionLifecycle from "../../../assets/diagrams/session-lifecycle.svg";

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Create passkey accounts
-description: Create numbered EVM and Solana accounts from one passkey ceremony, with credential pinning.
+description: Create EVM and Solana accounts from a passkey.
 ---
 
 import FirstVsReturning from "../../../assets/diagrams/first-vs-returning.svg";

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -1,6 +1,6 @@
 ---
 title: Send a transaction with viem
-description: Sign in with a passkey, derive the first EVM account, and send a transaction through viem.
+description: Send an EVM transaction from a passkey account with viem.
 ---
 
 Mera exports an adapter function [toViemAccount](/reference/to-viem-account/) that adapts a [signing session](/concepts/signing-sessions/) into the account shape [viem](https://viem.sh) accepts, so viem signs and broadcasts while the key is owned by the session.


### PR DESCRIPTION
## Problem

The docs search modal opens empty. A reader who opens search has nothing to start from.

## Change

Override Starlight's `Search` component so the modal shows a short list of suggested pages when the query is empty. The list disappears the moment the reader types, handing the panel back to Pagefind.

Suggested pages are sourced by slug from the docs content collection at build time, so titles and descriptions come straight from each page's frontmatter. Adding a suggestion is a one-line slug entry, a stale title cannot drift from its page, and an unknown slug fails the build.

Neither Starlight nor Pagefind exposes a hook for the modal's empty state, so the component renders the panel outside the dialog and moves it in. CSS then decides whether it shows, keyed on the class Pagefind puts on its clear button while the query is empty. Reading the input value instead needs a MutationObserver, because Pagefind's clear button rewrites the value without firing an `input` event.

## Frontmatter

While wiring this up I also rewrote the `description` on the four suggested pages. The old descriptions leaned on jargon (`PRF output`, `ceremony`, `credential pinning`) and a `X, with Y` qualifier pattern no other description in the docs uses. The new ones match the plain, single-statement shape of the rest of the site.

## Verification

`npm run check` and `npm run build` pass. The build output carries the four links with titles, descriptions, and base-aware hrefs (verified at root and under `DOCS_BASE=/preview`).

In a served build, the panel shows on open, hides on the first keystroke, and returns after Pagefind's clear button, with the modal staying open throughout. Its row padding, corners, and type sizes measure identical to Pagefind's result rows, which the panel gives way to.
