### PR TITLE
Fit the PRF demo's inputs and output on one mobile screen

### DIFF
--- a/prf-demo/index.html
+++ b/prf-demo/index.html
@@ -101,7 +101,7 @@
             </div>
 
             <div class="field">
-              <label for="in-passkey">Modeled passkey</label>
+              <label for="in-passkey">Passkey</label>
               <select id="in-passkey">
                 <option value="blue-yubikey">blue-yubikey</option>
                 <option value="1password-passkey">1password</option>

--- a/prf-demo/src/main.ts
+++ b/prf-demo/src/main.ts
@@ -94,11 +94,15 @@ function setAnimatedText(element: HTMLElement, value: string): void {
   if (previous) animateChange(element);
 }
 
+// The compact layout puts the fingerprint beside the byte matrix as a swatch.
+// Each size gets its own draw so the cells land on whole pixels either way.
+const compactLayout = window.matchMedia("(max-width: 760px)");
+
 function drawFingerprint(fingerprint: Uint8Array): void {
   const context = fingerprintCanvas.getContext("2d");
   if (!context) throw new Error("Canvas is unavailable");
 
-  const size = 112;
+  const size = compactLayout.matches ? 32 : 112;
   const scale = Math.min(window.devicePixelRatio || 1, 3);
   const gridSize = 7;
   const padding = size * 0.12;
@@ -129,8 +133,6 @@ function drawFingerprint(fingerprint: Uint8Array): void {
       }
     }
   }
-
-  if (previous) animateChange(fingerprintCanvas);
 }
 
 function syncChips(values: ModelInputs): void {
@@ -163,6 +165,7 @@ function render(values: ModelInputs): void {
     setAnimatedText(solanaAddressElement, result.solanaAddress);
     if (previous?.fingerprintHex !== result.fingerprintHex) {
       drawFingerprint(result.fingerprint);
+      if (previous) animateChange(fingerprintCanvas);
     }
 
     previous = result;
@@ -204,6 +207,10 @@ for (const group of document.querySelectorAll<HTMLElement>(".chips")) {
     });
   }
 }
+
+compactLayout.addEventListener("change", () => {
+  if (previous) drawFingerprint(previous.fingerprint);
+});
 
 reportHeightWhenEmbedded();
 setInputs(DEFAULT_INPUTS);

