### PR TITLE
docs: state the passkey trust boundary as the rpId

### DIFF
--- a/docs/src/assets/diagrams/trust-boundary.svg
+++ b/docs/src/assets/diagrams/trust-boundary.svg
@@ -1,18 +1,18 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 680 384"
+  viewBox="0 0 680 276"
   width="680"
-  height="384"
+  height="276"
   role="img"
   class="mera-diagram"
 >
   <title>
-    The trust boundary. The page contains the app, which derives keys from PRF
-    output and decides when to end sessions, and mera, which copies the bytes it
-    is given and zeroes its own copies. The authenticator sits outside the page,
-    reachable only through WebAuthn ceremonies: it holds the passkey and PRF,
-    the key never leaves, and it asks for user verification. Any script on the
-    page can see key material and sign with a live session.
+    The trust boundary. The app runs in a page under the rpId with mera embedded
+    in it, and the app holds the derived key in memory. The app reaches the
+    authenticator through mera, which runs the WebAuthn ceremonies. The
+    authenticator sits outside the page: it holds the passkey and PRF, the key
+    never leaves, and it asks for user verification. Any page under the rpId can
+    run a ceremony and read the PRF output.
   </title>
   <defs>
     <marker
@@ -28,45 +28,36 @@
     </marker>
   </defs>
 
-  <rect class="d-zone" x="24" y="24" width="396" height="296" rx="10" />
-  <text x="38" y="46" class="d-sub">the page</text>
+  <rect class="d-zone" x="24" y="24" width="372" height="228" rx="10" />
+  <text x="38" y="46" class="d-sub">any page under the rpId</text>
 
-  <rect class="d-node" x="48" y="88" width="348" height="80" rx="8" />
-  <text x="222" y="116" text-anchor="middle">The app</text>
-  <text x="222" y="135" text-anchor="middle" class="d-sub">
-    derives keys from PRF output
-  </text>
-  <text x="222" y="153" text-anchor="middle" class="d-sub">
-    decides when to end sessions
+  <rect class="d-node" x="48" y="72" width="324" height="140" rx="8" />
+  <text x="210" y="98" text-anchor="middle">The app</text>
+  <text x="210" y="117" text-anchor="middle" class="d-sub">
+    holds the derived key in memory
   </text>
 
-  <rect class="d-node" x="48" y="200" width="348" height="80" rx="8" />
-  <text x="222" y="228" text-anchor="middle">mera</text>
-  <text x="222" y="247" text-anchor="middle" class="d-sub">
-    copies the bytes it is given
-  </text>
-  <text x="222" y="265" text-anchor="middle" class="d-sub">
-    zeroes its own copies
-  </text>
+  <rect class="d-node" x="72" y="136" width="276" height="52" rx="8" />
+  <text x="210" y="167" text-anchor="middle">mera</text>
 
   <path
     class="d-edge"
-    d="M428 204 H478"
+    d="M348 162 H478"
     marker-start="url(#tb-arrow)"
     marker-end="url(#tb-arrow)"
   />
-  <text x="452" y="194" text-anchor="middle" class="d-sub">WebAuthn</text>
-  <text x="452" y="224" text-anchor="middle" class="d-sub">ceremonies</text>
+  <text x="440" y="152" text-anchor="middle" class="d-sub">WebAuthn</text>
+  <text x="440" y="182" text-anchor="middle" class="d-sub">ceremonies</text>
 
-  <rect class="d-secret" x="484" y="130" width="180" height="140" rx="8" />
-  <text x="574" y="166" text-anchor="middle">Authenticator</text>
-  <text x="574" y="188" text-anchor="middle" class="d-sub">
+  <rect class="d-secret" x="484" y="92" width="180" height="140" rx="8" />
+  <text x="574" y="128" text-anchor="middle">Authenticator</text>
+  <text x="574" y="150" text-anchor="middle" class="d-sub">
     holds the passkey and PRF
   </text>
-  <text x="574" y="206" text-anchor="middle" class="d-sub">
+  <text x="574" y="168" text-anchor="middle" class="d-sub">
     the key never leaves
   </text>
-  <text x="574" y="224" text-anchor="middle" class="d-sub">
+  <text x="574" y="186" text-anchor="middle" class="d-sub">
     asks for user verification
   </text>
 </svg>

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -7,7 +7,7 @@ import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
 Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, mera's security model matches that of a wallet browser extension like MetaMask or Phantom: whatever the wallet signs with, a seed phrase, a private key, or an access token for a remote signer, lives in script memory.
 
-- A ceremony under the rpId (the relying party domain) returns the [PRF output](/concepts/passkeys-and-prf/) for the salt it asks for. Whoever takes over a hostname under the rpId can serve a page there and run one. So can any script in the app's own page, injected or from a dependency or extension.
+- Whoever takes over a hostname under the rpId (the relying party domain) can serve a page there and run a ceremony, which returns the [PRF output](/concepts/passkeys-and-prf/) that the account keys derive from. So can any script in the app's own page, injected or from a dependency or extension.
 - Losing access to the passkey without a backup or export also loses access to the accounts derived from it.
 - A passkey works only under the rpId it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -7,7 +7,7 @@ import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
 Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, mera's security model matches that of a wallet browser extension like MetaMask or Phantom: whatever the wallet signs with, a seed phrase, a private key, or an access token for a remote signer, lives in script memory.
 
