### PR TITLE
Add Symbol.dispose to the PRF result types

### DIFF
--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -63,6 +63,8 @@ WebAuthn timeout in milliseconds, applied to each ceremony.
 
 `Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`.
 
+Disposing the result zeroes `prfOutput`, so a `using` declaration clears it when its scope exits. `prfSalt` stays readable, because a vault stores it. Destructuring the result drops the disposal member, and the `prfOutput` binding then lives as long as the caller keeps it.
+
 ## Errors
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not enable PRF, or did not return PRF output on the fallback ceremony.

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -55,6 +55,8 @@ WebAuthn timeout in milliseconds.
 
 `Promise<PasskeyPrfResult>`: the `credentialId` the browser actually selected (canonical unpadded base64url) and the 32-byte `prfOutput`. When `credential` was omitted, the person picks the passkey in the browser UI, so the returned ID can name a different credential than the app expected.
 
+Disposing the result zeroes `prfOutput`, so a `using` declaration clears it when its scope exits. Destructuring the result drops the disposal member, and the `prfOutput` binding then lives as long as the caller keeps it.
+
 ## Errors
 
 - [`PRF_UNAVAILABLE`](/reference/errors/#prf_unavailable): the authenticator did not return a usable 32-byte PRF output.

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -177,6 +177,9 @@ async function createPasskeyWithPrfOutput({
       ...credentialMetadata,
       prfSalt: prfSaltCopy,
       prfOutput,
+      [Symbol.dispose]: () => {
+        prfOutput.fill(0);
+      },
     };
   } catch (error) {
     if (isMeraError(error)) {
@@ -286,9 +289,14 @@ async function getPasskeyPrfOutput({
       );
     }
 
+    const prfOutput = copyPrfOutput(first);
+
     return {
       credentialId: base64UrlEncode(new Uint8Array(publicKeyCredential.rawId)),
-      prfOutput: copyPrfOutput(first),
+      prfOutput,
+      [Symbol.dispose]: () => {
+        prfOutput.fill(0);
+      },
     };
   } catch (error) {
     if (isMeraError(error)) {

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -16,7 +16,7 @@ import {
   toCredentialMetadata,
 } from "./passkey.js";
 import type {
-  CreatePasskeyWithPrfOutputResult,
+  PasskeyCredentialMetadata,
   PasskeyCredentialTransport,
   PasskeySecretVault,
 } from "./types.js";
@@ -97,8 +97,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 /** Inputs for `createSecretVault`. */
 type CreateSecretVaultOptions = {
-  /** Credential metadata plus the PRF salt and PRF output that key this secret. */
-  credential: CreatePasskeyWithPrfOutputResult;
+  /**
+   * Credential metadata plus the PRF salt and PRF output that key this secret.
+   * Narrower than `CreatePasskeyWithPrfOutputResult`: these bytes are read
+   * here and owned by the caller, so no disposal member is required.
+   */
+  credential: PasskeyCredentialMetadata & {
+    prfSalt: Uint8Array;
+    prfOutput: Uint8Array;
+  };
   /** Secret bytes to encrypt. */
   secret: Uint8Array;
 };
@@ -210,21 +217,18 @@ async function createSecretVaultWithNewPasskey({
   timeout,
 }: CreateSecretVaultWithNewPasskeyOptions): Promise<PasskeySecretVault> {
   const secretCopy = copyNonEmptySecret(secret);
-  let prfOutput: Uint8Array<ArrayBuffer> | undefined;
 
   try {
-    const credential = await createPasskeyWithPrfOutput({
+    using credential = await createPasskeyWithPrfOutput({
       rp,
       user,
       ...(timeout !== undefined ? { timeout } : {}),
       prfSalt: randomBytes(PRF_SALT_LENGTH),
     });
-    prfOutput = credential.prfOutput;
 
     return await createSecretVault({ credential, secret: secretCopy });
   } finally {
     secretCopy.fill(0);
-    prfOutput?.fill(0);
   }
 }
 
@@ -255,17 +259,15 @@ async function createSecretVaultWithExistingPasskey({
   const credentialCopy =
     credential &&
     toCredentialMetadata(credential.credentialId, credential.transports);
-  let prfOutput: Uint8Array<ArrayBuffer> | undefined;
 
   try {
     const prfSalt = randomBytes(PRF_SALT_LENGTH);
-    const evaluated = await getPasskeyPrfOutput({
+    using evaluated = await getPasskeyPrfOutput({
       rpId,
       ...(credentialCopy !== undefined ? { credential: credentialCopy } : {}),
       prfSalt,
       ...(timeout !== undefined ? { timeout } : {}),
     });
-    prfOutput = evaluated.prfOutput;
 
     // Reuse the caller's metadata (with its transports) only when the browser
     // selected that same credential.
@@ -275,12 +277,15 @@ async function createSecretVaultWithExistingPasskey({
         : { credentialId: evaluated.credentialId };
 
     return await createSecretVault({
-      credential: { ...credentialMetadata, prfSalt, prfOutput },
+      credential: {
+        ...credentialMetadata,
+        prfSalt,
+        prfOutput: evaluated.prfOutput,
+      },
       secret: secretCopy,
     });
   } finally {
     secretCopy.fill(0);
-    prfOutput?.fill(0);
   }
 }
 
@@ -431,18 +436,19 @@ async function decryptSecretVaultWithPasskey({
   timeout,
 }: DecryptSecretVaultWithPasskeyOptions): Promise<Uint8Array<ArrayBuffer>> {
   const parsedVault = parseSecretVault(vault);
-  const { prfOutput } = await getPasskeyPrfOutput({
+  using evaluated = await getPasskeyPrfOutput({
     rpId,
     credential: parsedVault.credential,
     prfSalt: base64UrlDecode(parsedVault.prfSalt),
     ...(timeout !== undefined ? { timeout } : {}),
   });
 
-  try {
-    return await decryptSecretVault({ vault: parsedVault, prfOutput });
-  } finally {
-    prfOutput.fill(0);
-  }
+  // `return await` so disposal zeroes the PRF output after decryption reads it,
+  // not while it is still in flight.
+  return await decryptSecretVault({
+    vault: parsedVault,
+    prfOutput: evaluated.prfOutput,
+  });
 }
 
 export type {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,11 @@ type PasskeyPrfResult = {
   readonly credentialId: string;
   /** First PRF output from WebAuthn. Always 32 bytes. */
   readonly prfOutput: Uint8Array<ArrayBuffer>;
+  /**
+   * Zeroes `prfOutput`, so a `using` declaration clears it when its scope
+   * exits. Reading `prfOutput` afterwards yields zeroes.
+   */
+  [Symbol.dispose](): void;
 };
 
 /** Result of creating a passkey together with its first PRF output. */
@@ -57,6 +62,12 @@ type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
   readonly prfSalt: Uint8Array<ArrayBuffer>;
   /** First WebAuthn PRF output for `prfSalt`. Always 32 bytes. */
   readonly prfOutput: Uint8Array<ArrayBuffer>;
+  /**
+   * Zeroes `prfOutput`, so a `using` declaration clears it when its scope
+   * exits. `prfSalt` is not secret and stays readable, which matters because a
+   * vault stores it.
+   */
+  [Symbol.dispose](): void;
 };
 
 /**

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -318,6 +318,61 @@ test("getPasskeyPrfOutput rejects an empty credentialId without prompting", asyn
   });
 });
 
+test("a using declaration zeroes the PRF output when its scope exits", async () => {
+  const expected = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+  const navigator = {
+    credentials: {
+      async create() {
+        return stubPublicKeyCredential({
+          prf: { enabled: true, results: { first: expected.buffer } },
+          transports: ["internal"],
+        });
+      },
+      async get() {
+        return stubPublicKeyCredential({
+          prf: { results: { first: expected.buffer } },
+        });
+      },
+    },
+  };
+
+  // Distinct from the PRF output, and non-zero so the surviving-salt assertion
+  // below cannot pass by accident.
+  const salt = Uint8Array.from({ length: 32 }, (_, index) => index + 100);
+
+  await withStubbedGlobal("navigator", navigator, async () => {
+    let assertedOutput: Uint8Array | undefined;
+    let createdOutput: Uint8Array | undefined;
+    let createdSalt: Uint8Array | undefined;
+
+    {
+      using asserted = await getPasskeyPrfOutput({
+        rpId: "example.com",
+        prfSalt: salt,
+      });
+      using created = await createPasskeyWithPrfOutput({
+        rp: { id: "example.com", name: "Mera Test" },
+        user: { name: "nad", displayName: "nad" },
+        prfSalt: salt,
+      });
+
+      assertedOutput = asserted.prfOutput;
+      createdOutput = created.prfOutput;
+      createdSalt = created.prfSalt;
+
+      expect(assertedOutput).toEqual(expected);
+      expect(createdOutput).toEqual(expected);
+    }
+
+    expect(assertedOutput).toEqual(new Uint8Array(32));
+    expect(createdOutput).toEqual(new Uint8Array(32));
+    // A vault stores the salt, so disposal must leave it readable.
+    expect(createdSalt).toEqual(salt);
+    // The authenticator's own buffer is upstream of the copy and untouched.
+    expect(expected[0]).toBe(1);
+  });
+});
+
 test("createPasskeyWithPrfOutput snapshots prfSalt for fallback and result", async () => {
   const originalSalt = Uint8Array.from({ length: 32 }, (_, index) => index);
   const prfSalt = new Uint8Array(originalSalt);


### PR DESCRIPTION
Exploratory, to see the API. The two PRF functions return the root secret with no lifetime affordance while signing sessions get `[Symbol.dispose]`.

The decision to settle: whether the ergonomics beat the costs. Three showed up.

- A lifecycle member on a data type forces every builder of that shape to supply one. `CreateSecretVaultOptions` had to stop naming the public result type, and a consumer's code would hit the same wall.
- `decryptSecretVaultWithPasskey` now needs `return await` for correctness. Plain `return` disposes mid-decryption. The `try/finally` it replaced needed no such note.
- Every example and the demo destructure the result, which drops the member. It buys nothing until those are rewritten.

Against that, both vault-creation functions lose the `let prfOutput | undefined` bookkeeping that drew the readability complaint.

Review focus: `using` plus a buffer that escapes the scope is use-after-zero. Sessions already carry the same hazard.