--- a/prf-demo/src/styles.css
+++ b/prf-demo/src/styles.css
@@ -587,7 +587,7 @@ button:focus-visible {
 
   .stage {
     grid-template-columns: 1fr;
-    gap: 0.75rem;
+    gap: 0.55rem;
   }
 
   .stage-marker {
@@ -603,11 +603,43 @@ button:focus-visible {
 
   .inputs {
     grid-template-columns: 1fr;
-    gap: 1.05rem;
+    gap: 0.6rem;
+  }
+
+  /* Label beside the control rather than above it, chips under both. */
+  .field {
+    display: grid;
+    align-items: center;
+    gap: 0.35rem 0.55rem;
+    grid-template-columns: 4.5rem minmax(0, 1fr);
+  }
+
+  .field input,
+  .field select {
+    min-height: 2.45rem;
+    padding: 0.5rem 0.6rem;
+  }
+
+  /* Restored so the shorthand above leaves the select's chevron uncovered. */
+  .field select {
+    padding-right: 1.75rem;
+  }
+
+  .field .chips {
+    grid-column: 1 / -1;
+  }
+
+  .input-merge {
+    padding-bottom: 0.85rem;
+  }
+
+  .input-merge::after {
+    height: 0.85rem;
   }
 
   .merge-lines {
     width: 1px;
+    height: 1rem;
   }
 
   .merge-lines::before {
@@ -626,17 +658,69 @@ button:focus-visible {
 
   .process-node {
     margin-top: 0;
+    padding: 0.42rem 0.8rem;
+  }
+
+  .prf-card {
+    gap: 0.85rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .fingerprint-figure {
+    align-self: start;
+    padding: 0;
+    border: 0;
+  }
+
+  .fingerprint-figure figcaption {
+    display: none;
+  }
+
+  .fingerprint {
+    border-radius: 6px;
+  }
+
+  .transition {
+    min-height: 2.4rem;
+  }
+
+  .recovery-heading {
+    margin-bottom: 0.5rem;
   }
 
   .mnemonic-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .mnemonic-grid li {
+    min-height: 2.4rem;
+    gap: 0.3rem;
+    padding: 0.4rem 0.45rem;
   }
 
   .account-grid {
     grid-template-columns: 1fr;
+    gap: 0.55rem;
   }
 
-  .panel-foot,
+  .account-card {
+    padding: 0.75rem 0.85rem;
+  }
+
+  .account-card header {
+    margin-bottom: 0.45rem;
+  }
+
+  .panel-foot {
+    margin: 1.25rem 0 0;
+    padding-top: 0.85rem;
+  }
+
+  .note {
+    padding: 0.5rem 0.65rem;
+    font-size: 0.72rem;
+  }
+
   .error {
     margin-left: 0;
   }
@@ -652,14 +736,24 @@ button:focus-visible {
   }
 
   .prf-card {
-    gap: 1rem;
+    gap: 0.7rem;
     padding: 0.9rem;
   }
 
+  /* Keep each label whole and let the meta text drop to its own line instead. */
+  .value-heading,
+  .account-card header {
+    flex-wrap: wrap;
+  }
+
+  .value-heading h3,
+  .account-card h3 {
+    white-space: nowrap;
+  }
+
   .value-heading {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 0.3rem;
+    gap: 0.55rem;
+    margin-bottom: 0.6rem;
   }
 
   .byte-row {
@@ -671,23 +765,13 @@ button:focus-visible {
     font-size: 0.67rem;
   }
 
-  .mnemonic-grid li {
-    gap: 0.35rem;
-    padding: 0.55rem 0.5rem;
-  }
-
   .word {
     font-size: 0.7rem;
   }
 
   .account-card header {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 0.4rem;
-  }
-
-  .account-path {
-    text-align: left;
+    gap: 0.55rem;
+    margin-bottom: 0.4rem;
   }
 }
 


### PR DESCRIPTION
At 375px wide the demo ran 2136px tall, and the input stage alone reached 501px. That left 311px of an 812px screen for a PRF card needing 438, so a chip tap changed the bytes, the phrase, and both addresses while a viewer on a phone saw none of it move. Watching the output follow the input is the whole point of the page.

It is now 1279px. The first screen holds all three inputs, the full 32-byte matrix, the fingerprint, and the first fifteen words, so the change flashes in place. Both addresses and the rest of the phrase fit the second screen.

Nothing is hidden to get there. Every stage, label, and value a wide screen shows, a narrow screen still shows. Layouts above 760px are untouched apart from the label rename.

![prf-demo-mobile-first-screen.png](https://github.com/user-attachments/assets/08ec39a4-c595-4c1b-abf1-841157954abc)

*First screen at 375x812, before and after. On the left the inputs use it all up; on the right the byte matrix and the first words are already visible.*

![prf-demo-mobile-full-page.png](https://github.com/user-attachments/assets/f5f6db8f-b9a8-45f6-98ce-aec073ec1553)

*The same page end to end at 375px wide.*

Rebased onto #286 and the hash-state removal. The passkey field is a `<select>` now, so the compact rule sizes `input` and `select` together and puts the select's right padding back, which the padding shorthand would otherwise have dropped onto its chevron. A field's children are placed by auto-placement rather than by tag, so the select needs no rule of its own to sit beside its label. My earlier note here said #286 renamed the same label; it did not, and the conflict was in the surrounding markup.

Checked by hand at 320px, 375px, 900px, and 1280px for horizontal overflow, clipped recovery words at three columns, truncated hex, and the select's chevron clearing its text. One path I could not exercise: the fingerprint redraw when the viewport crosses 760px. The harness fires neither `resize` nor media-change events on an emulated resize, so rotation went untested. Should the listener ever miss, the swatch draws at the other size until the next input change.

Two things I left out. Setting the recovery phrase as wrapped word chips saves another 123px, but rounded chips read as tappable beside the input chips right above them, and the saving does not bring a further stage onto the first screen. A sticky input bar cannot work at all: the embed sizes the iframe to content height, so nothing scrolls inside it and sticky never engages.
