### PR TITLE
Fit the PRF demo's recovery phrase into fewer mobile rows

### DIFF
--- a/prf-demo/src/styles.css
+++ b/prf-demo/src/styles.css
@@ -688,12 +688,16 @@ button:focus-visible {
     margin-bottom: 0.5rem;
   }
 
+  /* Words flow instead of filling even columns, so a short word claims less
+     width and each row carries as many words as it fits. */
   .mnemonic-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    display: flex;
+    flex-wrap: wrap;
   }
 
   .mnemonic-grid li {
     min-height: 2.4rem;
+    flex: 1 1 auto;
     gap: 0.3rem;
     padding: 0.4rem 0.45rem;
   }


### PR DESCRIPTION
On a phone the recovery phrase was the tallest thing on the page. Three even columns sized every cell for the longest word it might hold, so `boy` and `clarify` took the same width and the 24 words ran to eight rows, pushing the accounts below two screens of scrolling.

The words now flow and stretch to fill each row, so a short word claims less width. On a 440px screen the block drops from eight rows to five (308px to 193px) and the page loses 115px. The cells keep the same borders, numbering, and row height, so the block still reads as a table rather than a bag of chips.

Only the `max-width: 760px` block changes. Full-page renders at 1200px, 900px, and 761px are pixel-identical to `main`.

Checked across 40 phrases at each of 320, 375, 390, 440, 600, and 759px. Row counts land at 8, 6, 6, 5, 4, and 3 against 8 everywhere before. When the leftover word lands alone on the last row it stretches across the full width, which happens on a third of phrases at 320px and about one in 40 at 375-440px; it reads like the short last line of a justified paragraph, so I left it.

## Screenshots

Before on the left, after on the right, iPhone 16 Pro Max width (440px).

| Recovery phrase | Full page |
| --- | --- |
| ![pair-recovery.png](https://github.com/user-attachments/assets/2e9de05b-2009-4fa0-8051-324c6e13dc7f) | ![pair-full.png](https://github.com/user-attachments/assets/1c532321-da12-4373-808f-4914d8374a9b) |
