### PR TITLE
Add type-aware documentation snippets

### DIFF
--- a/.github/workflows/mera-ci.yml
+++ b/.github/workflows/mera-ci.yml
@@ -43,14 +43,13 @@ jobs:
           matches() { grep -qE "$1" changed-files.txt && echo true || echo false; }
           library='^(src/|test/|scripts/|package\.json$|package-lock\.json$|tsconfig\.[^/]*json$|playwright\.config\.ts$|\.nvmrc$|\.github/workflows/)'
           packaged='^(README\.md|LICENSE-MIT|LICENSE-APACHE)$'
-          shared='^(\.nvmrc$|\.github/workflows/)'
 
           {
             echo "library=$(matches "$library")"
             echo "demo=$(matches "$library|^demo/|^prf-demo/")"
             echo "mobile=$(matches "$library|^demo-mobile/")"
             echo "package=$(matches "$library|$packaged")"
-            echo "docs=$(matches "$shared|^docs/")"
+            echo "docs=$(matches "$library|^docs/")"
           } >> "$GITHUB_OUTPUT"
 
   check:
@@ -196,7 +195,15 @@ jobs:
           node-version-file: .nvmrc
           check-latest: true
           cache: npm
-          cache-dependency-path: docs/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            docs/package-lock.json
+
+      - name: Install library dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build
 
       - name: Install docs dependencies
         run: npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,10 @@ npm run check
 
 Running it on a device needs Xcode or Android Studio, a passkey provider with PRF, and the domain association files described in [demo-mobile/README.md](./demo-mobile/README.md).
 
-Build the documentation website from its package directory. Run both web demo builds above first so their generated files are present:
+Build the library before installing the documentation website. TypeScript examples compile against the built package. Run both web demo builds above first so their generated files are present:
 
 ```sh
+npm run build
 cd docs
 npm ci
 npm run build

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+install-links=true

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,19 @@
 # mera docs
 
-The documentation website, built with [Astro Starlight](https://starlight.astro.build). A standalone package: run the commands below from this directory.
+The documentation website, built with [Astro Starlight](https://starlight.astro.build). Build the library before installing the docs because TypeScript examples compile against the local package.
 
 ```sh
+npm ci
+npm run build
+cd docs
 npm ci
 npm run dev      # local dev server
 npm run build    # static site in dist/
 npm run preview  # serve the built site
 ```
 
-Pages live in `src/content/docs/` as Markdown/MDX. The visual style is `src/styles/mera.css`, which maps the demo app’s palette and the `site/` article’s typography onto Starlight's CSS variables. The landing page is `src/components/Hero.astro`; it embeds the hosted demo app through `src/components/DemoEmbed.astro`. The frame follows the demo's content height in stacked layouts and uses a viewport-sized sticky panel on wide screens.
+Pages live in `src/content/docs/` as Markdown/MDX. Twoslash checks every TypeScript and TSX block and adds type and JSDoc details on hover. Hidden setup before `// ---cut---` keeps each short example valid on its own.
+
+The visual style is `src/styles/mera.css`, which maps the demo app’s palette and the `site/` article’s typography onto Starlight's CSS variables. The landing page is `src/components/Hero.astro`; it embeds the hosted demo app through `src/components/DemoEmbed.astro`. The frame follows the demo's content height in stacked layouts and uses a viewport-sized sticky panel on wide screens.
 
 Authoring guidance (page structure, voice, review checklist) lives in [AGENTS.md](./AGENTS.md).

--- a/docs/ec.config.mjs
+++ b/docs/ec.config.mjs
@@ -1,0 +1,25 @@
+// @ts-check
+
+import { fileURLToPath } from "node:url";
+import { defineEcConfig } from "@astrojs/starlight/expressive-code";
+import ecTwoSlash from "expressive-code-twoslash";
+
+const docsDirectory = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineEcConfig({
+  plugins: [
+    ecTwoSlash({
+      cwd: docsDirectory,
+      tsConfigPath: "tsconfig.twoslash.json",
+      includeJsDoc: true,
+      instanceConfigs: {
+        twoslash: {
+          // Version 0.6.1 ignores `false`; an always-matching trigger applies
+          // Twoslash to every block in the configured languages.
+          explicitTrigger: /^/,
+          languages: ["ts", "tsx"],
+        },
+      },
+    }),
+  ],
+});

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,14 +10,33 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.2",
         "@astrojs/starlight": "^0.41.3",
