### PR TITLE
Keep the PRF demo's fingerprint beside its byte matrix

### DIFF
--- a/prf-demo/src/styles.css
+++ b/prf-demo/src/styles.css
@@ -556,17 +556,6 @@ button:focus-visible {
     gap: 1rem;
   }
 
-  .prf-card {
-    grid-template-columns: 1fr;
-  }
-
-  .fingerprint-figure {
-    padding-top: 1.1rem;
-    padding-left: 0;
-    border-top: 1px solid var(--border);
-    border-left: 0;
-  }
-
   .mnemonic-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Why

Between 761px and 960px the PRF output card collapsed to a single column, so the visual fingerprint dropped below the hex bytes and picked up a top divider. Under 761px the card returned to two columns with a small swatch. The stacked layout was therefore a middle-width detour rather than a step in a progression: the fingerprint left its row and then came back.

Deleting the collapse lets the two-column layout run from the widest screens down to the compact swatch at 760px. The bytes need about 300px and get 386px at 761px, the narrowest point of the fixed 9.75rem sidebar, so the band that used to stack has the room to sit side by side.

## Notes for reviewers

I measured the card at 19 widths from 320px to 1000px. The figure stays in the byte matrix's row at every one, and no width overflows horizontally.

Left alone: the canvas still switches from 112px to a 32px swatch at the 760px breakpoint in `prf-demo/src/main.ts`. That size jump now happens in place instead of alongside a row change, so it reads more abruptly than before. The 112px canvas still fits beside the bytes at 700px, so we could push that breakpoint lower in a follow-up.