### PR TITLE
Remove user.id from passkey creation

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,7 +12,7 @@
         "@scure/bip39": "^2.2.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "viem": "^2.55.2"
+        "viem": "2.55.10"
       },
       "devDependencies": {
         "@types/node": "^24.13.3",
@@ -877,6 +877,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1218,9 +1224,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.30",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.30.tgz",
-      "integrity": "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==",
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
       "funding": [
         {
           "type": "github",
@@ -1309,12 +1315,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/ox/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1504,9 +1504,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.55.2",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.2.tgz",
-      "integrity": "sha512-XlJeyNAZ96dQfOHlxLTK1FKgtWw/TtxENKNMBSBgxqALjiWiBWrFmSSzwwMivryKnBwkbt5E+90jSCLnVEilLA==",
+      "version": "2.55.10",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.10.tgz",
+      "integrity": "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==",
       "funding": [
         {
           "type": "github",
@@ -1521,7 +1521,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.30",
+        "ox": "0.14.33",
         "ws": "8.21.0"
       },
       "peerDependencies": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "@scure/bip39": "^2.2.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "viem": "^2.55.2"
+    "viem": "2.55.10"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/demo/src/connect.ts
+++ b/demo/src/connect.ts
@@ -49,6 +49,17 @@ const DEFAULT_USER = "nad";
 
 const rpId = location.hostname;
 
+const passkeyLabelFormat = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "medium",
+});
+
+// Every create adds a passkey, so a creation-time label keeps the entries
+// apart in the authenticator's picker.
+function passkeyLabel(): string {
+  return `Account ${passkeyLabelFormat.format(new Date())}`;
+}
+
 /**
  * Derives the demo's account (HD index 0) from a BIP-39 seed and zeroes the
  * seed, so no caller retains it past the derivation.
@@ -90,11 +101,9 @@ function buildPasskeyWallet(
 }
 
 async function createPasskeyWallet(): Promise<ConnectedWallet> {
-  // `user.id` is left to default (32 random bytes), so every "Create" is a
-  // distinct, parallel passkey rather than silently overwriting an existing one.
   const credential = await createPasskeyWithPrfOutput({
     rp: { id: rpId, name: RP_NAME },
-    user: { name: DEFAULT_USER, displayName: DEFAULT_USER },
+    user: { name: DEFAULT_USER, displayName: passkeyLabel() },
   });
 
   rememberPasskeyWallet({
@@ -143,7 +152,7 @@ async function createVaultAccount(mnemonic: string): Promise<ConnectedWallet> {
   try {
     const vault = await createSecretVaultWithNewPasskey({
       rp: { id: rpId, name: RP_NAME },
-      user: { name: DEFAULT_USER, displayName: DEFAULT_USER },
+      user: { name: DEFAULT_USER, displayName: passkeyLabel() },
       secret,
     });
     localStorage.setItem(VAULT_KEY, JSON.stringify(vault));

--- a/docs/src/content/docs/concepts/passkey-accounts.md
+++ b/docs/src/content/docs/concepts/passkey-accounts.md
@@ -7,7 +7,7 @@ In mera's model, a passkey account is a blockchain account whose keys derive fro
 
 ## Losing the passkey
 
-The accounts may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, or unavailable under the app's rpId after a domain migration. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works.
+The accounts may be unrecoverable if the passkey is deleted, not synced, tied to a lost provider account, unavailable under the app's rpId after a domain migration, or [overwritten](/concepts/passkeys-and-prf/#user-handles) by a second passkey with the same user handle. Recovery then depends on an app-provided export, import, or backup path, taken while the passkey still works.
 
 ## When the secret already exists
 

--- a/docs/src/content/docs/concepts/passkeys-and-prf.mdx
+++ b/docs/src/content/docs/concepts/passkeys-and-prf.mdx
@@ -11,6 +11,12 @@ A passkey is a WebAuthn credential. [WebAuthn](https://www.w3.org/TR/webauthn-3/
 
 **Passkeys sync.** Platform authenticators, the credential stores built into an operating system or a password manager, replicate credentials across a person's devices: iCloud Keychain across Apple devices, Google Password Manager across Android and Chrome, 1Password wherever it runs.
 
+## User handles
+
+**A passkey has a [user handle](https://www.w3.org/TR/webauthn-3/#user-handle), the id of the account it belongs to on that site.** WebAuthn calls it `user.id`.
+
+Creating a passkey with the same rpId and user handle as one the authenticator already holds overwrites it. The replacement gets a new key pair and a new PRF. Mera generates a fresh random 32-byte handle for every passkey it creates, so each creation adds a passkey and leaves existing ones in place.
+
 ## User verification
 
 Every mera ceremony requires user verification, the authenticator's local check that the person is present and is the owner. The gesture depends on the platform: a biometric, a device PIN, a password.
@@ -35,6 +41,7 @@ A ceremony is one WebAuthn call and one user-verification prompt. A ceremony eit
 
 ## See also
 
+- [Passkey accounts](/concepts/passkey-accounts/): the account model built on a passkey's PRF output.
 - [Keys and accounts](/concepts/entropy-keys-and-accounts/): what the 32 bytes become once the app holds them.
 - [Authenticator support](/authenticator-support/): which stacks deliver PRF today.
 - [Getting started](/getting-started/): the ceremony-to-signature path in code.

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -45,13 +45,6 @@ User name displayed or stored by the authenticator.
 
 Human-readable display name for the authenticator UI.
 
-### options.user.id
-
-- Type: `Uint8Array`
-- Optional; a fresh 32-byte random handle is generated per call when omitted
-
-User handle stored with the discoverable credential. Must be 1 to 64 bytes when provided (WebAuthn's user-handle limit).
-
 ### options.prfSalt
 
 - Type: `Uint8Array`
@@ -73,7 +66,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 ## Errors
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF, or did not return PRF output on the fallback ceremony.
-- [`INPUT_INVALID`](/reference/errors/#input_invalid): an explicit `prfSalt` is not 32 bytes, or the provided `user.id` length is outside 1 to 64 bytes.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): an explicit `prfSalt` is not 32 bytes.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
@@ -81,7 +74,7 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 The credential is requested with fixed parameters: ES256 or RS256 key types, attestation `"none"` (no statement about the authenticator's make is requested), a required resident key, and required user verification. Resident key is the WebAuthn term for a [discoverable](/concepts/passkeys-and-prf/) credential. The user-verification requirement is not configurable ([Passkeys and the PRF extension](/concepts/passkeys-and-prf/#user-verification) explains the mechanism).
 
-WebAuthn challenges are generated internally.
+WebAuthn challenges and the credential's [user handle](/concepts/passkeys-and-prf/#user-handles) (`user.id`) are generated internally, 32 random bytes each. A fresh handle per call means each call adds a passkey and never overwrites one.
 
 Any failure after the creation ceremony completes leaves the passkey on the authenticator: it appears in the authenticator's passkey list, but the thrown error does not carry its metadata.
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -38,12 +38,19 @@ try {
 
 Relying party identity passed to [WebAuthn](https://www.w3.org/TR/webauthn-3/). The required ID is reused by the fallback [assertion](/concepts/passkeys-and-prf/#ceremonies-and-prompts).
 
-### options.user
+### options.user.name
 
-- Type: `{ id?: Uint8Array; name: string; displayName: string }`
+- Type: `string`
 - Required
 
-User identity passed to WebAuthn. `id` must be 1 to 64 bytes when provided. A fresh random 32-byte user handle is generated when it is omitted.
+User name displayed or stored by the authenticator.
+
+### options.user.displayName
+
+- Type: `string`
+- Required
+
+Human-readable display name for the authenticator UI.
 
 ### options.secret
 
@@ -66,11 +73,13 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 ## Errors
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF or return a usable 32-byte output.
-- [`INPUT_INVALID`](/reference/errors/#input_invalid): `secret` is empty, or the provided `user.id` length is outside 1 to 64 bytes.
+- [`INPUT_INVALID`](/reference/errors/#input_invalid): `secret` is empty.
 - [`CRYPTO_UNAVAILABLE`](/reference/errors/#crypto_unavailable): the page is not in a secure context, or the runtime lacks Web Crypto.
 - [`PASSKEY_OPERATION_FAILED`](/reference/errors/#passkey_operation_failed): WebAuthn is unavailable, cancelled, or returns an unexpected credential.
 
 ## Notes
+
+The credential's [user handle](/concepts/passkeys-and-prf/#user-handles) (`user.id`) is 32 random bytes, generated per call, so each call adds a passkey and never overwrites one.
 
 If the fallback ceremony or vault encryption fails after creation, the passkey remains on the authenticator and the error does not contain its metadata.
 

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -26,12 +26,6 @@ type CreatePasskeyWithPrfOutputOptions = {
   rp: PublicKeyCredentialRpEntity & { id: string };
   /** User identity passed to WebAuthn. */
   user: {
-    /**
-     * User handle stored for the discoverable credential. Must be 1 to 64
-     * bytes when provided (WebAuthn's user-handle limit). When omitted, a
-     * fresh 32-byte random handle is generated for each call.
-     */
-    id?: Uint8Array;
     /** User name displayed or stored by the authenticator. */
     name: string;
     /** Human-readable display name for the authenticator UI. */
@@ -90,7 +84,10 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * fallback `navigator.credentials.get()` evaluates the same salt and shows a
  * second prompt.
  *
- * WebAuthn challenges are generated internally.
+ * WebAuthn challenges and the credential's user handle (`user.id`) are
+ * generated internally, 32 random bytes each. An authenticator overwrites a
+ * discoverable credential that has the same `rp.id` and `user.id`, so a fresh
+ * handle per call adds a passkey instead of replacing one.
  *
  * The credential is requested with fixed parameters: ES256 or RS256 key types,
  * attestation `"none"`, a required resident key, and required user
@@ -99,7 +96,7 @@ type PublicKeyCredentialWithPrf = PublicKeyCredential & {
  * Any failure after the creation ceremony completes leaves the passkey on the
  * authenticator, but the thrown error does not carry its metadata.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF, returns a malformed create-time PRF output, or does not return PRF output on the fallback ceremony.
- * @throws MeraError with code `INPUT_INVALID` when an explicit `prfSalt` is not 32 bytes, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when an explicit `prfSalt` is not 32 bytes.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */
@@ -116,17 +113,13 @@ async function createPasskeyWithPrfOutput({
       throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
     }
 
-    if (user.id !== undefined && (user.id.length < 1 || user.id.length > 64)) {
-      throw new MeraError("INPUT_INVALID", "user.id must be 1 to 64 bytes");
-    }
-
     const prfSaltCopy = copyBytes(prfSalt ?? DEFAULT_PRF_SALT);
 
     const credential = await navigator.credentials.create({
       publicKey: {
         rp,
         user: {
-          id: asArrayBuffer(user.id ?? randomBytes(32)),
+          id: asArrayBuffer(randomBytes(32)),
           name: user.name,
           displayName: user.displayName,
         },

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -192,11 +192,14 @@ function copyNonEmptySecret(secret: Uint8Array): Uint8Array<ArrayBuffer> {
  * A fresh random PRF salt is generated internally and stored in the returned
  * vault.
  *
+ * A fresh random user handle (`user.id`) is generated for the new credential,
+ * so each call adds a passkey instead of replacing one.
+ *
  * If the fallback ceremony or vault encryption fails, the passkey from the
  * completed creation ceremony still exists on the authenticator, but the
  * thrown error does not carry its metadata.
  * @throws MeraError with code `PRF_UNAVAILABLE` when the authenticator does not enable PRF or return a usable 32-byte PRF output.
- * @throws MeraError with code `INPUT_INVALID` when `secret` is empty, or `user.id` is provided but not 1 to 64 bytes.
+ * @throws MeraError with code `INPUT_INVALID` when `secret` is empty.
  * @throws MeraError with code `CRYPTO_UNAVAILABLE` when Web Crypto is unavailable.
  * @throws MeraError with code `PASSKEY_OPERATION_FAILED` when WebAuthn is unavailable, cancelled, or returns an unexpected credential.
  */

--- a/test/passkey.e2e.ts
+++ b/test/passkey.e2e.ts
@@ -43,11 +43,7 @@ test("creates a PRF-capable passkey and returns stable PRF output", async ({
       const otherSalt = new Uint8Array(32).fill(6);
       const credential = await mera.createPasskeyWithPrfOutput({
         rp: { id: "localhost", name: "Mera Test" },
-        user: {
-          id: crypto.getRandomValues(new Uint8Array(32)),
-          name: "nad",
-          displayName: "nad",
-        },
+        user: { name: "nad", displayName: "nad" },
         prfSalt: salt,
       });
       const second = await mera.getPasskeyPrfOutput({
@@ -96,11 +92,7 @@ test("PRF output helpers use the default salt when prfSalt is omitted", async ({
       const mera = await import("@category-labs/mera");
       const created = await mera.createPasskeyWithPrfOutput({
         rp: { id: "localhost", name: "Mera Test" },
-        user: {
-          id: crypto.getRandomValues(new Uint8Array(32)),
-          name: "nad",
-          displayName: "nad",
-        },
+        user: { name: "nad", displayName: "nad" },
       });
 
       // Omission uses the same stable salt for returning assertions.
@@ -146,11 +138,7 @@ test("secret-vault orchestrators create independent vaults and decrypt them", as
 
       const firstVault = await mera.createSecretVaultWithNewPasskey({
         rp: { id: "localhost", name: "Mera Test" },
-        user: {
-          id: crypto.getRandomValues(new Uint8Array(32)),
-          name: "nad",
-          displayName: "nad",
-        },
+        user: { name: "nad", displayName: "nad" },
         secret: new TextEncoder().encode(firstPhrase),
       });
 

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -235,11 +235,7 @@ test("passkey helpers generate internal challenges and request no attestation", 
   await withStubbedGlobal("navigator", navigator, async () => {
     await createPasskeyWithPrfOutput({
       rp: { id: "example.com", name: "Mera Test" },
-      user: {
-        id: new Uint8Array([1]),
-        name: "nad",
-        displayName: "nad",
-      },
+      user: { name: "nad", displayName: "nad" },
       prfSalt: new Uint8Array(32),
     });
     await getPasskeyPrfOutput({
@@ -259,6 +255,41 @@ test("passkey helpers generate internal challenges and request no attestation", 
   expect(createOptions.attestation).toBe("none");
   expect(getOptions.challenge).toBeInstanceOf(ArrayBuffer);
   expect(new Uint8Array(getOptions.challenge as ArrayBuffer)).toHaveLength(32);
+});
+
+test("createPasskeyWithPrfOutput generates a fresh user handle per call", async () => {
+  // The handle never reaches the caller, so the WebAuthn options are the only
+  // place it is observable. A repeated handle would make the second call
+  // overwrite the passkey the first one created.
+  const handles: Uint8Array[] = [];
+
+  const navigator = {
+    credentials: {
+      async create({ publicKey }: CredentialCreationOptions) {
+        handles.push(new Uint8Array(publicKey?.user.id as ArrayBuffer));
+        return stubPublicKeyCredential({
+          prf: {
+            enabled: true,
+            results: { first: new Uint8Array(32).buffer },
+          },
+          transports: ["internal"],
+        });
+      },
+    },
+  };
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    const options = {
+      rp: { id: "example.com", name: "Mera Test" },
+      user: { name: "nad", displayName: "nad" },
+    };
+    await createPasskeyWithPrfOutput(options);
+    await createPasskeyWithPrfOutput(options);
+  });
+
+  expect(handles[0]).toHaveLength(32);
+  expect(handles[1]).toHaveLength(32);
+  expect(handles[0]).not.toEqual(handles[1]);
 });
 
 test("getPasskeyPrfOutput rejects an empty credentialId without prompting", async () => {
@@ -314,11 +345,7 @@ test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", asy
   await withStubbedGlobal("navigator", navigator, async () => {
     const pending = createPasskeyWithPrfOutput({
       rp: { id: "example.com", name: "Mera Test" },
-      user: {
-        id: new Uint8Array([1]),
-        name: "nad",
-        displayName: "nad",
-      },
+      user: { name: "nad", displayName: "nad" },
       prfSalt,
     });
 


### PR DESCRIPTION
## Why

Raised in review: passing a stable `user.id` to a second creation ceremony silently destroys the first passkey.

The report is correct. CTAP's `authenticatorMakeCredential` overwrites a discoverable credential when a creation ceremony arrives with the same relying party ID and user handle. The replacement holds a new key pair and a new PRF, so every passkey account and every vault keyed to the old PRF output stops being reachable. There is no prompt and no error.

An ordinary footgun would be bad enough. This one is worse, because the ecosystem teaches the exact input that fires it: web.dev's registration guide says `user.id` should be permanent. That advice is right for server-verified login, where re-registering is meant to replace one account's credential. Under PRF-derived keys it destroys funds. We accepted the parameter, checked only that it was 1 to 64 bytes, and warned nowhere. The single place in the repo that stated the hazard was a comment in the demo.

Removing the parameter costs nothing today. Deliberate overwrite is the only reason to set a handle, and no consumer needs it. Even an app that wanted it could not get there: reusing a handle means keeping a handle registry, and no assertion returns `userHandle`, so the rotation flow was unreachable through this API in the first place.

The asymmetry decides the rest. At `0.1.0` with no users, removing is free and adding back later is additive. Keeping the parameter means removing it later, which is a break we would have to earn. If rotation turns out to matter, it returns as an option whose name states the consequence, together with `userHandle` on the assertion result.

## Notes for reviewers

**On `excludeCredentials`, also raised in the report: deferred rather than rejected.** It is the only mechanism that turns the silent overwrite into a loud `InvalidStateError`, and it answers the flip-side failure too, where someone accumulates identical-looking passkeys and picks the wrong one. But it only helps an app that already knows its credential IDs. The vault path stores them; the passkey-account path stores nothing, by design. So it covers half the library, and not the half that carries the core value. It lands separately, scoped to the vault path.

On the wrong-passkey case specifically: an app that stores `credentialId` at creation and passes it to `getPasskeyPrfOutput` already pins later sign-ins to one passkey, and the demo does this. What remains unfixed is creating the duplicate in the first place. The docs now say plainly that mera does not filter creation against existing passkeys, so the gap is stated rather than hidden.

**Where the docs work landed.** The overwrite rule is a property of passkeys, so it sits on the concepts page that owns WebAuthn mechanics, with the consequence for accounts on the passkey-accounts page and a pointer from both reference pages. The claim about a lost PRF output is scoped to the authenticator on purpose: a synced provider propagates the overwrite and a roaming key does not, and the scoped statement is what the specs support.

**On the new test.** Nothing guarded the removed validation, and nothing guarded the random handle either. The handle never reaches the caller, so the WebAuthn creation options are the only place it is observable, which is why that assertion is white-box.

**Also in the diff, not required by the change.** `createSecretVaultWithNewPasskey`'s `options.user` was one combined block while its sibling page split the fields; since the block had to change anyway, it now follows the one-subheading-per-field form that `docs/AGENTS.md` prescribes.

**Manual validation beyond CI.** Demo and docs sites both build. I confirmed the two new anchors exist in the generated HTML and that all four referring pages resolve to them.
