### PR TITLE
Drop an overclaimed comment about public-key divergence

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -32,8 +32,6 @@ function createSigningKey(
   let activePrivateKey: Uint8Array<ArrayBuffer> | undefined;
 
   try {
-    // Derive and store from the same owned snapshot, so the public key cannot
-    // diverge from the private key later used for signing.
     activePrivateKey = copyBytes(privateKey);
     const publicKey = derivePublicKey(activePrivateKey);
 


### PR DESCRIPTION
## Why

A security review read the comment on `createSigningKey` as a guarantee about the session's whole lifetime: the public key "cannot diverge from the private key later used for signing". Tested against the returned `publicKey` buffer, that promise fails, because a `Uint8Array` cannot be frozen and a caller can write into it.

The comment was the defect. Mutating `session.publicKey` needs same-realm JS execution, which the [security model](docs/src/content/docs/concepts/security-model.mdx) already concedes grants an attacker the strictly stronger powers of signing with any live session and keeping the PRF output a ceremony returns. So this is a wording fix, not a boundary change.

Nothing replaces the comment: the JSDoc directly above already says the function copies the private key into a session-owned snapshot and derives the public key from it. The invariant worth keeping stays pinned by `test/session.test.ts`, whose derive callback mutates the caller's buffer mid-derivation and asserts both keys still match the original.

## Notes for reviewers

We considered and rejected two code changes: making `publicKey` copy on read, and exposing the copy as a method. Both bought protection against a caller mutating its own per-instance buffer, and both cost more than that is worth. Copy-on-read also makes `session.publicKey !== session.publicKey`, a permanent oddity in a documented API.

`DEFAULT_PRF_SALT` does copy at both use sites, which looks inconsistent but is not: it is a module-level singleton where one write corrupts every later derivation, while a session's public key is per-instance state held by the caller who mutated it.