### PR TITLE
Warn against importing a funded phrase in vault mode

### DIFF
--- a/demo/src/ConnectPanel.tsx
+++ b/demo/src/ConnectPanel.tsx
@@ -47,8 +47,9 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
     return (
       <div className="connect-cta">
         <p className="hint">
-          The demo encrypts a generated or imported recovery phrase in a vault
-          that opens with the passkey.
+          The demo encrypts a recovery phrase in a vault that opens with the
+          passkey. Generate a fresh one rather than importing a phrase that
+          holds funds.
         </p>
         <label className="field">
           <span className="field-head">


### PR DESCRIPTION
## Why

Vault mode explained how the vault works but never said which phrase to bring,
and the input placeholder, "Generate a recovery phrase, or paste one from a
wallet app", reads as an invitation to paste one from a real wallet app. Nothing
is gained by bringing a funded phrase to a demo that trades play money on a
private network, and the panel did not say so.

The line had to be formally present without turning the demo's most interesting
path into a compliance screen. It reuses the existing `.hint` paragraph: no
modal, no banner, no icon, no new component, no new CSS, and no new element in
the card.

![vault mode connect panel showing the disclaimer](https://github.com/user-attachments/assets/57ad6024-560c-4c34-a95d-de2fa185a82e)

## Notes for reviewers

- Placement was picked by rendering both candidates and comparing them: a
  standalone line under the input, and the sentence appended to the hint above
  the field. The appended version won on compactness, since it adds no element
  and grows the card by one wrapped line.
- "Generated or imported" leaves the first sentence because the second sentence
  now names both paths. Keeping both repeated the paragraph.
- The placeholder keeps "or paste one from a wallet app" on purpose.
  Portability to wallet apps is the reason vault mode exists, and the hint
  directly above now answers it.
- Manual validation beyond CI, in headless Chrome driving a CDP virtual
  authenticator: vault create runs the passkey ceremony through to a signed-in
  account, and reveal round-trips the identical twelve words. Passkey mode
  renders no disclaimer. The validation error still sits directly under the
  input, below the hint.
- The embedded demo reports its own height, so that was checked too: vault mode
  reports 626px against 626px of measured content, up from 480px in passkey
  mode. The extra wrapped line is measured content, so the hardcoded footer
  reserves in `demo/src/styles.css` are untouched.