-- Any script served under the rpId (the relying party domain) can prompt the user for a ceremony and read the [PRF output](/concepts/passkeys-and-prf/). That output reproduces every account derived from the passkey and decrypts its vaults. An injected script, a malicious dependency, a browser extension with page access, and a stranger's script under the same rpId all get the same output from an approved prompt.
+- A ceremony under the rpId (the relying party domain) returns the [PRF output](/concepts/passkeys-and-prf/) for the salt it asks for. Whoever takes over a hostname under the rpId can serve a page there and run one. So can any script in the app's own page, injected or from a dependency or extension.
 - Losing access to the passkey without a backup or export also loses access to the accounts derived from it.
 - A passkey works only under the rpId it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -7,9 +7,9 @@ import TrustBoundary from "../../../assets/diagrams/trust-boundary.svg";
 
 Mera runs in the page JS code, the keys it produces and derives are software keys and not hardware backed. In principle, mera's security model matches that of a wallet browser extension like MetaMask or Phantom: whatever the wallet signs with, a seed phrase, a private key, or an access token for a remote signer, lives in script memory.
 
-- Any script in the page can read the [PRF output](/concepts/passkeys-and-prf/) and every key derived from it, and can sign with a live session. An injected script, a malicious dependency, and a browser extension with page access are all inside this boundary. Ending sessions when idle and zeroing key material promptly reduce the exposure.
+- Any script served under the rpId (the relying party domain) can prompt the user for a ceremony and read the [PRF output](/concepts/passkeys-and-prf/). That output reproduces every account derived from the passkey and decrypts its vaults. An injected script, a malicious dependency, a browser extension with page access, and a stranger's script under the same rpId all get the same output from an approved prompt.
 - Losing access to the passkey without a backup or export also loses access to the accounts derived from it.
-- A passkey works only under the rpId (the relying party domain) it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
+- A passkey works only under the rpId it was created for: after a domain migration, passkey accounts can no longer be reproduced and vaults can no longer be decrypted. Accounts need an export path before any planned migration.
 - Secrets encrypted with one reused PRF output share an encryption key, and exposing that key exposes them all. The vault functions generate a fresh random 32-byte salt per secret.
 - The only runtime dependencies are `@noble/*` and `@scure/*`, well-known audited cryptography libraries.
 


### PR DESCRIPTION
## Why

Review feedback said the security model covers domain problems only as loss, never as takeover. Checking that turned up two sentences on the page that were wrong, both in the direction of overstating what the page boundary means:

- "Any script in the page can read the PRF output" — nothing reads the output out of memory. It arrives from a ceremony, and a ceremony is one user-verification prompt.
- "can sign with a live session" — `createEd25519SigningSession` keeps the private key behind `use()` in a closure and returns only the session object. JS exposes no way to enumerate closure scopes, so script holding no reference cannot sign with it.

Naming the rpId as the boundary states the reported risk and fixes both: whoever takes over a hostname under the rpId can serve a page there and run a ceremony, and so can script that reaches the app's own page. Reproduction is deterministic, so accounts created long before a takeover are in range.

Copilot then caught that the first draft still named the wrong unit. WebAuthn takes `callerOrigin` from the document, never from the URL that served a script file, so a dependency loaded from a third-party CDN holds full rpId authority while a file hosted on the rpId but running in another page holds none. Confirmed in Chrome: a script served by `cdn.localhost`, running in an `app.localhost` page, gets SecurityError for `rpId: "cdn.localhost"` and reaches the authenticator for `rpId: "app.localhost"`. The bullet now qualifies pages, not script files.

Same comment caught a second error: the draft said one output decrypts the vaults. Each vault stores its own random salt and one ceremony evaluates one salt, so it does not, and the claim contradicted the salt bullet lower on the page.

## Notes for reviewers

The feedback attributed this to the fixed default PRF salt. That is not what enables it, and a per-app secret salt would not close it, since any salt ships in the page bundle and travels with the ceremony. The docs say nothing about salt secrecy for that reason.

Two sentences went away that reviewers may want back. "Ending sessions when idle and zeroing key material promptly reduce the exposure" — the list now states risks without advice, and [signing-sessions](docs/src/content/docs/concepts/signing-sessions.mdx) covers session lifetime and zeroing. "A live session signs without any prompt at all" — true, but sitting next to the actor list it implies those actors can sign without a prompt, which is the claim the closure disproves.

The diagram labelled the boundary "the page" and its description repeated both wrong claims, so it moves with the prose. mera is now nested in the app it is imported into, with the ceremony leaving through it, and the node captions that restated the prose are gone per the diagram rule in docs/AGENTS.md.

Diagram layout was checked in headless Chromium with `mera.css` applied, measuring `getBBox` per text node: every label is contained by its rect, and the zone narrowed from 396 to 372 so the edge labels stop overlapping the boundary and the authenticator box. The in-app browser pane renders SVG with all styling dropped and is no use for this.

Follow-up outside this diff: the intro compares the model to MetaMask or Phantom, which bind key material to an extension ID rather than a web origin, so the first bullet has no counterpart there.

## Screenshots

Rendered from the docs site, which is light-only by design (`ThemeProvider.astro` pins the theme).

| Before | After |
| --- | --- |
| ![diagram-before.png](https://github.com/user-attachments/assets/b2be82c8-a124-4f38-ba4c-6403e5558f2b) | ![diagram-after.png](https://github.com/user-attachments/assets/6135ffd3-7197-444a-a2a9-b14599ea0569) |

The before shot also shows the edge labels crowding the boundary and the authenticator box, which the narrower zone fixes.
