### PR TITLE
ci: add release and security workflows; pin actions to SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     commit-message:
@@ -32,6 +34,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
-# Dependabot version updates. The private demo/ app is intentionally not
-# covered.
+# Weekly version updates for the root library's npm dependencies and the
+# SHA-pinned actions in CI. The private demo/ app is intentionally not covered.
 version: 2
 
 updates:
@@ -26,9 +26,8 @@ updates:
           - "minor"
           - "patch"
 
-  # GitHub Actions in CI. The workflows track floating major tags
-  # (e.g. actions/checkout@v7), which already pick up minor and patch
-  # releases; Dependabot opens a PR when a new major tag is available.
+  # GitHub Actions in CI. The workflows pin actions to commit SHAs; Dependabot
+  # PRs bump the SHA and the version comment beside it.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -28,10 +28,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           check-latest: true

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -50,7 +50,7 @@ jobs:
           npm --prefix demo run build
 
       - name: Build and upload docs
-        uses: withastro/action@v6
+        uses: withastro/action@e84f40bd8d2caa9e768ec82ad30dd81f0b280853 # v6.1.2
         with:
           path: docs
           node-version: 24
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -86,7 +86,7 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.library == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -112,7 +112,7 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.demo == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -145,7 +145,7 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -174,7 +174,7 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.package == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -61,10 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           check-latest: true
@@ -86,10 +86,10 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.library == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           check-latest: true
@@ -112,10 +112,10 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.demo == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           check-latest: true
@@ -145,10 +145,10 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           check-latest: true
@@ -174,10 +174,10 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.package == 'true') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Mera - Release
+
+# Publishes @category-labs/mera to npm with provenance.
+#
+# The package is built AND published on a GitHub-hosted runner in the same job.
+# This is a requirement for meaningful npm provenance: the attestation is signed
+# with the runner's OIDC token and certifies that the published artifact was
+# built from this repository at this commit by this workflow. Building elsewhere
+# (e.g. inside a Docker container) and only uploading the tarball would weaken
+# that guarantee to "a runner uploaded a file", so the Dockerfile is used for
+# local verification only, not for the publish path.
+#
+# Triggers:
+#   - push of a v* tag   -> real publish with provenance
+#   - workflow_dispatch  -> dry-run only (no registry write, no secrets needed)
+#
+# Cut a release (once the prerequisites below exist):
+#   npm version <patch|minor|major>   # bumps package.json + creates the tag
+#   git push --follow-tags
+#
+# One-time prerequisites before the first real publish:
+#   1. Create the `category-labs` npm org/scope (unscoped `mera` is taken).
+#   2. Add an `NPM_TOKEN` secret (automation/granular token that can publish
+#      to @category-labs/*).
+#   3. Create the `npm-publish` GitHub Actions environment (optionally gated
+#      with required reviewers).
+# The dry-run path works without any of these.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Real publish: only on a v* tag. Builds on the runner so provenance is honest.
+  publish:
+    name: Publish to npm (provenance)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest # must be GitHub-hosted for provenance
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write # OIDC token used to sign the provenance attestation
+    steps:
+      # Provenance is unsupported for private repos: npm publish --provenance
+      # would fail deep in the run. Fail fast with a clear message instead.
+      - name: Require a public repository (provenance prerequisite)
+        if: github.event.repository.private
+        run: |
+          echo "::error::Repository is private. npm provenance requires a public repo; make it public before releasing."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          # No dependency cache in the publish path: a poisoned cache could
+          # inject artifacts into the published package (zizmor cache-poisoning).
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Refuse to republish an existing version
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "::error::${name}@${version} is already published. Bump the version."
+            exit 1
+          fi
+
+      # publishConfig in package.json sets access:public + provenance:true.
+      - name: Publish
+        run: npm publish --provenance
+
+  # Dry-run: manual trigger only. Exercises checkout -> build -> pack/publish
+  # resolution without contacting the registry. Needs no secrets and no OIDC,
+  # and deliberately omits --provenance (only meaningful on a real publish).
+  dry-run:
+    name: Dry-run publish (no registry write)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: .nvmrc
+          # No dependency cache in the publish path: a poisoned cache could
+          # inject artifacts into the published package (zizmor cache-poisoning).
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish (dry-run)
+        run: npm publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
@@ -67,10 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           package-manager-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,8 @@
 name: Mera - Release
 
