### PR TITLE
Hide stage markers on mobile in the PRF demo

### DIFF
--- a/prf-demo/src/styles.css
+++ b/prf-demo/src/styles.css
@@ -591,14 +591,7 @@ button:focus-visible {
   }
 
   .stage-marker {
-    display: flex;
-    align-items: baseline;
-    gap: 0.65rem;
-    padding-top: 0;
-  }
-
-  .stage-marker h2 {
-    margin-top: 0;
+    display: none;
   }
 
   .inputs {

--- a/prf-demo/src/styles.css
+++ b/prf-demo/src/styles.css
@@ -590,8 +590,20 @@ button:focus-visible {
     gap: 0.55rem;
   }
 
+  /* Visually hidden, kept in the a11y tree so the stage <h2>s stay reachable
+     by screen-reader heading navigation while the visual pipeline carries the
+     flow on small screens. */
   .stage-marker {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
   }
 
   .inputs {


### PR DESCRIPTION
## Problem

On mobile, the PRF demo shows both the stage markers (01 Input, 02 PRF output, …) and the visual pipeline elements — process nodes, transition labels, and merge lines — that already convey the flow. The stage markers become redundant at small widths.

## Change

Hides  (number + heading) under the existing `max-width: 760px` breakpoint in `prf-demo/src/styles.css`. The pipeline flow stays legible through the process nodes, transitions, and merge lines, so the markers are no longer needed there.

## Verification

`npm run build` passes.