### PR TITLE
docs: state the key lifecycle without the wallet extension analogy

### DIFF
--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -3,7 +3,7 @@ title: Passkey accounts
 description: Accounts derived from a passkey with no stored secret.
 ---
 
-In mera's model, a passkey account is a blockchain account whose keys derive from a passkey's [PRF output](/concepts/passkeys-and-prf/), the 32 secret bytes a passkey returns deterministically. Mera evaluates the PRF with a fixed salt, so each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts on every device the passkey syncs to, with no secret stored anywhere. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
+In mera's model, a passkey account is a blockchain account whose keys derive from a passkey's [PRF output](/concepts/passkeys-and-prf/), the 32 secret bytes a passkey returns deterministically. mera evaluates the PRF with a fixed salt, so each [ceremony](/concepts/passkeys-and-prf/#ceremonies-and-prompts) recomputes the same accounts on every device the passkey syncs to, with no secret stored anywhere. The app passes the output to a [derivation scheme](/concepts/entropy-keys-and-accounts/) of its choosing. [Create passkey accounts](/recipes/create-passkey-accounts/) shows one built on common HD (hierarchical deterministic) standards.
 
 ## Losing the passkey
 

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -7,10 +7,10 @@ import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
 mera produces software keys and not hardware-backed ones. The [PRF output](/concepts/passkeys-and-prf/) and every key derived from it are bytes in the memory of the code that calls mera. Only the passkey private key stays inside the authenticator.
 
-The library host decides who can reach those bytes. In a web page, every script the page loads shares the same memory. The diagram below shows a web page under the rpId.
+The library host decides who can reach those bytes. In a web page, every script the page loads runs in the same JavaScript environment as mera. The diagram below shows a web page under the rpId.
 
 - Whoever takes over a hostname under the rpId (the relying party domain) can serve a page there and run a ceremony, which returns the PRF output that the account keys derive from.
-- Any code that runs in the same page as mera shares one JavaScript environment with it. An injected script, a malicious dependency, and a browser extension with page access all run there.
+- A script in that environment can replace the browser APIs mera calls and keep the PRF output a ceremony returns. It also signs with any live session it reaches. Injected scripts and malicious dependencies run there. An extension content script stays isolated until the extension injects code into the page.
 - Losing access to the passkey without a backup or export also loses access to the accounts derived from it.
 - A passkey works only under the rpId it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -5,9 +5,12 @@ description: What mera protects, what it cannot, and the risks left to the app.
 
 import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
-Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, mera's security model matches that of a wallet browser extension like MetaMask or Phantom: whatever the wallet signs with, a seed phrase, a private key, or an access token for a remote signer, lives in script memory.
+mera produces software keys and not hardware-backed ones. The [PRF output](/concepts/passkeys-and-prf/) and every key derived from it are bytes in the memory of the code that calls mera. Only the passkey private key stays inside the authenticator.
 
-- Whoever takes over a hostname under the rpId (the relying party domain) can serve a page there and run a ceremony, which returns the [PRF output](/concepts/passkeys-and-prf/) that the account keys derive from. So can any script in the app's own page, injected or from a dependency or extension.
+The library host decides who can reach those bytes. In a web page, every script the page loads shares the same memory. The diagram below shows a web page under the rpId.
+
+- Whoever takes over a hostname under the rpId (the relying party domain) can serve a page there and run a ceremony, which returns the PRF output that the account keys derive from.
+- Any code that runs in the same page as mera shares one JavaScript environment with it. An injected script, a malicious dependency, and a browser extension with page access all run there.
 - Losing access to the passkey without a backup or export also loses access to the accounts derived from it.
 - A passkey works only under the rpId it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -3,7 +3,7 @@ title: Send a transaction with viem
 description: Send an EVM transaction from a passkey account with viem.
 ---
 
-Mera exports an adapter function [toViemAccount](/reference/to-viem-account/) that adapts a [signing session](/concepts/signing-sessions/) into the account shape [viem](https://viem.sh) accepts, so viem signs and broadcasts while the key is owned by the session.
+mera exports an adapter function [toViemAccount](/reference/to-viem-account/) that adapts a [signing session](/concepts/signing-sessions/) into the account shape [viem](https://viem.sh) accepts, so viem signs and broadcasts while the key is owned by the session.
 
 ## Sign in
 


### PR DESCRIPTION
## Why

The security model page told a reader that mera's model "matches that of a wallet browser extension like MetaMask or Phantom." That sentence was written to describe the key lifecycle, a signing secret held in memory while in use, but it reads as a claim about the boundary, and there it is wrong: an extension keeps its seed in a context the pages it talks to cannot read, while keys held in an app page are reachable by every script that page loads. A security reviewer could quote it against us.

The page now states the facts the analogy stood in for. The keys are software keys in the memory of the code that calls mera, and only the passkey private key stays in the authenticator. The boundary belongs to the host rather than to the library, which is both accurate and platform-neutral: the same library can run somewhere narrower than a web page, and the page no longer implies otherwise.

One bullet is added, on what sharing a page costs. A script in the page's JavaScript environment can replace the browser APIs mera calls, so a ceremony runs for real and returns its PRF output through a function the script controls. User verification does not narrow this: it proves a human is present rather than authorizing one script over another. What the platform does not grant is access to every value in the page, since a script cannot read another module's locals, so the bullet claims the capability rather than the memory.

## Notes for reviewers

This branch was linearized onto `main` after an earlier merge commit, since the repository allows only rebase and squash. `main` had rewritten the same first risk bullet, leading it with the rpId takeover case and moving the rpId gloss into it. Both bullets survive here, with `main`'s leading and its gloss intact, so the later migration bullet stays gloss-free as `main` left it. Its trailing note about scripts in the app's own page is gone, along with a second `PRF output` link, because the merged page carries both elsewhere.

The interception claim was checked rather than reasoned about. A throwaway Playwright run against the repository's PRF virtual authenticator replaced `CredentialsContainer.prototype.get`, let mera run a real ceremony through it, and captured the same 32 bytes the call returned to the caller. The properties involved are `writable` and `configurable`, and `navigator.credentials` can be shadowed outright. The test is not kept: it asserts a browser behavior rather than a mera contract.

The lowercase `mera` in prose is a separate mechanical pass over the two pages that still capitalized it. No `MeraError` or code identifier changed.

The diagram is untouched. `main` had already relabelled its zone `any page under the rpId`, so the prose now points at that scope instead of calling the web page the widest case.

## Screenshot

![security-model-light.png](https://github.com/user-attachments/assets/31010fd9-2321-482c-958b-9e6cca2a0686)
