### PR TITLE
Hand the PRF output and secret to Web Crypto uncopied

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -45,8 +45,6 @@ function base64UrlDecode(
 
   let bytes: Uint8Array<ArrayBuffer>;
   try {
-    // The decoder takes a string and allocates its own output, so the buffer
-    // cannot be shared; @scure/base types it as the wider ArrayBufferLike.
     bytes = base64urlnopad.decode(value) as Uint8Array<ArrayBuffer>;
   } catch (cause) {
     throw new MeraError(code, `${name} must be base64url`, { cause });

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -11,17 +11,6 @@ function copyBytes(value: Uint8Array): Uint8Array<ArrayBuffer> {
 }
 
 /**
- * Copies bytes into a standalone `ArrayBuffer` for Web APIs.
- *
- * @internal
- */
-function asArrayBuffer(value: Uint8Array): ArrayBuffer {
-  const output = new ArrayBuffer(value.byteLength);
-  new Uint8Array(output).set(value);
-  return output;
-}
-
-/**
  * Encodes bytes as canonical unpadded base64url.
  *
  * @internal
@@ -51,12 +40,14 @@ function base64UrlDecode(
     byteLength?: number;
     minByteLength?: number;
   } = {},
-): Uint8Array {
+): Uint8Array<ArrayBuffer> {
   const { name = "value", code = "INPUT_INVALID" } = options;
 
-  let bytes: Uint8Array;
+  let bytes: Uint8Array<ArrayBuffer>;
   try {
-    bytes = base64urlnopad.decode(value);
+    // The decoder takes a string and allocates its own output, so the buffer
+    // cannot be shared; @scure/base types it as the wider ArrayBufferLike.
+    bytes = base64urlnopad.decode(value) as Uint8Array<ArrayBuffer>;
   } catch (cause) {
     throw new MeraError(code, `${name} must be base64url`, { cause });
   }
@@ -78,4 +69,4 @@ function base64UrlDecode(
   return bytes;
 }
 
-export { asArrayBuffer, base64UrlDecode, base64UrlEncode, copyBytes };
+export { base64UrlDecode, base64UrlEncode, copyBytes };

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -227,8 +227,6 @@ async function getPasskeyPrfOutput({
       throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
     }
 
-    // The salt is caller-owned and DEFAULT_PRF_SALT is shared across calls, so
-    // the ceremony gets a copy either way.
     const prf = {
       eval: { first: copyBytes(prfSalt ?? DEFAULT_PRF_SALT) },
     };

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -1,11 +1,6 @@
 import { sha256 } from "@noble/hashes/sha2.js";
 import { utf8ToBytes } from "@noble/hashes/utils.js";
-import {
-  asArrayBuffer,
-  base64UrlDecode,
-  base64UrlEncode,
-  copyBytes,
-} from "./encoding.js";
+import { base64UrlDecode, base64UrlEncode, copyBytes } from "./encoding.js";
 import { isMeraError, MeraError } from "./errors.js";
 import type {
   CreatePasskeyWithPrfOutputResult,
@@ -119,11 +114,11 @@ async function createPasskeyWithPrfOutput({
       publicKey: {
         rp,
         user: {
-          id: asArrayBuffer(randomBytes(32)),
+          id: randomBytes(32),
           name: user.name,
           displayName: user.displayName,
         },
-        challenge: asArrayBuffer(randomBytes(32)),
+        challenge: randomBytes(32),
         pubKeyCredParams: [
           { type: "public-key", alg: -7 },
           { type: "public-key", alg: -257 },
@@ -136,7 +131,7 @@ async function createPasskeyWithPrfOutput({
           userVerification: "required",
         },
         extensions: {
-          prf: { eval: { first: asArrayBuffer(prfSaltCopy) } },
+          prf: { eval: { first: prfSaltCopy } },
         },
       },
     });
@@ -232,13 +227,15 @@ async function getPasskeyPrfOutput({
       throw new MeraError("INPUT_INVALID", "PRF salt must be 32 bytes");
     }
 
+    // The salt is caller-owned and DEFAULT_PRF_SALT is shared across calls, so
+    // the ceremony gets a copy either way.
     const prf = {
-      eval: { first: asArrayBuffer(prfSalt ?? DEFAULT_PRF_SALT) },
+      eval: { first: copyBytes(prfSalt ?? DEFAULT_PRF_SALT) },
     };
 
     const publicKey: PublicKeyCredentialRequestOptions = {
       rpId,
-      challenge: asArrayBuffer(randomBytes(32)),
+      challenge: randomBytes(32),
       ...(timeout !== undefined ? { timeout } : {}),
       userVerification: "required",
       extensions: { prf },
@@ -253,12 +250,10 @@ async function getPasskeyPrfOutput({
       // https://www.w3.org/TR/webauthn-3/#credential-id
       publicKey.allowCredentials = [
         {
-          id: asArrayBuffer(
-            base64UrlDecode(allowCredential.credentialId, {
-              name: "credential.credentialId",
-              minByteLength: 1,
-            }),
-          ),
+          id: base64UrlDecode(allowCredential.credentialId, {
+            name: "credential.credentialId",
+            minByteLength: 1,
+          }),
           type: "public-key",
           ...(allowCredential.transports !== undefined
             ? {

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -1,10 +1,5 @@
 import { utf8ToBytes } from "@noble/hashes/utils.js";
-import {
-  asArrayBuffer,
-  base64UrlDecode,
-  base64UrlEncode,
-  copyBytes,
-} from "./encoding.js";
+import { base64UrlDecode, base64UrlEncode, copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
 import type {
   CreatePasskeyWithPrfOutputOptions,
@@ -31,7 +26,7 @@ const GCM_TAG_LENGTH = 16;
 
 // HKDF info keeps the encryption key distinct from any other key derived from
 // the same PRF output.
-const SECRET_ENCRYPTION_INFO = utf8ToBytes("mera.v1.encrypt.secret");
+const SECRET_ENCRYPTION_INFO = copyBytes(utf8ToBytes("mera.v1.encrypt.secret"));
 
 // Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256.
 // prfOutput reaches importKey uncopied, so the caller's zeroing covers every
@@ -58,7 +53,7 @@ async function deriveEncryptionKey(
       name: "HKDF",
       hash: "SHA-256",
       salt: new Uint8Array(0),
-      info: asArrayBuffer(SECRET_ENCRYPTION_INFO),
+      info: SECRET_ENCRYPTION_INFO,
     },
     material,
     {
@@ -323,10 +318,10 @@ async function decryptSecretVault({
     const plaintext = await crypto.subtle.decrypt(
       {
         name: "AES-GCM",
-        iv: asArrayBuffer(nonce),
+        iv: nonce,
       },
       encryptionKey,
-      asArrayBuffer(ciphertext),
+      ciphertext,
     );
     return new Uint8Array(plaintext);
   } catch (error) {

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -33,37 +33,26 @@ const GCM_TAG_LENGTH = 16;
 // the same PRF output.
 const SECRET_ENCRYPTION_INFO = utf8ToBytes("mera.v1.encrypt.secret");
 
-/**
- * Passes a standalone `ArrayBuffer` copy of `value` to `use`, then zeroes the
- * copy.
- *
- * Web Crypto reads a `BufferSource` argument into its own copy synchronously,
- * before the returned promise settles, so zeroing after the await cannot race
- * the operation.
- */
-async function withSecretArrayBuffer<T>(
-  value: Uint8Array,
-  use: (buffer: ArrayBuffer) => Promise<T>,
-): Promise<T> {
-  const buffer = asArrayBuffer(value);
-
-  try {
-    return await use(buffer);
-  } finally {
-    new Uint8Array(buffer).fill(0);
-  }
-}
-
 // Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256. The
 // 32-byte check validates the key material before it reaches HKDF.
-async function deriveEncryptionKey(prfOutput: Uint8Array): Promise<CryptoKey> {
+//
+// prfOutput reaches importKey uncopied so that the caller's zeroing covers
+// every buffer holding these bytes. importKey reads the buffer before its
+// promise settles, so a later fill cannot race the import.
+async function deriveEncryptionKey(
+  prfOutput: Uint8Array<ArrayBuffer>,
+): Promise<CryptoKey> {
   if (prfOutput.length !== 32) {
     throw new MeraError("INPUT_INVALID", "PRF output must be 32 bytes");
   }
 
   const crypto = getCrypto();
-  const material = await withSecretArrayBuffer(prfOutput, (keyData) =>
-    crypto.subtle.importKey("raw", keyData, "HKDF", false, ["deriveKey"]),
+  const material = await crypto.subtle.importKey(
+    "raw",
+    prfOutput,
+    "HKDF",
+    false,
+    ["deriveKey"],
   );
 
   return crypto.subtle.deriveKey(
@@ -116,7 +105,7 @@ type CreateSecretVaultOptions = {
   /** Credential metadata plus the PRF salt and PRF output that key this secret. */
   credential: CreatePasskeyWithPrfOutputResult;
   /** Secret bytes to encrypt. */
-  secret: Uint8Array;
+  secret: Uint8Array<ArrayBuffer>;
 };
 
 /**
@@ -145,17 +134,15 @@ async function createSecretVault({
   const encryptionKey = await deriveEncryptionKey(credential.prfOutput);
 
   // The GCM nonce is generated internally so callers cannot accidentally reuse
-  // one.
+  // one. secret reaches encrypt uncopied, like the PRF output above.
   const nonce = randomBytes(NONCE_LENGTH);
-  const ciphertext = await withSecretArrayBuffer(secret, (data) =>
-    getCrypto().subtle.encrypt(
-      {
-        name: "AES-GCM",
-        iv: asArrayBuffer(nonce),
-      },
-      encryptionKey,
-      data,
-    ),
+  const ciphertext = await getCrypto().subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv: nonce,
+    },
+    encryptionKey,
+    secret,
   );
 
   return {
@@ -307,7 +294,7 @@ type DecryptSecretVaultOptions = {
   /** Secret vault to decrypt. */
   vault: PasskeySecretVault;
   /** WebAuthn PRF output for the vault's PRF salt. Must be exactly 32 bytes. */
-  prfOutput: Uint8Array;
+  prfOutput: Uint8Array<ArrayBuffer>;
 };
 
 /**

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -33,12 +33,10 @@ const GCM_TAG_LENGTH = 16;
 // the same PRF output.
 const SECRET_ENCRYPTION_INFO = utf8ToBytes("mera.v1.encrypt.secret");
 
-// Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256. The
-// 32-byte check validates the key material before it reaches HKDF.
-//
-// prfOutput reaches importKey uncopied so that the caller's zeroing covers
-// every buffer holding these bytes. importKey reads the buffer before its
-// promise settles, so a later fill cannot race the import.
+// Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256.
+// prfOutput reaches importKey uncopied, so the caller's zeroing covers every
+// buffer holding these bytes; importKey reads it before its promise settles,
+// so a later fill cannot race the import.
 async function deriveEncryptionKey(
   prfOutput: Uint8Array<ArrayBuffer>,
 ): Promise<CryptoKey> {
@@ -119,8 +117,8 @@ type CreateSecretVaultOptions = {
  * vaults encrypted with one reused PRF output share an encryption key, so each
  * secret needs a fresh salt.
  *
- * Inputs arrive validated and caller-owned; callers own the pre-ceremony
- * snapshots and the zeroing.
+ * Inputs arrive validated and caller-owned, and reach Web Crypto in place;
+ * callers own the pre-ceremony snapshots and the zeroing.
  *
  * @returns A JSON-safe secret vault.
  * @throws MeraError with code `INPUT_INVALID` when the PRF output is not 32 bytes.
@@ -134,7 +132,7 @@ async function createSecretVault({
   const encryptionKey = await deriveEncryptionKey(credential.prfOutput);
 
   // The GCM nonce is generated internally so callers cannot accidentally reuse
-  // one. secret reaches encrypt uncopied, like the PRF output above.
+  // one. secret reaches encrypt uncopied, so the caller's zeroing covers it.
   const nonce = randomBytes(NONCE_LENGTH);
   const ciphertext = await getCrypto().subtle.encrypt(
     {

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -1,4 +1,3 @@
-import { utf8ToBytes } from "@noble/hashes/utils.js";
 import { base64UrlDecode, base64UrlEncode, copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
 import type {
@@ -26,12 +25,14 @@ const GCM_TAG_LENGTH = 16;
 
 // HKDF info keeps the encryption key distinct from any other key derived from
 // the same PRF output.
-const SECRET_ENCRYPTION_INFO = copyBytes(utf8ToBytes("mera.v1.encrypt.secret"));
+const SECRET_ENCRYPTION_INFO = new TextEncoder().encode(
+  "mera.v1.encrypt.secret",
+);
 
 // Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256.
-// prfOutput reaches importKey uncopied, so the caller's zeroing covers every
-// buffer holding these bytes; importKey reads it before its promise settles,
-// so a later fill cannot race the import.
+// prfOutput reaches importKey uncopied, so this adds no buffer for the caller
+// to zero; importKey reads it before its promise settles, so a later fill
+// cannot race the import.
 async function deriveEncryptionKey(
   prfOutput: Uint8Array<ArrayBuffer>,
 ): Promise<CryptoKey> {
@@ -126,9 +127,11 @@ async function createSecretVault({
 }: CreateSecretVaultOptions): Promise<PasskeySecretVault> {
   const encryptionKey = await deriveEncryptionKey(credential.prfOutput);
 
-  // The GCM nonce is generated internally so callers cannot accidentally reuse
-  // one. secret reaches encrypt uncopied, so the caller's zeroing covers it.
+  // Generated internally so callers cannot accidentally reuse one.
   const nonce = randomBytes(NONCE_LENGTH);
+
+  // secret reaches encrypt uncopied, so this adds no buffer for the caller to
+  // zero.
   const ciphertext = await getCrypto().subtle.encrypt(
     {
       name: "AES-GCM",

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -220,8 +220,6 @@ async function createSecretVaultWithNewPasskey({
 
     return await createSecretVault({ credential, secret: secretCopy });
   } finally {
-    // Web Crypto reads a BufferSource into its own copy before its promise
-    // settles, so filling these after the await cannot race the encryption.
     secretCopy.fill(0);
     prfOutput?.fill(0);
   }

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -30,9 +30,6 @@ const SECRET_ENCRYPTION_INFO = new TextEncoder().encode(
 );
 
 // Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256.
-// prfOutput reaches importKey uncopied, so this adds no buffer for the caller
-// to zero; importKey reads it before its promise settles, so a later fill
-// cannot race the import.
 async function deriveEncryptionKey(
   prfOutput: Uint8Array<ArrayBuffer>,
 ): Promise<CryptoKey> {
@@ -113,8 +110,8 @@ type CreateSecretVaultOptions = {
  * vaults encrypted with one reused PRF output share an encryption key, so each
  * secret needs a fresh salt.
  *
- * Inputs arrive validated and caller-owned, and reach Web Crypto in place;
- * callers own the pre-ceremony snapshots and the zeroing.
+ * Inputs arrive validated and caller-owned; callers own the pre-ceremony
+ * snapshots and the zeroing.
  *
  * @returns A JSON-safe secret vault.
  * @throws MeraError with code `INPUT_INVALID` when the PRF output is not 32 bytes.
@@ -127,11 +124,10 @@ async function createSecretVault({
 }: CreateSecretVaultOptions): Promise<PasskeySecretVault> {
   const encryptionKey = await deriveEncryptionKey(credential.prfOutput);
 
-  // Generated internally so callers cannot accidentally reuse one.
+  // The GCM nonce is generated internally so callers cannot accidentally reuse
+  // one.
   const nonce = randomBytes(NONCE_LENGTH);
 
-  // secret reaches encrypt uncopied, so this adds no buffer for the caller to
-  // zero.
   const ciphertext = await getCrypto().subtle.encrypt(
     {
       name: "AES-GCM",
@@ -224,6 +220,8 @@ async function createSecretVaultWithNewPasskey({
 
     return await createSecretVault({ credential, secret: secretCopy });
   } finally {
+    // Web Crypto reads a BufferSource into its own copy before its promise
+    // settles, so filling these after the await cannot race the encryption.
     secretCopy.fill(0);
     prfOutput?.fill(0);
   }

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -33,21 +33,37 @@ const GCM_TAG_LENGTH = 16;
 // the same PRF output.
 const SECRET_ENCRYPTION_INFO = utf8ToBytes("mera.v1.encrypt.secret");
 
-// Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256.
-// asArrayBuffer snapshots the output before importKey's first await, preserving
-// the public copy guarantee while the 32-byte check validates the key material.
+/**
+ * Passes a standalone `ArrayBuffer` copy of `value` to `use`, then zeroes the
+ * copy.
+ *
+ * Web Crypto reads a `BufferSource` argument into its own copy synchronously,
+ * before the returned promise settles, so zeroing after the await cannot race
+ * the operation.
+ */
+async function withSecretArrayBuffer<T>(
+  value: Uint8Array,
+  use: (buffer: ArrayBuffer) => Promise<T>,
+): Promise<T> {
+  const buffer = asArrayBuffer(value);
+
+  try {
+    return await use(buffer);
+  } finally {
+    new Uint8Array(buffer).fill(0);
+  }
+}
+
+// Derives the non-extractable AES-256-GCM vault key with HKDF-SHA-256. The
+// 32-byte check validates the key material before it reaches HKDF.
 async function deriveEncryptionKey(prfOutput: Uint8Array): Promise<CryptoKey> {
   if (prfOutput.length !== 32) {
     throw new MeraError("INPUT_INVALID", "PRF output must be 32 bytes");
   }
 
   const crypto = getCrypto();
-  const material = await crypto.subtle.importKey(
-    "raw",
-    asArrayBuffer(prfOutput),
-    "HKDF",
-    false,
-    ["deriveKey"],
+  const material = await withSecretArrayBuffer(prfOutput, (keyData) =>
+    crypto.subtle.importKey("raw", keyData, "HKDF", false, ["deriveKey"]),
   );
 
   return crypto.subtle.deriveKey(
@@ -114,8 +130,8 @@ type CreateSecretVaultOptions = {
  * vaults encrypted with one reused PRF output share an encryption key, so each
  * secret needs a fresh salt.
  *
- * Inputs arrive validated and caller-owned. Byte inputs are read in place and
- * never zeroed here; callers own the pre-ceremony snapshots and the zeroing.
+ * Inputs arrive validated and caller-owned; callers own the pre-ceremony
+ * snapshots and the zeroing.
  *
  * @returns A JSON-safe secret vault.
  * @throws MeraError with code `INPUT_INVALID` when the PRF output is not 32 bytes.
@@ -128,16 +144,18 @@ async function createSecretVault({
 }: CreateSecretVaultOptions): Promise<PasskeySecretVault> {
   const encryptionKey = await deriveEncryptionKey(credential.prfOutput);
 
-  // subtle.encrypt copies its inputs synchronously; the GCM nonce is generated
-  // internally so callers cannot accidentally reuse one.
+  // The GCM nonce is generated internally so callers cannot accidentally reuse
+  // one.
   const nonce = randomBytes(NONCE_LENGTH);
-  const ciphertext = await getCrypto().subtle.encrypt(
-    {
-      name: "AES-GCM",
-      iv: asArrayBuffer(nonce),
-    },
-    encryptionKey,
-    asArrayBuffer(secret),
+  const ciphertext = await withSecretArrayBuffer(secret, (data) =>
+    getCrypto().subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv: asArrayBuffer(nonce),
+      },
+      encryptionKey,
+      data,
+    ),
   );
 
   return {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -31,7 +31,9 @@ function stubPublicKeyCredential({
   };
 }
 
-// Reads the PRF salt a stubbed WebAuthn call was asked to evaluate.
+// Reads the PRF salt a stubbed WebAuthn call was asked to evaluate. The salt
+// arrives as the library's own live buffer, so the read is a copy: a caller
+// that mutates a returned prfSalt must not change what a stub already recorded.
 function readEvaluatedPrfSalt(
   publicKey:
     | PublicKeyCredentialRequestOptions
@@ -39,8 +41,8 @@ function readEvaluatedPrfSalt(
     | undefined,
 ): Uint8Array<ArrayBuffer> {
   const first = publicKey?.extensions?.prf?.eval?.first;
-  if (!(first instanceof ArrayBuffer)) {
-    throw new Error("expected PRF salt as an ArrayBuffer");
+  if (!(first instanceof Uint8Array)) {
+    throw new Error("expected PRF salt as a Uint8Array");
   }
   return new Uint8Array(first);
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -37,7 +37,7 @@ function readEvaluatedPrfSalt(
     | PublicKeyCredentialRequestOptions
     | PublicKeyCredentialCreationOptions
     | undefined,
-): Uint8Array {
+): Uint8Array<ArrayBuffer> {
   const first = publicKey?.extensions?.prf?.eval?.first;
   if (!(first instanceof ArrayBuffer)) {
     throw new Error("expected PRF salt as an ArrayBuffer");

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -248,13 +248,11 @@ test("passkey helpers generate internal challenges and request no attestation", 
     throw new Error("expected WebAuthn options to be captured");
   }
 
-  expect(createOptions.challenge).toBeInstanceOf(ArrayBuffer);
-  expect(new Uint8Array(createOptions.challenge as ArrayBuffer)).toHaveLength(
-    32,
-  );
+  expect(createOptions.challenge).toBeInstanceOf(Uint8Array);
+  expect(createOptions.challenge as Uint8Array).toHaveLength(32);
   expect(createOptions.attestation).toBe("none");
-  expect(getOptions.challenge).toBeInstanceOf(ArrayBuffer);
-  expect(new Uint8Array(getOptions.challenge as ArrayBuffer)).toHaveLength(32);
+  expect(getOptions.challenge).toBeInstanceOf(Uint8Array);
+  expect(getOptions.challenge as Uint8Array).toHaveLength(32);
 });
 
 test("createPasskeyWithPrfOutput generates a fresh user handle per call", async () => {
@@ -266,7 +264,7 @@ test("createPasskeyWithPrfOutput generates a fresh user handle per call", async 
   const navigator = {
     credentials: {
       async create({ publicKey }: CredentialCreationOptions) {
-        handles.push(new Uint8Array(publicKey?.user.id as ArrayBuffer));
+        handles.push(new Uint8Array(publicKey?.user.id as Uint8Array));
         return stubPublicKeyCredential({
           prf: {
             enabled: true,

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -274,6 +274,57 @@ test("secret vault helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavaila
   });
 });
 
+test("zeroes the secret copies handed to Web Crypto", async () => {
+  const real = globalThis.crypto;
+  // Every buffer the library hands to Web Crypto carrying PRF output or
+  // plaintext. Nonces and the HKDF info arrive as algorithm fields, not as the
+  // captured arguments, so they stay out of the assertion.
+  const captured: ArrayBuffer[] = [];
+  const capturing = {
+    getRandomValues: real.getRandomValues.bind(real),
+    subtle: {
+      deriveKey: real.subtle.deriveKey.bind(real.subtle),
+      decrypt: real.subtle.decrypt.bind(real.subtle),
+      importKey(
+        format: "raw",
+        keyData: ArrayBuffer,
+        algorithm: "HKDF",
+        extractable: boolean,
+        usages: KeyUsage[],
+      ) {
+        captured.push(keyData);
+        return real.subtle.importKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          usages,
+        );
+      },
+      encrypt(algorithm: AesGcmParams, key: CryptoKey, data: ArrayBuffer) {
+        captured.push(data);
+        return real.subtle.encrypt(algorithm, key, data);
+      },
+    },
+  };
+
+  await withStubbedGlobal("crypto", capturing, async () => {
+    const vault = await createTestVault();
+
+    await expect(
+      decryptSecretVault({ vault, prfOutput: PRF_OUTPUT }),
+    ).resolves.toEqual(SECRET);
+  });
+
+  // One PRF-output import per key derivation (encrypting, then decrypting) plus
+  // the plaintext handed to encrypt.
+  expect(captured.length).toBe(3);
+
+  for (const buffer of captured) {
+    expect(new Uint8Array(buffer)).toEqual(new Uint8Array(buffer.byteLength));
+  }
+});
+
 test("secret vault encryption is independent of credential metadata and PRF salt", async () => {
   const vault = await createTestVault();
   const edited = parseSecretVault({

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -25,12 +25,14 @@ const PRF_OUTPUT = new Uint8Array(32).fill(7);
 const PRF_SALT = new Uint8Array(32).fill(9);
 // A real 12-word BIP-39 phrase stands in for an opaque secret; the library
 // neither knows nor cares that these bytes are a mnemonic.
-const SECRET = utf8ToBytes(
-  "legal winner thank year wave sausage worth useful legal winner thank yellow",
+const SECRET = new Uint8Array(
+  utf8ToBytes(
+    "legal winner thank year wave sausage worth useful legal winner thank yellow",
+  ),
 );
 
 async function createTestVault(
-  secret: Uint8Array = SECRET,
+  secret: Uint8Array<ArrayBuffer> = SECRET,
 ): Promise<PasskeySecretVault> {
   return createSecretVault({
     credential: {
@@ -133,7 +135,7 @@ test("createSecretVaultWithNewPasskey owns a random salt and snapshots the secre
   const creationGate = new Promise<void>((resolve) => {
     releaseCreation = resolve;
   });
-  let evaluatedSalt: Uint8Array | undefined;
+  let evaluatedSalt: Uint8Array<ArrayBuffer> | undefined;
 
   const navigator = {
     credentials: {
@@ -185,7 +187,7 @@ test("createSecretVaultWithExistingPasskey snapshots inputs and preserves transp
   const assertionGate = new Promise<void>((resolve) => {
     releaseAssertion = resolve;
   });
-  let evaluatedSalt: Uint8Array | undefined;
+  let evaluatedSalt: Uint8Array<ArrayBuffer> | undefined;
 
   const navigator = {
     credentials: {
@@ -274,12 +276,12 @@ test("secret vault helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavaila
   });
 });
 
-test("zeroes the secret copies handed to Web Crypto", async () => {
+test("zeroes every buffer handed to Web Crypto", async () => {
   const real = globalThis.crypto;
   // Every buffer the library hands to Web Crypto carrying PRF output or
   // plaintext. Nonces and the HKDF info arrive as algorithm fields, not as the
   // captured arguments, so they stay out of the assertion.
-  const captured: ArrayBuffer[] = [];
+  const captured: Uint8Array[] = [];
   const capturing = {
     getRandomValues: real.getRandomValues.bind(real),
     subtle: {
@@ -287,7 +289,7 @@ test("zeroes the secret copies handed to Web Crypto", async () => {
       decrypt: real.subtle.decrypt.bind(real.subtle),
       importKey(
         format: "raw",
-        keyData: ArrayBuffer,
+        keyData: Uint8Array<ArrayBuffer>,
         algorithm: "HKDF",
         extractable: boolean,
         usages: KeyUsage[],
@@ -301,19 +303,50 @@ test("zeroes the secret copies handed to Web Crypto", async () => {
           usages,
         );
       },
-      encrypt(algorithm: AesGcmParams, key: CryptoKey, data: ArrayBuffer) {
+      encrypt(
+        algorithm: AesGcmParams,
+        key: CryptoKey,
+        data: Uint8Array<ArrayBuffer>,
+      ) {
         captured.push(data);
         return real.subtle.encrypt(algorithm, key, data);
       },
     },
   };
 
-  await withStubbedGlobal("crypto", capturing, async () => {
-    const vault = await createTestVault();
+  // The orchestrators own the zeroing, so the assertion runs against them
+  // rather than against createSecretVault and decryptSecretVault, whose inputs
+  // stay caller-owned.
+  const navigator = {
+    credentials: {
+      async create({ publicKey }: CredentialCreationOptions) {
+        const prfSalt = readEvaluatedPrfSalt(publicKey);
+        return stubPublicKeyCredential({
+          prf: { enabled: true, results: { first: prfSalt.buffer } },
+          transports: ["internal"],
+        });
+      },
+      async get({ publicKey }: CredentialRequestOptions) {
+        const prfSalt = readEvaluatedPrfSalt(publicKey);
+        return stubPublicKeyCredential({
+          prf: { results: { first: prfSalt.buffer } },
+        });
+      },
+    },
+  };
 
-    await expect(
-      decryptSecretVault({ vault, prfOutput: PRF_OUTPUT }),
-    ).resolves.toEqual(SECRET);
+  await withStubbedGlobal("navigator", navigator, async () => {
+    await withStubbedGlobal("crypto", capturing, async () => {
+      const vault = await createSecretVaultWithNewPasskey({
+        rp: { id: "example.com", name: "Mera Test" },
+        user: { name: "nad", displayName: "nad" },
+        secret: SECRET,
+      });
+
+      await expect(
+        decryptSecretVaultWithPasskey({ rpId: "example.com", vault }),
+      ).resolves.toEqual(SECRET);
+    });
   });
 
   // One PRF-output import per key derivation (encrypting, then decrypting) plus
@@ -321,7 +354,7 @@ test("zeroes the secret copies handed to Web Crypto", async () => {
   expect(captured.length).toBe(3);
 
   for (const buffer of captured) {
-    expect(new Uint8Array(buffer)).toEqual(new Uint8Array(buffer.byteLength));
+    expect(buffer).toEqual(new Uint8Array(buffer.byteLength));
   }
 });
 

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -1,4 +1,3 @@
-import { utf8ToBytes } from "@noble/hashes/utils.js";
 import { expect, test } from "@playwright/test";
 import type {
   PasskeyCredentialTransport,
@@ -25,10 +24,8 @@ const PRF_OUTPUT = new Uint8Array(32).fill(7);
 const PRF_SALT = new Uint8Array(32).fill(9);
 // A real 12-word BIP-39 phrase stands in for an opaque secret; the library
 // neither knows nor cares that these bytes are a mnemonic.
-const SECRET = new Uint8Array(
-  utf8ToBytes(
-    "legal winner thank year wave sausage worth useful legal winner thank yellow",
-  ),
+const SECRET = new TextEncoder().encode(
+  "legal winner thank year wave sausage worth useful legal winner thank yellow",
 );
 
 async function createTestVault(

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -276,11 +276,10 @@ test("secret vault helpers report CRYPTO_UNAVAILABLE when Web Crypto is unavaila
   });
 });
 
-test("zeroes every buffer handed to Web Crypto", async () => {
+test("zeroes the PRF output and secret handed to Web Crypto", async () => {
   const real = globalThis.crypto;
-  // Every buffer the library hands to Web Crypto carrying PRF output or
-  // plaintext. Nonces and the HKDF info arrive as algorithm fields, not as the
-  // captured arguments, so they stay out of the assertion.
+  // Nonces and the HKDF info reach Web Crypto as algorithm fields rather than
+  // as these arguments, and are public values that stay unzeroed.
   const captured: Uint8Array[] = [];
   const capturing = {
     getRandomValues: real.getRandomValues.bind(real),


### PR DESCRIPTION
#281 states a boundary: mera zeroes every sensitive buffer it allocates. The code did not hold to it.

`asArrayBuffer` copied the root PRF output and the plaintext secret one frame below the `finally` blocks that zeroed the originals, and left the copies there. The PRF-output copy was made on every vault create and every decrypt. Zeroing those copies would have been the wrong fix: Web Crypto reads a `BufferSource` before its promise settles, so the snapshot guarded nothing. The copies were the bug.

`asArrayBuffer` existed for a type error. `BufferSource` rejects a bare `Uint8Array`, because that now means `Uint8Array<ArrayBufferLike>` and admits `SharedArrayBuffer`; `Uint8Array<ArrayBuffer>` is accepted. `randomBytes`, `copyBytes`, and `prfOutput` already carry the narrow type, and only two internal signatures widened it back. Narrowing them lets both values reach Web Crypto as the buffers the orchestrators already zero.

Deleting the helper is what stops the boundary breaking the same way again: nothing at a call site separated a copy that was wanted from one that only fixed a type, so the mistake stayed one line away from every call. `copyBytes` stays at the two boundaries where the copy is the point.

Context the diff does not carry:

- Both narrowed types sit behind the `.` and `./viem` exports, so no public signature changes.
- Restoring either `asArrayBuffer` call makes the new test fail and leaves the rest of the suite green. It drives the orchestrators, which own the zeroing, not `createSecretVault` and `decryptSecretVault`, whose inputs stay caller-owned.
- The ceremony arguments are safe uncopied for the same reason the PRF output is: challenges and user handles are fresh buffers no one else holds. The PRF salt still gets a copy, because `DEFAULT_PRF_SALT` is shared across calls.
- `base64UrlDecode` is the one dependency type left to bridge. Its decoder allocates from a string, so the output cannot be backed by a `SharedArrayBuffer`, and its return type now says so.
- #281 stacks on this and needs to merge this head again.

Squash on merge. The first commit zeroed the copies instead of removing them; it is kept so the review reads in order.
