### PR TITLE
docs: add a page comparing where the signing key comes from

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -127,6 +127,7 @@ export default defineConfig({
       },
       sidebar: [
         { label: "Getting started", slug: "getting-started" },
+        { label: "How mera compares", slug: "how-mera-compares" },
         {
           label: "Concepts",
           items: [

--- a/docs/src/assets/diagrams/per-platform-keystores.svg
+++ b/docs/src/assets/diagrams/per-platform-keystores.svg
@@ -1,0 +1,104 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 680"
+  width="680"
+  height="680"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    Two ways to reach an account from an iOS app, an Android app, and a web app.
+    Per platform, each app runs its own chain: the iOS app stores an encrypted
+    seed in the Keychain, the Android app in the Keystore, the web app in
+    browser storage, and each chain ends at an account of its own. With mera,
+    the three apps share one chain: mera, then the passkey, then one account.
+  </title>
+
+  <defs>
+    <marker
+      id="pk-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <text x="24" y="24" class="d-sub">per platform</text>
+
+  <rect class="d-zone" x="24" y="36" width="192" height="280" rx="10" />
+  <rect class="d-zone" x="244" y="36" width="192" height="280" rx="10" />
+  <rect class="d-zone" x="464" y="36" width="192" height="280" rx="10" />
+
+  <rect class="d-node" x="40" y="52" width="160" height="44" rx="8" />
+  <text x="120" y="80" text-anchor="middle">iOS app</text>
+  <rect class="d-node" x="260" y="52" width="160" height="44" rx="8" />
+  <text x="340" y="80" text-anchor="middle">Android app</text>
+  <rect class="d-node" x="480" y="52" width="160" height="44" rx="8" />
+  <text x="560" y="80" text-anchor="middle">Web app</text>
+
+  <path class="d-edge" d="M120 96 V116" marker-end="url(#pk-arrow)" />
+  <path class="d-edge" d="M340 96 V116" marker-end="url(#pk-arrow)" />
+  <path class="d-edge" d="M560 96 V116" marker-end="url(#pk-arrow)" />
+
+  <rect class="d-node" x="40" y="120" width="160" height="44" rx="8" />
+  <text x="120" y="148" text-anchor="middle">Keychain</text>
+  <rect class="d-node" x="260" y="120" width="160" height="44" rx="8" />
+  <text x="340" y="148" text-anchor="middle">Keystore</text>
+  <rect class="d-node" x="480" y="120" width="160" height="44" rx="8" />
+  <text x="560" y="148" text-anchor="middle">Browser store</text>
+
+  <path class="d-edge" d="M120 164 V184" marker-end="url(#pk-arrow)" />
+  <path class="d-edge" d="M340 164 V184" marker-end="url(#pk-arrow)" />
+  <path class="d-edge" d="M560 164 V184" marker-end="url(#pk-arrow)" />
+
+  <rect class="d-secret" x="40" y="188" width="160" height="44" rx="8" />
+  <text x="120" y="216" text-anchor="middle">Encrypted seed</text>
+  <rect class="d-secret" x="260" y="188" width="160" height="44" rx="8" />
+  <text x="340" y="216" text-anchor="middle">Encrypted seed</text>
+  <rect class="d-secret" x="480" y="188" width="160" height="44" rx="8" />
+  <text x="560" y="216" text-anchor="middle">Encrypted seed</text>
+
+  <path class="d-edge" d="M120 232 V252" marker-end="url(#pk-arrow)" />
+  <path class="d-edge" d="M340 232 V252" marker-end="url(#pk-arrow)" />
+  <path class="d-edge" d="M560 232 V252" marker-end="url(#pk-arrow)" />
+
+  <rect class="d-node" x="40" y="256" width="160" height="44" rx="8" />
+  <text x="120" y="284" text-anchor="middle">Account 1</text>
+  <rect class="d-node" x="260" y="256" width="160" height="44" rx="8" />
+  <text x="340" y="284" text-anchor="middle">Account 2</text>
+  <rect class="d-node" x="480" y="256" width="160" height="44" rx="8" />
+  <text x="560" y="284" text-anchor="middle">Account 3</text>
+
+  <text x="24" y="352" class="d-sub">with mera</text>
+
+  <rect class="d-zone" x="24" y="364" width="632" height="308" rx="10" />
+
+  <rect class="d-node" x="40" y="380" width="160" height="44" rx="8" />
+  <text x="120" y="408" text-anchor="middle">iOS app</text>
+  <rect class="d-node" x="260" y="380" width="160" height="44" rx="8" />
+  <text x="340" y="408" text-anchor="middle">Android app</text>
+  <rect class="d-node" x="480" y="380" width="160" height="44" rx="8" />
+  <text x="560" y="408" text-anchor="middle">Web app</text>
+
+  <path class="d-edge" d="M120 424 V440 H560 V424" />
+  <path class="d-edge" d="M340 424 V440" />
+  <path class="d-edge" d="M340 440 V460" marker-end="url(#pk-arrow)" />
+
+  <rect class="d-node" x="40" y="468" width="600" height="44" rx="8" />
+  <text x="340" y="496" text-anchor="middle">mera</text>
+
+  <path class="d-edge" d="M340 512 V532" marker-end="url(#pk-arrow)" />
+
+  <rect class="d-secret" x="40" y="540" width="600" height="44" rx="8" />
+  <text x="340" y="568" text-anchor="middle">The passkey</text>
+
+  <path class="d-edge" d="M340 584 V604" marker-end="url(#pk-arrow)" />
+
+  <rect class="d-node" x="40" y="612" width="600" height="44" rx="8" />
+  <text x="340" y="640" text-anchor="middle">One account</text>
+</svg>

--- a/docs/src/assets/diagrams/service-held-keys.svg
+++ b/docs/src/assets/diagrams/service-held-keys.svg
@@ -1,0 +1,80 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 680 790"
+  width="680"
+  height="790"
+  role="img"
+  class="mera-diagram"
+>
+  <title>
+    Two ways to reach a signing key. In the first, the device holds the app and
+    a service SDK, and the path leaves the device: over the network sits the
+    service, where an auth server checks the sign-in and the signing key is
+    kept. In the second, the path stays on the device: the app calls mera, mera
+    runs a passkey ceremony, and the app derives keys from what the passkey
+    returns.
+  </title>
+
+  <defs>
+    <marker
+      id="shk-arrow"
+      viewBox="0 0 10 10"
+      refX="8"
+      refY="5"
+      markerWidth="7"
+      markerHeight="7"
+      orient="auto-start-reverse"
+    >
+      <path d="M0 0 L10 5 L0 10 z" class="d-head" />
+    </marker>
+  </defs>
+
+  <rect class="d-zone" x="24" y="24" width="632" height="166" rx="10" />
+  <text x="40" y="46" class="d-sub">on the device</text>
+
+  <rect class="d-node" x="180" y="58" width="320" height="44" rx="8" />
+  <text x="340" y="86" text-anchor="middle">The app</text>
+
+  <path class="d-edge" d="M340 102 V122" marker-end="url(#shk-arrow)" />
+
+  <rect class="d-node" x="180" y="130" width="320" height="44" rx="8" />
+  <text x="340" y="158" text-anchor="middle">The service SDK</text>
+
+  <path class="d-edge" d="M240 194 V242" marker-end="url(#shk-arrow)" />
+  <path class="d-edge" d="M440 242 V194" marker-end="url(#shk-arrow)" />
+  <text x="340" y="224" text-anchor="middle" class="d-sub">
+    over the network
+  </text>
+
+  <rect class="d-zone" x="24" y="250" width="632" height="166" rx="10" />
+  <text x="40" y="272" class="d-sub">in the service</text>
+
+  <rect class="d-node" x="180" y="284" width="320" height="44" rx="8" />
+  <text x="340" y="312" text-anchor="middle">Auth server</text>
+
+  <path class="d-edge" d="M340 328 V348" marker-end="url(#shk-arrow)" />
+
+  <rect class="d-secret" x="180" y="356" width="320" height="44" rx="8" />
+  <text x="340" y="384" text-anchor="middle">The signing key</text>
+
+  <rect class="d-zone" x="24" y="472" width="632" height="310" rx="10" />
+  <text x="40" y="494" class="d-sub">on the device, with mera</text>
+
+  <rect class="d-node" x="180" y="506" width="320" height="44" rx="8" />
+  <text x="340" y="534" text-anchor="middle">The app</text>
+
+  <path class="d-edge" d="M340 550 V570" marker-end="url(#shk-arrow)" />
+
+  <rect class="d-node" x="180" y="578" width="320" height="44" rx="8" />
+  <text x="340" y="606" text-anchor="middle">mera</text>
+
+  <path class="d-edge" d="M340 622 V642" marker-end="url(#shk-arrow)" />
+
+  <rect class="d-secret" x="180" y="650" width="320" height="44" rx="8" />
+  <text x="340" y="678" text-anchor="middle">The passkey</text>
+
+  <path class="d-edge" d="M340 694 V714" marker-end="url(#shk-arrow)" />
+
+  <rect class="d-secret" x="180" y="722" width="320" height="44" rx="8" />
+  <text x="340" y="750" text-anchor="middle">Keys the app derives</text>
+</svg>

--- a/docs/src/content/docs/how-mera-compares.mdx
+++ b/docs/src/content/docs/how-mera-compares.mdx
@@ -1,0 +1,41 @@
+---
+title: How mera compares
+description: Where the signing key comes from in mera, in a service that holds keys, and in a keystore built for each platform.
+---
+
+import PerPlatformKeystores from "../../assets/diagrams/per-platform-keystores.svg";
+import ServiceHeldKeys from "../../assets/diagrams/service-held-keys.svg";
+
+Mera derives keys from a passkey's [PRF output](/concepts/passkeys-and-prf/) and stores none of them. Two other models are common: a service holds a key for each user, or every platform gets a keystore of its own. This page shows where the signing key comes from in each of the three.
+
+## A service that holds the key
+
+<ServiceHeldKeys />
+
+Services that hold keys for an application's users are often called wallet services. The app calls the service's SDK, and the user signs in with an email address, a social account, or a passkey. Services hold the key in different ways, as shares split between the device and the service, or as one key inside a trusted execution environment. In each of them the app reaches the service to sign in and to reach the key.
+
+A passkey in that model is one way to sign in. The key sits elsewhere, so the service governs recovery, and the service is on the path to every signature. The app takes on an account with the service, its API keys, and its uptime, and trust extends to the service and the infrastructure under it.
+
+With mera the passkey returns the key material itself: 32 secret bytes, from a ceremony the authenticator answers on the device. No service stands between the passkey and the signature. Removing the service also removes the recovery it provided, which is why an app that derives [passkey accounts](/concepts/passkey-accounts/) owns its own export path.
+
+## One keystore for each platform
+
+<PerPlatformKeystores />
+
+An app with no shared source of key material stores the key on each platform separately: the iOS Keychain, the Android Keystore, browser storage behind a password. Each one is a separate implementation, with its own backup and its own recovery, and a fourth platform starts from nothing. One account across all of them means the person moves a seed phrase by hand.
+
+Passkeys sync, and their PRF output is stable. The same passkey therefore recomputes the same accounts wherever it syncs, so a web app and its native counterparts under one domain share one account and one code path.
+
+## What mera does not do
+
+- **Recovery.** Accounts derived from a passkey last as long as the passkey does. An export, import, or backup path is the app's to build, and to build before the passkey is gone.
+- **Custody and policy.** Mera signs on the device it runs on. Spending limits, transaction policy, sponsored fees, and server-side signing stay with the app.
+- **Protection from the page.** Keys derived in the page are software keys. Any script running there can read them and can sign with a live session, as the [security model](/concepts/security-model/) sets out.
+- **Universal reach.** PRF is unevenly implemented across authenticators. [Authenticator support](/authenticator-support/) records what works today.
+- **Survival of a domain change.** A passkey works only under the relying party ID it was created for, and derivation cannot be reproduced under another.
+
+## See also
+
+- [Passkey accounts](/concepts/passkey-accounts/): the model this page compares, and what losing the passkey costs.
+- [Security model](/concepts/security-model/): what mera protects, and the risks left to the app.
+- [Getting started](/getting-started/): the path from a passkey to a signature in code.


### PR DESCRIPTION
"How does this compare to Privy?" is now a routine question, and the docs never answered it. Worse, the pairing of "passkey" and "crypto" leads readers to the model they already know: a passkey as the login, with the key held by a service. Nothing on the site corrected that, so every occurrence was answered by hand.

The new page shows three places a signing key can come from, one diagram per alternative model, and ends with what mera leaves to the app.

Two calls that reviewers should weigh in on.

**No vendor is named**, on the page or in the diagrams. Their key handling genuinely differs, so per-vendor claims would need citations and would age as their architectures change. The page states only what the whole category shares: the key path runs through the service. The cost is that a search for "mera vs <vendor>" finds nothing here.

**"Wallet" appears once**, in "Services that hold keys for an application's users are often called wallet services". `docs/AGENTS.md` reserves the word for wallet apps, and I broke that on purpose: a reader who cannot match the page to the term they know will not recognise what is being compared. Every later mention is "the service". Happy to drop the sentence if you would rather hold the line.

The diagrams are 680 wide with their panels stacked, not the side-by-side pair I drafted first: at 1160 wide the content column scales them to 63% and the labels land near 8px. They carry no embedded styles and use only the classes `mera.css` already defines, so they follow the theme like the existing diagrams, and the trade-offs that were footnotes inside the drawing are page prose instead.

![pr-page.png](https://github.com/user-attachments/assets/8e0eba94-58db-4c6e-b698-6c874507f316)