-# Publishes @category-labs/mera to npm with provenance.
-#
-# The package is built AND published on a GitHub-hosted runner in the same job.
-# This is a requirement for meaningful npm provenance: the attestation is signed
-# with the runner's OIDC token and certifies that the published artifact was
-# built from this repository at this commit by this workflow. Building elsewhere
-# (e.g. inside a Docker container) and only uploading the tarball would weaken
-# that guarantee to "a runner uploaded a file", so the Dockerfile is used for
-# local verification only, not for the publish path.
-#
-# Triggers:
-#   - push of a v* tag   -> real publish with provenance
-#   - workflow_dispatch  -> dry-run only (no registry write, no secrets needed)
-#
-# Cut a release (once the prerequisites below exist):
-#   npm version <patch|minor|major>   # bumps package.json + creates the tag
-#   git push --follow-tags
-#
-# One-time prerequisites before the first real publish:
-#   1. Create the `category-labs` npm org/scope (unscoped `mera` is taken).
-#   2. Add an `NPM_TOKEN` secret (automation/granular token that can publish
-#      to @category-labs/*).
-#   3. Create the `npm-publish` GitHub Actions environment (optionally gated
-#      with required reviewers).
-# The dry-run path works without any of these.
+# Publishes @category-labs/mera to npm with provenance, building and publishing
+# in one GitHub-hosted job so the attestation certifies the artifact was built
+# here. A v* tag publishes for real; workflow_dispatch runs a dry-run.
 
 on:
   push:
@@ -36,18 +14,15 @@ permissions:
   contents: read
 
 jobs:
-  # Real publish: only on a v* tag. Builds on the runner so provenance is honest.
   publish:
     name: Publish to npm (provenance)
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest # must be GitHub-hosted for provenance
+    runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
       contents: read
-      id-token: write # OIDC token used to sign the provenance attestation
+      id-token: write
     steps:
-      # Provenance is unsupported for private repos: npm publish --provenance
-      # would fail deep in the run. Fail fast with a clear message instead.
       - name: Require a public repository (provenance prerequisite)
         if: github.event.repository.private
         run: |
@@ -62,8 +37,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
-          # No dependency cache in the publish path: a poisoned cache could
-          # inject artifacts into the published package (zizmor cache-poisoning).
           package-manager-cache: false
 
       - name: Install dependencies
@@ -81,13 +54,9 @@ jobs:
             exit 1
           fi
 
-      # publishConfig in package.json sets access:public + provenance:true.
       - name: Publish
         run: npm publish --provenance
 
-  # Dry-run: manual trigger only. Exercises checkout -> build -> pack/publish
-  # resolution without contacting the registry. Needs no secrets and no OIDC,
-  # and deliberately omits --provenance (only meaningful on a real publish).
   dry-run:
     name: Dry-run publish (no registry write)
     if: github.event_name == 'workflow_dispatch'