+        "@category-labs/mera": "file:..",
+        "@ec-ts/twoslash": "1.0.0",
+        "@expressive-code/core": "0.44.1",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@noble/hashes": "2.2.0",
+        "@scure/bip32": "2.2.0",
+        "@scure/bip39": "2.2.0",
         "astro": "^7.1.6",
+        "expo-crypto": "57.0.1",
+        "expo-modules-core": "57.0.10",
+        "expressive-code": "0.44.1",
+        "expressive-code-twoslash": "0.6.1",
+        "react-native-passkey": "3.6.1",
         "sharp": "^0.35.3",
-        "unist-util-visit": "^5.1.0"
+        "typescript": "5.9.3",
+        "unist-util-visit": "^5.1.0",
+        "viem": "2.55.10"
       },
       "engines": {
         "node": ">=24"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/compiler-binding": {
       "version": "0.3.2",
@@ -398,12 +417,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -413,9 +432,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -593,6 +612,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@category-labs/mera": {
+      "version": "0.1.0",
+      "resolved": "file:..",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "react-native-passkey": "3.6.1",
+        "viem": "^2.28.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-passkey": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@clack/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
@@ -630,16 +674,43 @@
         "node": ">=14"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+    "node_modules/@ec-ts/twoslash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ec-ts/twoslash/-/twoslash-1.0.0.tgz",
+      "integrity": "sha512-Bp4MCmeDWVRkTkuytPTszan+QGUqeftiasOBadvxSfQpbXYiWsle/N0lMrG+S14bfS9iBzI8mEqdGgd3Fvr3jQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
+        "@ec-ts/vfs": "^1.0.0",
+        "twoslash-protocol": "^0.3.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@ec-ts/twoslash-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ec-ts/twoslash-vue/-/twoslash-vue-1.0.0.tgz",
+      "integrity": "sha512-3bB0/1DPPLHjS0eok2Cne7xQjCQVU5AWScEBGYTqsKuTCTukDUMxUiYI54rDPQME3OLnpysiORi0FQKLA96pAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ec-ts/twoslash": "^1.0.0",
+        "@vue/language-core": "^3.2.5",
+        "twoslash-protocol": "^0.3.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@ec-ts/vfs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ec-ts/vfs/-/vfs-1.0.0.tgz",
+      "integrity": "sha512-GQYRPMp58p9ak+TOwSLB/HZ+iknFyTRjqMTdXDkitNN3h5yjHuO+yeeO+/cuXiv7dyXGLYs4HaYrFgRKImp8yg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5.5.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -648,17 +719,6 @@
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1078,6 +1138,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@expo/expo-modules-macros-plugin": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@expo/expo-modules-macros-plugin/-/expo-modules-macros-plugin-0.6.1.tgz",
+      "integrity": "sha512-cpsLZE4rqkc1Y3eZTkxB98jrqY1YXgetmtxFt8q89jBRmk3quRuk1BZo+VcnCSObZardjg99r1k5xijEMONFGA==",
+      "license": "MIT"
     },
     "node_modules/@expressive-code/core": {
       "version": "0.44.1",
@@ -1745,6 +1811,45 @@
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -2182,6 +2287,42 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@shikijs/core": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
@@ -2385,11 +2526,244 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
+      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "license": "MIT"
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.18.0",
@@ -2411,6 +2785,12 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "license": "MIT"
     },
     "node_modules/am-i-vibing": {
       "version": "0.4.0",
@@ -2614,6 +2994,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bcp-47": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.1.tgz",
@@ -2644,6 +3033,18 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2799,6 +3200,12 @@
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
+    },
+    "node_modules/css-js-gen": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/css-js-gen/-/css-js-gen-1.1.0.tgz",
+      "integrity": "sha512-CuPSTe6EwlrDHcMFOfcO3SwVqclVKLnqSbTGGYzfFt8z2NenGeupp47Z3wx+yhQ2pdozb3R8hc+nyECBTykooQ==",
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -3182,6 +3589,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/estree-util-attach-comments": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
@@ -3279,6 +3698,45 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expo-crypto": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-57.0.1.tgz",
+      "integrity": "sha512-xwegXQw3ATgeL1ZuqbSNrGzOeG+zNeh6Z6DSJk825Qpa3TEQQ1kG3ioE1p3g/SNF373BAVz2iBKUTSytlIbBRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-modules-core": {
+      "version": "57.0.10",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-57.0.10.tgz",
+      "integrity": "sha512-aRi3G8OctoyZl8x9CLTVpbPljClfKm2eqKRgBzhcGsrH3gS1t5Y2ye7+PIZK4XK2VVP5iGqygN2b1vtqRo3xVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/expo-modules-macros-plugin": "0.6.1",
+        "expo-modules-jsi": "~57.0.4",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-worklets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-modules-jsi": {
+      "version": "57.0.4",
+      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-57.0.4.tgz",
+      "integrity": "sha512-vt7FyqUqqFXiRVnBqYD7y+GSPTgeua5Ocoy0+SYt+RSHkZEA2Fyop7If3g1TYDzQObYybPRo7TG2Rle1XLaWFw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/expressive-code": {
       "version": "0.44.1",
       "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.44.1.tgz",
@@ -3289,6 +3747,27 @@
         "@expressive-code/plugin-frames": "^0.44.1",
         "@expressive-code/plugin-shiki": "^0.44.1",
         "@expressive-code/plugin-text-markers": "^0.44.1"
+      }
+    },
+    "node_modules/expressive-code-twoslash": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/expressive-code-twoslash/-/expressive-code-twoslash-0.6.1.tgz",
+      "integrity": "sha512-aEeKBgqg6cF4rQPxT5BHNbRffwsA66zWkNT/Y7CcUIE8eHW6KJHPCnZrGCLxvQ5xRd+qWj7ZXq84gT2zd2ECbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ec-ts/twoslash": "^1.0.0",
+        "@ec-ts/twoslash-vue": "^1.0.0",
+        "@typescript-eslint/parser": "^8.56.1",
+        "css-js-gen": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.3",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-to-hast": "^13.2.1",
+        "twoslash-eslint": "^0.3.6"
+      },
+      "peerDependencies": {
+        "@expressive-code/core": "^0.41.7",
+        "expressive-code": "^0.41.7",
+        "typescript": "^5.5.0"
       }
     },
     "node_modules/extend": {
@@ -3851,6 +4330,15 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -3930,6 +4418,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
@@ -4237,6 +4746,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -5355,6 +5876,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5368,6 +5904,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5490,6 +6032,105 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -5611,6 +6252,12 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -5735,6 +6382,16 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/react-native-passkey": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-passkey/-/react-native-passkey-3.6.1.tgz",
+      "integrity": "sha512-m3lN9IQvR3rhatmKfviYg7l91Or5QgykIoD5dsDJUvRo4C2Lnm82NbwM9nJ7oXSO3WY1DQig5t/fk9QLx0PYIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -6452,12 +7109,58 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/twoslash-eslint": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/twoslash-eslint/-/twoslash-eslint-0.3.9.tgz",
+      "integrity": "sha512-KxXHj3iCSIR3blHk7OUI0WqXpR9brhOW8/DYQ54ghijmKmH0BBZFETJetWERAD823tTnXbugvRx89XHQNDNkww==",
+      "license": "MIT",
+      "dependencies": {
+        "twoslash-protocol": "0.3.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.50.0"
+      }
+    },
+    "node_modules/twoslash-protocol": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/twoslash-protocol/-/twoslash-protocol-0.3.9.tgz",
+      "integrity": "sha512-9/iwp+CXOnjFMPQuPL5PkuRbZnDoNpBvtJCLs9t8kDYkL3YHujbvnHfZA1i5fApDftVEdBw+T/4F+dH5kIzpYQ==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.4",
@@ -6805,6 +7508,99 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/viem": {
+      "version": "2.55.10",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.10.tgz",
+      "integrity": "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.33",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/vite": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
@@ -6909,6 +7705,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xxhash-wasm": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,16 +5,30 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "check:snippets": "node scripts/check-code-snippets.mjs",
+    "build": "npm run check:snippets && astro build",
     "preview": "astro preview"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.2",
     "@astrojs/starlight": "^0.41.3",
