### PR TITLE
docs: state what zeroing bounds and what it does not

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,11 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 - Preserve runtime validation at cryptographic, string, wire, and untrusted JSON boundaries. Avoid "perfect validation" of typed internal invariants that TypeScript or a dependency already owns.
 - Keep object-parameter APIs when the operation is likely to gain optional parameters or when named fields make security-sensitive inputs harder to mix up.
 
+### Secret Handling
+
+- Zero buffers the library allocated. Inputs belong to the caller, and so are the returned buffers.
+- Treat zeroing as a bound on secret lifetime and reachability, not as erasure from the process. Documentation must not claim more.
+
 ### Documentation and Examples
 
 - Documentation prose is technical writing held to a hard bar: simple, concise, and detailed at once. Every sentence must add information; cut sentences that only set up, restate, or editorialize on what adjacent sentences already show.

--- a/docs/src/content/docs/concepts/security-model.mdx
+++ b/docs/src/content/docs/concepts/security-model.mdx
@@ -18,6 +18,14 @@ The library host decides who can reach those bytes. In a web page, every script 
 
 <TrustBoundary />
 
+## Zeroing
+
+mera zeroes every sensitive buffer it allocates after it no longer needs it. Input buffers belong to the caller and so are buffers returned by mera.
+
+Zeroing bounds how long key material stays readable. It reduces the chance that a key appears in a crash dump, a swap or hibernation file, a heap snapshot, or an error report that serializes the object graph.
+
+A zeroed buffer is not proof the bytes left the process. Garbage collection copies values, dependencies may convert private keys to immutable bigint scalars while signing, etc. Also, the behaviour may differ between JavaScript engines. Zeroing is a defense-in-depth measure, not a guarantee.
+
 ## See also
 
 - [Passkeys and the PRF extension](/concepts/passkeys-and-prf/)

--- a/docs/src/content/docs/concepts/signing-sessions.mdx
+++ b/docs/src/content/docs/concepts/signing-sessions.mdx
@@ -38,3 +38,4 @@ An app that signs frequently may keep the session for a burst of work and end it
 - [Secp256k1SigningSession](/reference/secp256k1-signing-session/) and [Ed25519SigningSession](/reference/ed25519-signing-session/): what a live session exposes.
 - [toViemAccount](/reference/to-viem-account/): a viem account backed by a secp256k1 session.
 - [Getting started](/getting-started/): the ceremony-to-signature path in code.
+- [Security model](/concepts/security-model/#zeroing): learn about mera's security model.


### PR DESCRIPTION
Secret vaults sent readers to the security model for "zeroing, salts, and what the library cannot protect", and the page never mentioned zeroing.

Stacked on #280 so the page does not describe unshipped behavior. Retarget to `main` when that merges.

Review focus: the section claims mera zeroes every sensitive buffer it allocates. #280 is what makes that true.

#280 changed approach after review, so the second commit here merges its new head and corrects the list. "The copies it hands to Web Crypto" is gone, because there are no longer any; the secret snapshot the orchestrators take before a ceremony is added, because it is a library allocation they zero and the list had missed it. The AGENTS.md rule that keeps the copies from returning is new.


Review added a merge and one commit.

"Web Crypto reads those buffers in place, so no copy of them outlives the call" claimed more than #280 earns. Web Crypto copies the bytes it reads, and for `importKey` that copy becomes the `CryptoKey`, which outlives the call by design. The narrower claim is the one #280 established: the buffers reach Web Crypto uncopied, so the ones mera zeroes are the ones it holds.

The scope sentences covered buffers mera receives from a caller and returns to one, and left out the buffers neither side allocates. A ceremony hands back the PRF output in a browser-owned buffer that `copyPrfOutput` reads and cannot reliably clear. That is the largest copy the page did not account for, and "every sensitive buffer it allocates" sends a reader looking for it.

The Web Crypto rule now names the type to carry instead of a copy, because deleting `asArrayBuffer` leaves the boundary asking for one. It stops at Web Crypto: WebAuthn's read timing is not specified as synchronous, and the ceremony arguments are public values, so no secret rule rests on it.