@@ -100,8 +69,6 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .nvmrc
-          # No dependency cache in the publish path: a poisoned cache could
-          # inject artifacts into the published package (zizmor cache-poisoning).
           package-manager-cache: false
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,14 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Refuse to republish an existing version
+      - name: Validate release version and refuse to republish
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
+          if [ "$GITHUB_REF_NAME" != "v${version}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match package version ${version}."
+            exit 1
+          fi
           if npm view "${name}@${version}" version >/dev/null 2>&1; then
             echo "::error::${name}@${version} is already published. Bump the version."
             exit 1

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Node

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,0 +1,42 @@
+name: Socket
+
+# Supply-chain scanning via Socket. The root library depends on @noble/curves,
+# @noble/hashes, and @scure/base (plus viem as an optional peer), so this guards
+# every install against known-malicious packages and catches risky additions to
+# the dependency tree.
+#
+# Free mode ("Socket Firewall: Free") requires no account and no token: it
+# installs `sfw` and proxies the install, blocking known-malicious packages.
+# For richer PR-level analysis, install the Socket GitHub App as well (see
+# SETUP.md) — that requires a (free) Socket account.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  socket:
+    name: socket
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Install Socket Firewall (free)
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      # Run the locked install through Socket Firewall so every dependency in
+      # the tree is checked before it is fetched.
+      - name: Locked install through Socket
+        run: sfw npm ci

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -29,5 +29,8 @@ jobs:
         uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-      - name: Locked install through Socket
-        run: sfw npm ci
+      - name: Locked installs through Socket
+        run: |
+          sfw npm ci
+          (cd demo && sfw npm ci)
+          (cd docs && sfw npm ci)

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,14 +1,7 @@
 name: Socket
 
-# Supply-chain scanning via Socket. The root library depends on @noble/curves,
-# @noble/hashes, and @scure/base (plus viem as an optional peer), so this guards
-# every install against known-malicious packages and catches risky additions to
-# the dependency tree.
-#
-# Free mode ("Socket Firewall: Free") requires no account and no token: it
-# installs `sfw` and proxies the install, blocking known-malicious packages.
-# For richer PR-level analysis, install the Socket GitHub App as well (see
-# SETUP.md) — that requires a (free) Socket account.
+# Supply-chain scanning: runs the locked install through Socket Firewall so
+# every package in the dependency tree is checked before it is fetched.
 on:
   push:
     branches: [main]
@@ -36,7 +29,5 @@ jobs:
         uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-      # Run the locked install through Socket Firewall so every dependency in
-      # the tree is checked before it is fetched.
       - name: Locked install through Socket
         run: sfw npm ci

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,8 +1,7 @@
 name: zizmor
 
-# Lints everything in .github/workflows/ for CI/CD security problems:
-# unpinned actions, over-broad permissions, credential persistence, template
-# injection, etc. Modelled on otter-sec/anchor's zizmor workflow.
+# Audits .github/workflows/ for CI/CD security problems: unpinned actions,
+# over-broad permissions, credential persistence, template injection, etc.
 on:
   push:
     branches: [main]
@@ -25,12 +24,8 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
-          # Fail the build on medium-or-higher findings.
           min-severity: medium
           persona: regular
           online-audits: true
-          # Emit findings as inline PR annotations and fail the run, rather than
-          # uploading SARIF to GitHub code scanning (which needs Advanced
-          # Security + security-events: write). Keeps this repo self-contained.
           advanced-security: false
           annotations: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,11 +18,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           min-severity: medium
           persona: regular

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: zizmor
+
+# Lints everything in .github/workflows/ for CI/CD security problems:
+# unpinned actions, over-broad permissions, credential persistence, template
+# injection, etc. Modelled on otter-sec/anchor's zizmor workflow.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        with:
+          # Fail the build on medium-or-higher findings.
+          min-severity: medium
+          persona: regular
+          online-audits: true
+          # Emit findings as inline PR annotations and fail the run, rather than
+          # uploading SARIF to GitHub code scanning (which needs Advanced
+          # Security + security-events: write). Keeps this repo self-contained.
+          advanced-security: false
+          annotations: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,22 @@ cd docs
 npm ci
 npm run build
 ```
+
+## Releases
+
+A GitHub workflow publishes the library to npm as `@category-labs/mera`. A release takes three steps: merge the version bump, push a matching tag, then create the GitHub release that carries the notes for the version.
+
+Bump `version` in `package.json` and merge that change to `main`. Then tag the merge commit:
+
+```sh
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+The tag starts the workflow, which builds and publishes in the same job, so the provenance attestation covers the artifact it built. Publishing fails if the tag does not read `v<version>` from `package.json`, or if that version is already on npm. Both checks run before any registry write.
+
+The workflow authenticates through npm trusted publishing, and the repository holds no npm token. npm accepts the publish only when its trusted publisher for the package names this repository and the workflow file, so renaming either means updating the setting on npmjs.com.
+
+Once npm has the version, create the release from the tag and write its notes.
+
+Running the workflow by hand from the Actions tab does a dry run and writes nothing to the registry.


### PR DESCRIPTION
- **release.yml** — npm publish with provenance on `v*` tags; `workflow_dispatch` dry-run.
- **socket.yml** — locked install through Socket Firewall to block malicious packages.
- **zizmor.yml** — workflow security audit, failing on medium+ findings.
- All actions pinned to commit SHAs; dependabot keeps the pins updated.