+    "@category-labs/mera": "file:..",
+    "@ec-ts/twoslash": "1.0.0",
+    "@expressive-code/core": "0.44.1",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@noble/hashes": "2.2.0",
+    "@scure/bip32": "2.2.0",
+    "@scure/bip39": "2.2.0",
     "astro": "^7.1.6",
+    "expo-crypto": "57.0.1",
+    "expo-modules-core": "57.0.10",
+    "expressive-code": "0.44.1",
+    "expressive-code-twoslash": "0.6.1",
+    "react-native-passkey": "3.6.1",
     "sharp": "^0.35.3",
-    "unist-util-visit": "^5.1.0"
+    "typescript": "5.9.3",
+    "unist-util-visit": "^5.1.0",
+    "viem": "2.55.10"
   },
   "engines": {
     "node": ">=24"

--- a/docs/scripts/check-code-snippets.mjs
+++ b/docs/scripts/check-code-snippets.mjs
@@ -1,0 +1,80 @@
+// @ts-check
+
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createTwoslasher } from "@ec-ts/twoslash";
+import ts from "typescript";
+
+const docsDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const contentDirectory = join(docsDirectory, "src/content/docs");
+const tsConfigPath = join(docsDirectory, "tsconfig.twoslash.json");
+
+const configFile = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
+if (configFile.error !== undefined) {
+  throw new Error(formatDiagnostic(configFile.error));
+}
+
+const parsedConfig = ts.parseJsonConfigFileContent(
+  configFile.config,
+  ts.sys,
+  docsDirectory,
+  undefined,
+  tsConfigPath,
+);
+if (parsedConfig.errors.length > 0) {
+  throw new Error(parsedConfig.errors.map(formatDiagnostic).join("\n"));
+}
+
+const twoslasher = createTwoslasher({
+  compilerOptions: parsedConfig.options,
+  shouldGetHoverInfo: () => false,
+  tsModule: ts,
+  vfsRoot: docsDirectory,
+});
+
+const failures = [];
+for (const path of await listContentFiles(contentDirectory)) {
+  const source = await readFile(path, "utf8");
+  const codeFence = /^```(tsx?)(?:[^\n]*)\r?\n([\s\S]*?)^```\s*$/gm;
+
+  for (const match of source.matchAll(codeFence)) {
+    const language = match[1];
+    const code = match[2];
+    if (language === undefined || code === undefined) continue;
+
+    try {
+      twoslasher(code, language, {
+        handbookOptions: { noStaticSemanticInfo: true },
+      });
+    } catch (error) {
+      const line = source.slice(0, match.index).split("\n").length;
+      const relativePath = path.slice(docsDirectory.length + 1);
+      const message = error instanceof Error ? error.message : String(error);
+      failures.push(`${relativePath}:${line}\n${message}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`TypeScript code blocks failed:\n\n${failures.join("\n\n")}`);
+}
+
+/** @param {string} directory */
+async function listContentFiles(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listContentFiles(path)));
+    } else if ([".md", ".mdx"].includes(extname(entry.name))) {
+      files.push(path);
+    }
+  }
+  return files.sort();
+}
+
+/** @param {ts.Diagnostic} diagnostic */
+function formatDiagnostic(diagnostic) {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+}

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -53,6 +53,9 @@ mera uses a stable PRF salt for this call, so a later sign-in reproduces the sam
 The PRF output is the root of every account. This walkthrough maps it through [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) to a phrase and a [seed](/concepts/entropy-keys-and-accounts/#deterministic-derivation), then derives keys with [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
 
 ```ts
+declare const prfOutput: Uint8Array;
+
+// ---cut---
 import { HDKey } from "@scure/bip32";
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
@@ -68,6 +71,12 @@ if (node.privateKey === null) throw new Error("derivation produced no key");
 ## Sign
 
 ```ts
+import { HDKey } from "@scure/bip32";
+
+const node = HDKey.fromMasterSeed(crypto.getRandomValues(new Uint8Array(32)));
+if (node.privateKey === null) throw new Error("derivation produced no key");
+
+// ---cut---
 import {
   createSecp256k1SigningSession,
   getEvmAddress,
@@ -90,6 +99,9 @@ session.end();
 A later visit reproduces the same account.
 
 ```ts
+const rpId = "account.example.com";
+
+// ---cut---
 import { getPasskeyPrfOutput } from "@category-labs/mera";
 
 const { prfOutput } = await getPasskeyPrfOutput({

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -34,6 +34,11 @@ Every call creates a new passkey.
 The app can store the credential metadata and pass it back on the next sign-in, so the browser reuses the same passkey instead of offering a choice.
 
 ```ts
+import type { CreatePasskeyWithPrfOutputResult } from "@category-labs/mera";
+
+declare const created: CreatePasskeyWithPrfOutputResult;
+
+// ---cut---
 localStorage.setItem(
   "app.derivedCredential",
   JSON.stringify({
@@ -48,6 +53,9 @@ localStorage.setItem(
 ## Sign in
 
 ```ts
+const rpId = "account.example.com";
+
+// ---cut---
 import { getPasskeyPrfOutput } from "@category-labs/mera";
 
 const stored = localStorage.getItem("app.derivedCredential");
@@ -69,6 +77,9 @@ localStorage.setItem("app.derivedCredential", JSON.stringify(record));
 Turn the PRF output into a [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seed.
 
 ```ts
+declare const prfOutput: Uint8Array;
+
+// ---cut---
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
@@ -132,12 +143,40 @@ function deriveSolanaAccount(seed: Uint8Array, index: number) {
 Build the account list from these helpers:
 
 ```ts
+import type {
+  Ed25519SigningSession,
+  EvmAddress,
+  Secp256k1SigningSession,
+  SolanaAddress,
+} from "@category-labs/mera";
+
+declare const seed: Uint8Array;
+declare function deriveEvmAccount(
+  seed: Uint8Array,
+  index: number,
+): { session: Secp256k1SigningSession; address: EvmAddress };
+declare function deriveSolanaAccount(
+  seed: Uint8Array,
+  index: number,
+): { session: Ed25519SigningSession; address: SolanaAddress };
+
+// ---cut---
 const accounts = [deriveEvmAccount(seed, 0), deriveSolanaAccount(seed, 0)];
 ```
 
 ## End the sessions
 
 ```ts
+import type {
+  Ed25519SigningSession,
+  Secp256k1SigningSession,
+} from "@category-labs/mera";
+
+declare const accounts: Array<{
+  session: Ed25519SigningSession | Secp256k1SigningSession;
+}>;
+
+// ---cut---
 for (const account of accounts) {
   account.session.end();
 }

--- a/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
+++ b/docs/src/content/docs/recipes/send-a-transaction-with-viem.md
@@ -20,6 +20,9 @@ const { prfOutput } = await getPasskeyPrfOutput({ rpId });
 The seed and path come from the same mapping [Create passkey accounts](/recipes/create-passkey-accounts/) uses ([Keys and accounts](/concepts/entropy-keys-and-accounts/) introduces the standards).
 
 ```ts
+declare const prfOutput: Uint8Array;
+
+// ---cut---
 import { HDKey } from "@scure/bip32";
 import { entropyToMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
@@ -37,6 +40,12 @@ if (node.privateKey === null) throw new Error("derivation produced no key");
 `toViemAccount` lives in the `@category-labs/mera/viem` entry point, which requires the optional `viem` peer dependency.
 
 ```ts
+import { HDKey } from "@scure/bip32";
+
+const node = HDKey.fromMasterSeed(crypto.getRandomValues(new Uint8Array(32)));
+if (node.privateKey === null) throw new Error("derivation produced no key");
+
+// ---cut---
 import { createSecp256k1SigningSession } from "@category-labs/mera";
 import { toViemAccount } from "@category-labs/mera/viem";
 
@@ -50,6 +59,13 @@ const account = toViemAccount(session);
 ## Send the transaction
 
 ```ts
+import type { Secp256k1SigningSession } from "@category-labs/mera";
+import type { LocalAccount } from "viem";
+
+declare const account: LocalAccount;
+declare const session: Secp256k1SigningSession;
+
+// ---cut---
 import { createWalletClient, http, parseEther } from "viem";
 import { sepolia } from "viem/chains";
 

--- a/docs/src/content/docs/recipes/use-an-existing-secret.md
+++ b/docs/src/content/docs/recipes/use-an-existing-secret.md
@@ -38,6 +38,9 @@ A private key is encrypted the same way: pass its raw bytes as `secret` instead 
 The unlock runs one ceremony, pinned automatically to the credential stored in the vault:
 
 ```ts
+const rpId = "account.example.com";
+
+// ---cut---
 import {
   decryptSecretVaultWithPasskey,
   parseSecretVault,
@@ -60,5 +63,4 @@ async function unlockPhrase(): Promise<string> {
 - [Secret vaults](/concepts/secret-vaults/): how a vault works and when to use one.
 - [createSecretVaultWithExistingPasskey](/reference/create-secret-vault-with-existing-passkey/): encrypt another secret with the same passkey.
 - [Secret vault format](/reference/secret-vault-format/): the stored JSON, field by field.
-
 

--- a/docs/src/content/docs/recipes/use-mera-with-react-native.md
+++ b/docs/src/content/docs/recipes/use-mera-with-react-native.md
@@ -36,6 +36,18 @@ if (typeof globalThis.crypto?.getRandomValues !== "function") {
 Load the polyfill before any code that imports mera:
 
 ```ts
+// @filename: src/polyfills.ts
+import { getRandomValues } from "expo-crypto";
+
+if (typeof globalThis.crypto?.getRandomValues !== "function") {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: { ...globalThis.crypto, getRandomValues },
+  });
+}
+
+// @filename: index.ts
+// ---cut---
 import "./src/polyfills";
 ```
 

--- a/docs/src/content/docs/reference/create-ed25519-signing-session.md
+++ b/docs/src/content/docs/reference/create-ed25519-signing-session.md
@@ -43,6 +43,12 @@ Ed25519 private key (the 32-byte seed).
 
 ## Returns
 
+```ts
+import type { Ed25519SigningSession } from "@category-labs/mera";
+
+type ReturnType = Ed25519SigningSession;
+```
+
 A live [`Ed25519SigningSession`](/reference/ed25519-signing-session/).
 
 ## Errors

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -14,6 +14,9 @@ import { createPasskeyWithPrfOutput } from "@category-labs/mera";
 ## Usage
 
 ```ts
+import { createPasskeyWithPrfOutput } from "@category-labs/mera";
+
+// ---cut---
 const { credentialId, prfSalt, prfOutput } = await createPasskeyWithPrfOutput({
   rp: { id: "account.example.com", name: "Example" },
   user: { name: "account@example.com", displayName: "Example account" },
@@ -68,7 +71,16 @@ Client that runs the ceremonies. [WebAuthnClient](/reference/web-authn-client/) 
 
 ## Returns
 
-`Promise<CreatePasskeyWithPrfOutputResult>`. Credential metadata (`credentialId`, `transports` when reported) plus the 32-byte `prfSalt` that was evaluated and the 32-byte `prfOutput`.
+```ts
+import type { CreatePasskeyWithPrfOutputResult } from "@category-labs/mera";
+
+type ReturnType = Promise<CreatePasskeyWithPrfOutputResult>;
+```
+
+- `credentialId` (`string`): the new credential ID as canonical unpadded base64url.
+- `transports` (`readonly PasskeyCredentialTransport[] | undefined`): authenticator transports reported by the platform, when available.
+- `prfSalt` (`Uint8Array<ArrayBuffer>`): the 32-byte salt that WebAuthn evaluated.
+- `prfOutput` (`Uint8Array<ArrayBuffer>`): the 32-byte PRF output for `prfSalt`.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/create-secp256k1-signing-session.md
+++ b/docs/src/content/docs/reference/create-secp256k1-signing-session.md
@@ -43,6 +43,12 @@ secp256k1 private key. Must be exactly 32 bytes and a valid scalar, an integer i
 
 ## Returns
 
+```ts
+import type { Secp256k1SigningSession } from "@category-labs/mera";
+
+type ReturnType = Secp256k1SigningSession;
+```
+
 A live [`Secp256k1SigningSession`](/reference/secp256k1-signing-session/).
 
 ## Errors

--- a/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-existing-passkey.md
@@ -74,7 +74,13 @@ Client that runs the ceremony. [WebAuthnClient](/reference/web-authn-client/) co
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault with the selected credential's metadata and a fresh random 32-byte PRF salt. The [secret vault format](/reference/secret-vault-format/) page documents every field.
+```ts
+import type { PasskeySecretVault } from "@category-labs/mera";
+
+type ReturnType = Promise<PasskeySecretVault>;
+```
+
+A JSON-safe vault with `version`, `credential`, `prfSalt`, `nonce`, and `ciphertext`. It contains the selected credential's metadata and a fresh random 32-byte PRF salt. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
+++ b/docs/src/content/docs/reference/create-secret-vault-with-new-passkey.md
@@ -14,6 +14,9 @@ import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
 ## Usage
 
 ```ts
+import { createSecretVaultWithNewPasskey } from "@category-labs/mera";
+
+// ---cut---
 const secret = new TextEncoder().encode("the secret to protect");
 try {
   const vault = await createSecretVaultWithNewPasskey({
@@ -75,7 +78,13 @@ Client that runs the ceremonies. [WebAuthnClient](/reference/web-authn-client/) 
 
 ## Returns
 
-`Promise<PasskeySecretVault>`: a JSON-safe vault with the new credential's metadata and a fresh random 32-byte PRF salt. The [secret vault format](/reference/secret-vault-format/) page documents every field.
+```ts
+import type { PasskeySecretVault } from "@category-labs/mera";
+
+type ReturnType = Promise<PasskeySecretVault>;
+```
+
+A JSON-safe vault with `version`, `credential`, `prfSalt`, `nonce`, and `ciphertext`. It contains the new credential's metadata and a fresh random 32-byte PRF salt. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
+++ b/docs/src/content/docs/reference/decrypt-secret-vault-with-passkey.md
@@ -65,7 +65,11 @@ Client that runs the ceremony. [WebAuthnClient](/reference/web-authn-client/) co
 
 ## Returns
 
-`Promise<Uint8Array>`: the decrypted secret bytes as a fresh allocation.
+```ts
+export type ReturnType = Promise<Uint8Array<ArrayBuffer>>;
+```
+
+The decrypted secret bytes as a fresh allocation.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/errors.md
+++ b/docs/src/content/docs/reference/errors.md
@@ -8,7 +8,10 @@ The library uses `MeraError` for its documented failure modes. It carries a stab
 ## MeraError
 
 ```ts
-class MeraError extends Error {
+import type { MeraErrorCode } from "@category-labs/mera";
+
+// ---cut---
+declare class MeraError extends Error {
   readonly code: MeraErrorCode;
 }
 ```

--- a/docs/src/content/docs/reference/get-evm-address.md
+++ b/docs/src/content/docs/reference/get-evm-address.md
@@ -38,7 +38,13 @@ A secp256k1 public key, compressed (33 bytes) or uncompressed (65 bytes). Normal
 
 ## Returns
 
-An `EvmAddress`: the EIP-55 mixed-case checksummed address as a `0x`-prefixed string. `EvmAddress` is the structural type `` `0x${string}` ``.
+```ts
+import type { EvmAddress } from "@category-labs/mera";
+
+type ReturnType = EvmAddress;
+```
+
+The EIP-55 mixed-case checksummed address as a `0x`-prefixed string. `EvmAddress` is the structural type `` `0x${string}` ``.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -14,6 +14,9 @@ import { getPasskeyPrfOutput } from "@category-labs/mera";
 ## Usage
 
 ```ts
+import { getPasskeyPrfOutput } from "@category-labs/mera";
+
+// ---cut---
 const { credentialId, prfOutput } = await getPasskeyPrfOutput({
   rpId: "account.example.com",
 });
@@ -60,7 +63,16 @@ Client that runs the ceremony. [WebAuthnClient](/reference/web-authn-client/) co
 
 ## Returns
 
-`Promise<PasskeyPrfResult>`: the credential ID (canonical unpadded base64url) and the 32-byte PRF output. When `credential` is omitted, the result may identify any discoverable credential for the relying party.
+```ts
+import type { PasskeyPrfResult } from "@category-labs/mera";
+
+type ReturnType = Promise<PasskeyPrfResult>;
+```
+
+- `credentialId` (`string`): the selected credential ID as canonical unpadded base64url.
+- `prfOutput` (`Uint8Array<ArrayBuffer>`): the 32-byte PRF output.
+
+When `credential` is omitted, the result may identify any discoverable credential for the relying party.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/get-solana-address.md
+++ b/docs/src/content/docs/reference/get-solana-address.md
@@ -38,7 +38,13 @@ A 32-byte Ed25519 public key.
 
 ## Returns
 
-A `SolanaAddress`, a branded `string` type.
+```ts
+import type { SolanaAddress } from "@category-labs/mera";
+
+type ReturnType = SolanaAddress;
+```
+
+A base58-encoded 32-byte address. `SolanaAddress` is a branded `string` type and a plain string at runtime.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/parse-secret-vault.md
+++ b/docs/src/content/docs/reference/parse-secret-vault.md
@@ -14,6 +14,9 @@ import { parseSecretVault } from "@category-labs/mera";
 ## Usage
 
 ```ts
+import { parseSecretVault } from "@category-labs/mera";
+
+// ---cut---
 const vault = parseSecretVault(localStorage.getItem("vault"));
 ```
 
@@ -28,7 +31,13 @@ The secret vault as JSON text or an untrusted object. Strings are JSON-parsed fi
 
 ## Returns
 
-A validated `PasskeySecretVault`. Its credential ID, PRF salt, nonce, and ciphertext are canonical base64url with checked lengths (salt 32 bytes, nonce 12 bytes, ciphertext at least the 16-byte GCM tag). Unknown fields are dropped.
+```ts
+import type { PasskeySecretVault } from "@category-labs/mera";
+
+type ReturnType = PasskeySecretVault;
+```
+
+A validated vault with `version`, `credential`, `prfSalt`, `nonce`, and `ciphertext`. Its credential ID, PRF salt, nonce, and ciphertext are canonical base64url with checked lengths (salt 32 bytes, nonce 12 bytes, ciphertext at least the 16-byte GCM tag). Unknown fields are dropped. The [secret vault format](/reference/secret-vault-format/) page documents every field.
 
 ## Errors
 

--- a/docs/src/content/docs/reference/to-viem-account.md
+++ b/docs/src/content/docs/reference/to-viem-account.md
@@ -57,7 +57,13 @@ viem nonce manager forwarded to the account. viem clients use it to assign trans
 
 ## Returns
 
-A viem `LocalAccount` with `source: "mera"`, accepted anywhere viem takes an account.
+```ts
+import type { LocalAccount } from "viem";
+
+type ReturnType = LocalAccount<"mera">;
+```
+
+A viem [`LocalAccount`](https://viem.sh/docs/accounts/local) with `source: "mera"`, accepted anywhere viem takes an account.
 
 ### address
 

--- a/docs/src/content/docs/reference/web-authn-client.md
+++ b/docs/src/content/docs/reference/web-authn-client.md
@@ -10,6 +10,14 @@ The built-in browser client calls `navigator.credentials`. Apps on other platfor
 ## Members
 
 ```ts
+import type {
+  WebAuthnCreateCredentialRequest,
+  WebAuthnCreateCredentialResult,
+  WebAuthnGetCredentialRequest,
+  WebAuthnGetCredentialResult,
+} from "@category-labs/mera";
+
+// ---cut---
 type WebAuthnClient = {
   readonly createCredential: (
     request: WebAuthnCreateCredentialRequest,
@@ -19,6 +27,24 @@ type WebAuthnClient = {
   ) => Promise<WebAuthnGetCredentialResult>;
 };
 ```
+
+Related types: [`WebAuthnCreateCredentialRequest`](#webauthncreatecredentialrequest), [`WebAuthnCreateCredentialResult`](#webauthncreatecredentialresult), [`WebAuthnGetCredentialRequest`](#webauthngetcredentialrequest), and [`WebAuthnGetCredentialResult`](#webauthngetcredentialresult).
+
+### WebAuthnCreateCredentialRequest
+
+The relying party, user, challenge, credential policy, and PRF salt for a creation ceremony.
+
+### WebAuthnCreateCredentialResult
+
+The new credential ID, reported transports, PRF support flag, and optional PRF output.
+
+### WebAuthnGetCredentialRequest
+
+The relying party ID, challenge, optional allowed credential, and PRF salt for an assertion ceremony.
+
+### WebAuthnGetCredentialResult
+
+The credential ID that answered and its optional PRF output.
 
 Requests and results use `Uint8Array` for binary values. When creation enables PRF but returns no output, mera calls `getCredential` with the same client and salt.
 

--- a/docs/src/styles/mera.css
+++ b/docs/src/styles/mera.css
@@ -124,6 +124,13 @@ svg.mera-diagram {
   height: auto;
 }
 
+/* The Twoslash script sets a viewport-sized max height on each popup. Scroll
+   the popup itself so long types stay within that bound. */
+.expressive-code .twoslash-popup-container {
+  margin-top: 0;
+  overflow: auto;
+}
+
 .mera-diagram text {
   font-family: var(--sl-font);
   font-size: 15px;

--- a/docs/tsconfig.twoslash.json
+++ b/docs/tsconfig.twoslash.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "ESNext.Disposable"],
+    "types": [],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## Why

The docs show TypeScript types such as WebAuthnCreateCredentialRequest without enough context to understand them in place. Inline return types such as Promise<PasskeyPrfResult> also hide the returned object. Examples can drift from the public package because syntax highlighting does not check their types.

## Notes for reviewers

Twoslash adds hover details and JSDoc to each TypeScript and TSX block while the visible examples stay short. Every function reference now presents its return contract as checked TypeScript. Structured results also name their fields in plain text, so the API remains clear without hover.

Astro logs Twoslash errors from plain Markdown without returning a failing exit code. A separate snippet check makes the same errors fail the docs build. The docs install copies the built local package so its optional Viem peer resolves to the same Viem instance as the examples.

This PR stacks on #264.

Manual checks covered desktop hover, tooltip bounds, copied imports, and the narrow-screen fallback.