### PR TITLE
Standardize function-owned type namespaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ The library exposes unopinionated primitives ("Lego blocks") that consumers comp
 - Use strict typing and avoid `any`.
 - Prefer `type` aliases unless an `interface` is clearly better.
 - Exported functions should have explicit return types.
-- Keep central type files for durable shared/public data shapes. Define public single-function option bags near the implementation as named `<FunctionName>Options` types used directly in the signature, and avoid moving them into the central type file.
+- Keep central type files for durable shared/public data shapes. When a function or public contract owns two or more named types, put them in a merged `declare namespace` beside it, using names such as `functionName.Options` and `functionName.Result` directly in its signature. Keep a lone function-owned type near the implementation as a prefixed name such as `<FunctionName>Options`; do not create a namespace with one member or keep parallel aliases for namespaced types.
 - Keep exports grouped at the end of hand-written TypeScript files instead of scattering `export` keywords through declarations.
 - Use runtime validation at string and wire boundaries, where TypeScript cannot protect callers.
 - Do not add runtime checks for typed internal invariants that TypeScript already proves, such as required callbacks or disallowed fields within SDK-only control flow.

--- a/demo-mobile/src/prfStore.ts
+++ b/demo-mobile/src/prfStore.ts
@@ -1,4 +1,4 @@
-import type { PasskeyPrfResult } from "@category-labs/mera";
+import type { getPasskeyPrfOutput } from "@category-labs/mera";
 import { base64urlnopad } from "@scure/base";
 import {
   deleteItemAsync,
@@ -18,12 +18,14 @@ const ITEM_OPTIONS = {
 
 const PRF_OUTPUT_LENGTH = 32;
 
-type StoredPrfResult = Pick<PasskeyPrfResult, "credentialId"> & {
+type StoredPrfResult = Pick<getPasskeyPrfOutput.Result, "credentialId"> & {
   prfOutput: string;
 };
 
 /** Storage failures, declined authentication, and malformed data throw. */
-async function readStoredPrfResult(): Promise<PasskeyPrfResult | undefined> {
+async function readStoredPrfResult(): Promise<
+  getPasskeyPrfOutput.Result | undefined
+> {
   const stored = await getItemAsync(KEY, ITEM_OPTIONS);
 
   if (stored === null) {
@@ -47,7 +49,9 @@ async function readStoredPrfResult(): Promise<PasskeyPrfResult | undefined> {
   return { credentialId, prfOutput: bytes };
 }
 
-async function storePrfResult(result: PasskeyPrfResult): Promise<void> {
+async function storePrfResult(
+  result: getPasskeyPrfOutput.Result,
+): Promise<void> {
   const stored: StoredPrfResult = {
     credentialId: result.credentialId,
     prfOutput: base64urlnopad.encode(result.prfOutput),

--- a/demo-mobile/src/wallet.ts
+++ b/demo-mobile/src/wallet.ts
@@ -5,7 +5,6 @@ import {
   getEvmAddress,
   getPasskeyPrfOutput,
   isMeraError,
-  type PasskeyPrfResult,
   type Secp256k1SigningSession,
 } from "@category-labs/mera";
 import { reactNativeWebAuthnClient } from "@category-labs/mera/react-native-webauthn-client";
@@ -63,7 +62,7 @@ async function restoreStoredAccount(): Promise<PasskeyWallet | undefined> {
 function toWallet({
   credentialId,
   prfOutput,
-}: PasskeyPrfResult): PasskeyWallet {
+}: getPasskeyPrfOutput.Result): PasskeyWallet {
   const seed = mnemonicToSeed(prfOutputToMnemonic(prfOutput));
   prfOutput.fill(0);
   // The session copies what it is given, so this array is the demo's to clear.

--- a/docs/src/content/docs/recipes/create-passkey-accounts.mdx
+++ b/docs/src/content/docs/recipes/create-passkey-accounts.mdx
@@ -34,9 +34,9 @@ Every call creates a new passkey.
 The app can store the credential metadata and pass it back on the next sign-in, so the browser reuses the same passkey instead of offering a choice.
 
 ```ts
-import type { CreatePasskeyWithPrfOutputResult } from "@category-labs/mera";
+import type { createPasskeyWithPrfOutput } from "@category-labs/mera";
 
-declare const created: CreatePasskeyWithPrfOutputResult;
+declare const created: createPasskeyWithPrfOutput.Result;
 
 // ---cut---
 localStorage.setItem(

--- a/docs/src/content/docs/reference/create-passkey-with-prf-output.md
+++ b/docs/src/content/docs/reference/create-passkey-with-prf-output.md
@@ -25,7 +25,7 @@ const { credentialId, prfSalt, prfOutput } = await createPasskeyWithPrfOutput({
 
 ## Parameters
 
-`options` is a `CreatePasskeyWithPrfOutputOptions`.
+`options` is a `createPasskeyWithPrfOutput.Options`.
 
 ### options.rp
 
@@ -72,9 +72,9 @@ Client that runs the ceremonies. [WebAuthnClient](/reference/web-authn-client/) 
 ## Returns
 
 ```ts
-import type { CreatePasskeyWithPrfOutputResult } from "@category-labs/mera";
+import type { createPasskeyWithPrfOutput } from "@category-labs/mera";
 
-type ReturnType = Promise<CreatePasskeyWithPrfOutputResult>;
+type ReturnType = Promise<createPasskeyWithPrfOutput.Result>;
 ```
 
 - `credentialId` (`string`): the new credential ID as canonical unpadded base64url.

--- a/docs/src/content/docs/reference/get-passkey-prf-output.md
+++ b/docs/src/content/docs/reference/get-passkey-prf-output.md
@@ -24,7 +24,7 @@ const { credentialId, prfOutput } = await getPasskeyPrfOutput({
 
 ## Parameters
 
-`options` is a `GetPasskeyPrfOutputOptions`.
+`options` is a `getPasskeyPrfOutput.Options`.
 
 ### options.rpId
 
@@ -64,9 +64,9 @@ Client that runs the ceremony. [WebAuthnClient](/reference/web-authn-client/) co
 ## Returns
 
 ```ts
-import type { PasskeyPrfResult } from "@category-labs/mera";
+import type { getPasskeyPrfOutput } from "@category-labs/mera";
 
-type ReturnType = Promise<PasskeyPrfResult>;
+type ReturnType = Promise<getPasskeyPrfOutput.Result>;
 ```
 
 - `credentialId` (`string`): the selected credential ID as canonical unpadded base64url.

--- a/docs/src/content/docs/reference/web-authn-client.md
+++ b/docs/src/content/docs/reference/web-authn-client.md
@@ -10,39 +10,34 @@ The built-in browser client calls `navigator.credentials`. Apps on other platfor
 ## Members
 
 ```ts
-import type {
-  WebAuthnCreateCredentialRequest,
-  WebAuthnCreateCredentialResult,
-  WebAuthnGetCredentialRequest,
-  WebAuthnGetCredentialResult,
-} from "@category-labs/mera";
+import type { WebAuthnClient as MeraWebAuthnClient } from "@category-labs/mera";
 
 // ---cut---
 type WebAuthnClient = {
   readonly createCredential: (
-    request: WebAuthnCreateCredentialRequest,
-  ) => Promise<WebAuthnCreateCredentialResult>;
+    request: MeraWebAuthnClient.CreateCredentialRequest,
+  ) => Promise<MeraWebAuthnClient.CreateCredentialResult>;
   readonly getCredential: (
-    request: WebAuthnGetCredentialRequest,
-  ) => Promise<WebAuthnGetCredentialResult>;
+    request: MeraWebAuthnClient.GetCredentialRequest,
+  ) => Promise<MeraWebAuthnClient.GetCredentialResult>;
 };
 ```
 
-Related types: [`WebAuthnCreateCredentialRequest`](#webauthncreatecredentialrequest), [`WebAuthnCreateCredentialResult`](#webauthncreatecredentialresult), [`WebAuthnGetCredentialRequest`](#webauthngetcredentialrequest), and [`WebAuthnGetCredentialResult`](#webauthngetcredentialresult).
+Related types: [`WebAuthnClient.CreateCredentialRequest`](#webauthnclientcreatecredentialrequest), [`WebAuthnClient.CreateCredentialResult`](#webauthnclientcreatecredentialresult), [`WebAuthnClient.GetCredentialRequest`](#webauthnclientgetcredentialrequest), and [`WebAuthnClient.GetCredentialResult`](#webauthnclientgetcredentialresult).
 
-### WebAuthnCreateCredentialRequest
+### WebAuthnClient.CreateCredentialRequest
 
 The relying party, user, challenge, credential policy, and PRF salt for a creation ceremony.
 
-### WebAuthnCreateCredentialResult
+### WebAuthnClient.CreateCredentialResult
 
 The new credential ID, reported transports, PRF support flag, and optional PRF output.
 
-### WebAuthnGetCredentialRequest
+### WebAuthnClient.GetCredentialRequest
 
 The relying party ID, challenge, optional allowed credential, and PRF salt for an assertion ceremony.
 
-### WebAuthnGetCredentialResult
+### WebAuthnClient.GetCredentialResult
 
 The credential ID that answered and its optional PRF output.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,6 @@ export { getSolanaAddress } from "./chains/solana.js";
 export { createEd25519SigningSession } from "./ed25519.js";
 export type { MeraErrorCode } from "./errors.js";
 export { isMeraError, MeraError } from "./errors.js";
-export type {
-  CreatePasskeyWithPrfOutputOptions,
-  GetPasskeyPrfOutputOptions,
-} from "./passkey.js";
 export { createPasskeyWithPrfOutput, getPasskeyPrfOutput } from "./passkey.js";
 export { createSecp256k1SigningSession } from "./secp256k1.js";
 export type {
@@ -21,24 +17,15 @@ export {
   parseSecretVault,
 } from "./secret.js";
 export type {
-  CreatePasskeyWithPrfOutputResult,
   CreateSigningSessionOptions,
   Ed25519SigningSession,
   EvmAddress,
   PasskeyCredentialMetadata,
   PasskeyCredentialTransport,
-  PasskeyPrfResult,
   PasskeyRelyingParty,
   PasskeySecretVault,
   Secp256k1Signature,
   Secp256k1SigningSession,
   SolanaAddress,
 } from "./types.js";
-export type {
-  WebAuthnAllowCredential,
-  WebAuthnClient,
-  WebAuthnCreateCredentialRequest,
-  WebAuthnCreateCredentialResult,
-  WebAuthnGetCredentialRequest,
-  WebAuthnGetCredentialResult,
-} from "./webauthn.js";
+export type { WebAuthnClient } from "./webauthn.js";

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -3,74 +3,16 @@ import { utf8ToBytes } from "@noble/hashes/utils.js";
 import { base64UrlDecode, base64UrlEncode, copyBytes } from "./encoding.js";
 import { isMeraError, MeraError } from "./errors.js";
 import type {
-  CreatePasskeyWithPrfOutputResult,
   PasskeyCredentialMetadata,
   PasskeyCredentialTransport,
-  PasskeyPrfResult,
   PasskeyRelyingParty,
 } from "./types.js";
-import {
-  browserWebAuthnClient,
-  type WebAuthnAllowCredential,
-  type WebAuthnClient,
-} from "./webauthn.js";
+import { browserWebAuthnClient, type WebAuthnClient } from "./webauthn.js";
 import { randomBytes } from "./webcrypto.js";
 
 const DEFAULT_PRF_SALT = sha256(utf8ToBytes("mera.prf.salt.v1"));
 
 const PASSKEY_COSE_ALGORITHMS = [-7, -257];
-
-/** Inputs for creating a passkey and obtaining its first WebAuthn PRF output. */
-type CreatePasskeyWithPrfOutputOptions = {
-  /**
-   * Relying party identity passed to WebAuthn. `id` is required so the
-   * fallback assertion can target the same relying party.
-   */
-  rp: PasskeyRelyingParty;
-  /** User identity passed to WebAuthn. */
-  user: {
-    /** User name displayed or stored by the authenticator. */
-    name: string;
-    /** Human-readable display name for the authenticator UI. */
-    displayName: string;
-  };
-  /** WebAuthn timeout in milliseconds. Platform defaults apply when omitted. */
-  timeout?: number;
-  /**
-   * 32-byte PRF salt evaluated during creation, or by the fallback assertion.
-   * Defaults to the fixed salt documented on {@link getPasskeyPrfOutput}.
-   */
-  prfSalt?: Uint8Array;
-  /**
-   * Client that runs the WebAuthn ceremonies. Defaults to the built-in browser
-   * client, which calls `navigator.credentials`.
-   */
-  webAuthnClient?: WebAuthnClient;
-};
-
-/** Inputs for requesting the first WebAuthn PRF output from a passkey. */
-type GetPasskeyPrfOutputOptions = {
-  /** Relying party ID for the WebAuthn assertion. */
-  rpId: string;
-  /**
-   * Credential metadata to restrict the assertion to one passkey. When
-   * omitted, WebAuthn may choose any discoverable credential for the relying
-   * party.
-   */
-  credential?: PasskeyCredentialMetadata;
-  /**
-   * PRF salt as 32 raw bytes. Defaults to the fixed salt documented on
-   * {@link getPasskeyPrfOutput}.
-   */
-  prfSalt?: Uint8Array;
-  /** WebAuthn timeout in milliseconds. Platform defaults apply when omitted. */
-  timeout?: number;
-  /**
-   * Client that runs the WebAuthn ceremony. Defaults to the built-in browser
-   * client, which calls `navigator.credentials`.
-   */
-  webAuthnClient?: WebAuthnClient;
-};
 
 /**
  * Creates a discoverable, user-verified passkey that requires WebAuthn PRF
@@ -105,7 +47,7 @@ async function createPasskeyWithPrfOutput({
   timeout,
   prfSalt,
   webAuthnClient = browserWebAuthnClient,
-}: CreatePasskeyWithPrfOutputOptions): Promise<CreatePasskeyWithPrfOutputResult> {
+}: createPasskeyWithPrfOutput.Options): Promise<createPasskeyWithPrfOutput.Result> {
   try {
     validatePrfSalt(prfSalt);
 
@@ -168,6 +110,46 @@ async function createPasskeyWithPrfOutput({
   }
 }
 
+declare namespace createPasskeyWithPrfOutput {
+  /** Inputs for creating a passkey and obtaining its first WebAuthn PRF output. */
+  type Options = {
+    /**
+     * Relying party identity passed to WebAuthn. `id` is required so the
+     * fallback assertion can target the same relying party.
+     */
+    rp: PasskeyRelyingParty;
+    /** User identity passed to WebAuthn. */
+    user: {
+      /** User name displayed or stored by the authenticator. */
+      name: string;
+      /** Human-readable display name for the authenticator UI. */
+      displayName: string;
+    };
+    /** WebAuthn timeout in milliseconds. Platform defaults apply when omitted. */
+    timeout?: number;
+    /**
+     * 32-byte PRF salt evaluated during creation, or by the fallback assertion.
+     * Defaults to the fixed salt documented on {@link getPasskeyPrfOutput}.
+     */
+    prfSalt?: Uint8Array;
+    /**
+     * Client that runs the WebAuthn ceremonies. Defaults to the built-in browser
+     * client, which calls `navigator.credentials`.
+     */
+    webAuthnClient?: WebAuthnClient;
+  };
+
+  /** Result of creating a passkey together with its first PRF output. */
+  type Result = PasskeyCredentialMetadata & {
+    /**
+     * PRF salt that WebAuthn evaluated. Always 32 bytes, in a fresh allocation.
+     */
+    readonly prfSalt: Uint8Array<ArrayBuffer>;
+    /** First WebAuthn PRF output for `prfSalt`. Always 32 bytes. */
+    readonly prfOutput: Uint8Array<ArrayBuffer>;
+  };
+}
+
 /**
  * Requests a passkey PRF evaluation and returns the first output.
  *
@@ -203,7 +185,7 @@ async function getPasskeyPrfOutput({
   prfSalt,
   timeout,
   webAuthnClient = browserWebAuthnClient,
-}: GetPasskeyPrfOutputOptions): Promise<PasskeyPrfResult> {
+}: getPasskeyPrfOutput.Options): Promise<getPasskeyPrfOutput.Result> {
   try {
     validatePrfSalt(prfSalt);
 
@@ -243,6 +225,40 @@ async function getPasskeyPrfOutput({
   }
 }
 
+declare namespace getPasskeyPrfOutput {
+  /** Inputs for requesting the first WebAuthn PRF output from a passkey. */
+  type Options = {
+    /** Relying party ID for the WebAuthn assertion. */
+    rpId: string;
+    /**
+     * Credential metadata to restrict the assertion to one passkey. When
+     * omitted, WebAuthn may choose any discoverable credential for the relying
+     * party.
+     */
+    credential?: PasskeyCredentialMetadata;
+    /**
+     * PRF salt as 32 raw bytes. Defaults to the fixed salt documented on
+     * {@link getPasskeyPrfOutput}.
+     */
+    prfSalt?: Uint8Array;
+    /** WebAuthn timeout in milliseconds. Platform defaults apply when omitted. */
+    timeout?: number;
+    /**
+     * Client that runs the WebAuthn ceremony. Defaults to the built-in browser
+     * client, which calls `navigator.credentials`.
+     */
+    webAuthnClient?: WebAuthnClient;
+  };
+
+  /** Result of a passkey assertion with the WebAuthn PRF extension. */
+  type Result = {
+    /** Credential ID selected by the platform, as canonical unpadded base64url. */
+    readonly credentialId: string;
+    /** First PRF output from WebAuthn. Always 32 bytes. */
+    readonly prfOutput: Uint8Array<ArrayBuffer>;
+  };
+}
+
 function toCredentialMetadata(
   credentialId: string,
   transports: readonly PasskeyCredentialTransport[] | undefined,
@@ -262,7 +278,7 @@ function toCredentialMetadata(
  */
 function toAllowCredential(
   credential: PasskeyCredentialMetadata,
-): WebAuthnAllowCredential {
+): WebAuthnClient.AllowCredential {
   return {
     credentialId: base64UrlDecode(credential.credentialId, {
       name: "credential.credentialId",
@@ -288,7 +304,6 @@ function copyPrfOutput(prfOutput: Uint8Array): Uint8Array<ArrayBuffer> {
   return copyBytes(prfOutput);
 }
 
-export type { CreatePasskeyWithPrfOutputOptions, GetPasskeyPrfOutputOptions };
 export {
   createPasskeyWithPrfOutput,
   getPasskeyPrfOutput,

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -1,16 +1,11 @@
 import { base64UrlDecode, base64UrlEncode, copyBytes } from "./encoding.js";
 import { MeraError } from "./errors.js";
-import type {
-  CreatePasskeyWithPrfOutputOptions,
-  GetPasskeyPrfOutputOptions,
-} from "./passkey.js";
 import {
   createPasskeyWithPrfOutput,
   getPasskeyPrfOutput,
   toCredentialMetadata,
 } from "./passkey.js";
 import type {
-  CreatePasskeyWithPrfOutputResult,
   PasskeyCredentialTransport,
   PasskeySecretVault,
 } from "./types.js";
@@ -90,7 +85,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /** Inputs for `createSecretVault`. */
 type CreateSecretVaultOptions = {
   /** Credential metadata plus the PRF salt and PRF output that key this secret. */
-  credential: CreatePasskeyWithPrfOutputResult;
+  credential: createPasskeyWithPrfOutput.Result;
   /** Secret bytes to encrypt. */
   secret: Uint8Array<ArrayBuffer>;
 };
@@ -144,7 +139,7 @@ async function createSecretVault({
 
 /** Inputs for creating a secret vault together with a new passkey. */
 type CreateSecretVaultWithNewPasskeyOptions = Omit<
-  CreatePasskeyWithPrfOutputOptions,
+  createPasskeyWithPrfOutput.Options,
   "prfSalt"
 > & {
   /** Secret bytes to encrypt. Any non-empty length. */
@@ -153,7 +148,7 @@ type CreateSecretVaultWithNewPasskeyOptions = Omit<
 
 /** Inputs for creating a secret vault with an existing passkey. */
 type CreateSecretVaultWithExistingPasskeyOptions = Omit<
-  GetPasskeyPrfOutputOptions,
+  getPasskeyPrfOutput.Options,
   "prfSalt"
 > & {
   /** Secret bytes to encrypt. Any non-empty length. */
@@ -387,7 +382,7 @@ function parseSecretVault(value: unknown): PasskeySecretVault {
 
 /** Inputs for decrypting a secret vault with a passkey. */
 type DecryptSecretVaultWithPasskeyOptions = Omit<
-  GetPasskeyPrfOutputOptions,
+  getPasskeyPrfOutput.Options,
   "credential" | "prfSalt"
 > & {
   /** Secret vault to decrypt. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,24 +50,6 @@ type PasskeyCredentialMetadata = {
   readonly transports?: readonly PasskeyCredentialTransport[];
 };
 
-/** Result of a passkey assertion with the WebAuthn PRF extension. */
-type PasskeyPrfResult = {
-  /** Credential ID selected by the platform, as canonical unpadded base64url. */
-  readonly credentialId: string;
-  /** First PRF output from WebAuthn. Always 32 bytes. */
-  readonly prfOutput: Uint8Array<ArrayBuffer>;
-};
-
-/** Result of creating a passkey together with its first PRF output. */
-type CreatePasskeyWithPrfOutputResult = PasskeyCredentialMetadata & {
-  /**
-   * PRF salt that WebAuthn evaluated. Always 32 bytes, in a fresh allocation.
-   */
-  readonly prfSalt: Uint8Array<ArrayBuffer>;
-  /** First WebAuthn PRF output for `prfSalt`. Always 32 bytes. */
-  readonly prfOutput: Uint8Array<ArrayBuffer>;
-};
-
 /**
  * Versioned JSON-safe vault holding one secret encrypted behind a passkey.
  * The secret bytes are opaque to the library.
@@ -146,13 +128,11 @@ type Ed25519SigningSession = SigningSession & {
 };
 
 export type {
-  CreatePasskeyWithPrfOutputResult,
   CreateSigningSessionOptions,
   Ed25519SigningSession,
   EvmAddress,
   PasskeyCredentialMetadata,
   PasskeyCredentialTransport,
-  PasskeyPrfResult,
   PasskeyRelyingParty,
   PasskeySecretVault,
   Secp256k1Signature,

--- a/src/webauthn.ts
+++ b/src/webauthn.ts
@@ -5,81 +5,83 @@ import type {
   PasskeyRelyingParty,
 } from "./types.js";
 
-/** Ceremony parameters for creating one passkey and evaluating its PRF. */
-type WebAuthnCreateCredentialRequest = {
-  /** Relying party identity for the new credential. */
-  rp: PasskeyRelyingParty;
-  /** User identity stored with the discoverable credential. */
-  user: {
-    id: Uint8Array<ArrayBuffer>;
-    name: string;
-    displayName: string;
-  };
-  challenge: Uint8Array<ArrayBuffer>;
-  /** COSE algorithm identifiers for the credential key, most preferred first. */
-  algorithms: readonly number[];
-  /** PRF salt to evaluate during creation, as 32 raw bytes. */
-  prfSalt: Uint8Array<ArrayBuffer>;
-  /** Discoverable-credential requirement. */
-  residentKey: "required";
-  userVerification: "required";
-  attestation: "none";
-  /** Timeout in milliseconds. Platform defaults apply when omitted. */
-  timeout?: number;
-};
-
-/** Outcome of one credential-creation ceremony. */
-type WebAuthnCreateCredentialResult = {
-  /** Credential ID of the new passkey, as raw bytes. */
-  credentialId: Uint8Array;
-  /** Authenticator transports reported for the new credential. */
-  transports?: readonly PasskeyCredentialTransport[];
-  /** Whether the authenticator enabled PRF for the new credential. */
-  prfEnabled: boolean;
-  /** First PRF output, when the authenticator evaluated the salt during creation. */
-  prfOutput?: Uint8Array;
-};
-
-/** Credential an assertion is restricted to. */
-type WebAuthnAllowCredential = {
-  credentialId: Uint8Array<ArrayBuffer>;
-  /** Authenticator transports, which the platform reads as hints. */
-  transports?: readonly PasskeyCredentialTransport[];
-};
-
-/** Ceremony parameters for asserting a passkey and evaluating its PRF. */
-type WebAuthnGetCredentialRequest = {
-  /** Relying party ID the assertion targets. */
-  rpId: string;
-  challenge: Uint8Array<ArrayBuffer>;
-  /**
-   * Credential the assertion is restricted to. When omitted, any discoverable
-   * credential for `rpId` may answer.
-   */
-  allowCredential?: WebAuthnAllowCredential;
-  /** PRF salt to evaluate, as 32 raw bytes. */
-  prfSalt: Uint8Array<ArrayBuffer>;
-  userVerification: "required";
-  /** Timeout in milliseconds. Platform defaults apply when omitted. */
-  timeout?: number;
-};
-
-/** Outcome of one assertion ceremony. */
-type WebAuthnGetCredentialResult = {
-  /** Credential ID that answered, as raw bytes. */
-  credentialId: Uint8Array;
-  /** First PRF output for the requested salt. */
-  prfOutput?: Uint8Array;
-};
-
 type WebAuthnClient = {
   readonly createCredential: (
-    request: WebAuthnCreateCredentialRequest,
-  ) => Promise<WebAuthnCreateCredentialResult>;
+    request: WebAuthnClient.CreateCredentialRequest,
+  ) => Promise<WebAuthnClient.CreateCredentialResult>;
   readonly getCredential: (
-    request: WebAuthnGetCredentialRequest,
-  ) => Promise<WebAuthnGetCredentialResult>;
+    request: WebAuthnClient.GetCredentialRequest,
+  ) => Promise<WebAuthnClient.GetCredentialResult>;
 };
+
+declare namespace WebAuthnClient {
+  /** Ceremony parameters for creating one passkey and evaluating its PRF. */
+  type CreateCredentialRequest = {
+    /** Relying party identity for the new credential. */
+    rp: PasskeyRelyingParty;
+    /** User identity stored with the discoverable credential. */
+    user: {
+      id: Uint8Array<ArrayBuffer>;
+      name: string;
+      displayName: string;
+    };
+    challenge: Uint8Array<ArrayBuffer>;
+    /** COSE algorithm identifiers for the credential key, most preferred first. */
+    algorithms: readonly number[];
+    /** PRF salt to evaluate during creation, as 32 raw bytes. */
+    prfSalt: Uint8Array<ArrayBuffer>;
+    /** Discoverable-credential requirement. */
+    residentKey: "required";
+    userVerification: "required";
+    attestation: "none";
+    /** Timeout in milliseconds. Platform defaults apply when omitted. */
+    timeout?: number;
+  };
+
+  /** Outcome of one credential-creation ceremony. */
+  type CreateCredentialResult = {
+    /** Credential ID of the new passkey, as raw bytes. */
+    credentialId: Uint8Array;
+    /** Authenticator transports reported for the new credential. */
+    transports?: readonly PasskeyCredentialTransport[];
+    /** Whether the authenticator enabled PRF for the new credential. */
+    prfEnabled: boolean;
+    /** First PRF output, when the authenticator evaluated the salt during creation. */
+    prfOutput?: Uint8Array;
+  };
+
+  /** Credential an assertion is restricted to. */
+  type AllowCredential = {
+    credentialId: Uint8Array<ArrayBuffer>;
+    /** Authenticator transports, which the platform reads as hints. */
+    transports?: readonly PasskeyCredentialTransport[];
+  };
+
+  /** Ceremony parameters for asserting a passkey and evaluating its PRF. */
+  type GetCredentialRequest = {
+    /** Relying party ID the assertion targets. */
+    rpId: string;
+    challenge: Uint8Array<ArrayBuffer>;
+    /**
+     * Credential the assertion is restricted to. When omitted, any discoverable
+     * credential for `rpId` may answer.
+     */
+    allowCredential?: AllowCredential;
+    /** PRF salt to evaluate, as 32 raw bytes. */
+    prfSalt: Uint8Array<ArrayBuffer>;
+    userVerification: "required";
+    /** Timeout in milliseconds. Platform defaults apply when omitted. */
+    timeout?: number;
+  };
+
+  /** Outcome of one assertion ceremony. */
+  type GetCredentialResult = {
+    /** Credential ID that answered, as raw bytes. */
+    credentialId: Uint8Array;
+    /** First PRF output for the requested salt. */
+    prfOutput?: Uint8Array;
+  };
+}
 
 type PrfClientExtensionResults = AuthenticationExtensionsClientOutputs & {
   prf?: {
@@ -212,12 +214,5 @@ function assertPublicKeyCredential(
   return credential as PublicKeyCredentialWithPrf;
 }
 
-export type {
-  WebAuthnAllowCredential,
-  WebAuthnClient,
-  WebAuthnCreateCredentialRequest,
-  WebAuthnCreateCredentialResult,
-  WebAuthnGetCredentialRequest,
-  WebAuthnGetCredentialResult,
-};
+export type { WebAuthnClient };
 export { browserWebAuthnClient };

--- a/test/public-api-types.test-d.ts
+++ b/test/public-api-types.test-d.ts
@@ -1,0 +1,152 @@
+import type {
+  CreateSecretVaultWithExistingPasskeyOptions,
+  CreateSecretVaultWithNewPasskeyOptions,
+  CreateSigningSessionOptions,
+  createEd25519SigningSession,
+  createPasskeyWithPrfOutput,
+  createSecp256k1SigningSession,
+  createSecretVaultWithExistingPasskey,
+  createSecretVaultWithNewPasskey,
+  DecryptSecretVaultWithPasskeyOptions,
+  decryptSecretVaultWithPasskey,
+  getPasskeyPrfOutput,
+  WebAuthnClient,
+} from "../dist/index.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <
+    Value,
+  >() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+
+type Expect<Value extends true> = Value;
+
+type PublicFunctionOptions = [
+  Expect<
+    Equal<
+      Parameters<typeof createPasskeyWithPrfOutput>[0],
+      createPasskeyWithPrfOutput.Options
+    >
+  >,
+  Expect<
+    Equal<
+      Parameters<typeof getPasskeyPrfOutput>[0],
+      getPasskeyPrfOutput.Options
+    >
+  >,
+  Expect<
+    Equal<
+      Parameters<typeof createSecretVaultWithNewPasskey>[0],
+      CreateSecretVaultWithNewPasskeyOptions
+    >
+  >,
+  Expect<
+    Equal<
+      Parameters<typeof createSecretVaultWithExistingPasskey>[0],
+      CreateSecretVaultWithExistingPasskeyOptions
+    >
+  >,
+  Expect<
+    Equal<
+      Parameters<typeof decryptSecretVaultWithPasskey>[0],
+      DecryptSecretVaultWithPasskeyOptions
+    >
+  >,
+  Expect<
+    Equal<
+      Parameters<typeof createSecp256k1SigningSession>[0],
+      CreateSigningSessionOptions
+    >
+  >,
+  Expect<
+    Equal<
+      Parameters<typeof createEd25519SigningSession>[0],
+      CreateSigningSessionOptions
+    >
+  >,
+];
+
+type PublicFunctionResults = [
+  Expect<
+    Equal<
+      Awaited<ReturnType<typeof createPasskeyWithPrfOutput>>,
+      createPasskeyWithPrfOutput.Result
+    >
+  >,
+  Expect<
+    Equal<
+      Awaited<ReturnType<typeof getPasskeyPrfOutput>>,
+      getPasskeyPrfOutput.Result
+    >
+  >,
+];
+
+type NoSingleMemberNamespaces = [
+  // @ts-expect-error A lone options type stays standalone.
+  createSecretVaultWithNewPasskey.Options,
+  // @ts-expect-error A lone options type stays standalone.
+  createSecretVaultWithExistingPasskey.Options,
+  // @ts-expect-error A lone options type stays standalone.
+  decryptSecretVaultWithPasskey.Options,
+  // @ts-expect-error The two signing functions share one standalone options type.
+  createSecp256k1SigningSession.Options,
+  // @ts-expect-error The two signing functions share one standalone options type.
+  createEd25519SigningSession.Options,
+];
+
+type WebAuthnClientTypes = [
+  Expect<
+    Equal<
+      Parameters<WebAuthnClient["createCredential"]>[0],
+      WebAuthnClient.CreateCredentialRequest
+    >
+  >,
+  Expect<
+    Equal<
+      Awaited<ReturnType<WebAuthnClient["createCredential"]>>,
+      WebAuthnClient.CreateCredentialResult
+    >
+  >,
+  Expect<
+    Equal<
+      Parameters<WebAuthnClient["getCredential"]>[0],
+      WebAuthnClient.GetCredentialRequest
+    >
+  >,
+  Expect<
+    Equal<
+      Awaited<ReturnType<WebAuthnClient["getCredential"]>>,
+      WebAuthnClient.GetCredentialResult
+    >
+  >,
+];
+
+type RemovedRootAliases = [
+  // @ts-expect-error The options type now belongs to the function namespace.
+  import("../dist/index.js").CreatePasskeyWithPrfOutputOptions,
+  // @ts-expect-error The result type now belongs to the function namespace.
+  import("../dist/index.js").CreatePasskeyWithPrfOutputResult,
+  // @ts-expect-error The options type now belongs to the function namespace.
+  import("../dist/index.js").GetPasskeyPrfOutputOptions,
+  // @ts-expect-error The result type now belongs to the function namespace.
+  import("../dist/index.js").PasskeyPrfResult,
+  // @ts-expect-error The request type now belongs to WebAuthnClient.
+  import("../dist/index.js").WebAuthnCreateCredentialRequest,
+  // @ts-expect-error The result type now belongs to WebAuthnClient.
+  import("../dist/index.js").WebAuthnCreateCredentialResult,
+  // @ts-expect-error The request type now belongs to WebAuthnClient.
+  import("../dist/index.js").WebAuthnGetCredentialRequest,
+  // @ts-expect-error The result type now belongs to WebAuthnClient.
+  import("../dist/index.js").WebAuthnGetCredentialResult,
+  // @ts-expect-error The credential type now belongs to WebAuthnClient.
+  import("../dist/index.js").WebAuthnAllowCredential,
+];
+
+export type {
+  NoSingleMemberNamespaces,
+  PublicFunctionOptions,
+  PublicFunctionResults,
+  RemovedRootAliases,
+  WebAuthnClientTypes,
+};

--- a/test/viem-public-api-types.test-d.ts
+++ b/test/viem-public-api-types.test-d.ts
@@ -1,0 +1,19 @@
+import type { ToViemAccountOptions, toViemAccount } from "../dist/viem.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <
+    Value,
+  >() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+
+type Expect<Value extends true> = Value;
+
+type ViemFunctionOptions = Expect<
+  Equal<NonNullable<Parameters<typeof toViemAccount>[1]>, ToViemAccountOptions>
+>;
+
+// @ts-expect-error A lone options type stays standalone.
+type NoSingleMemberNamespace = toViemAccount.Options;
+
+export type { NoSingleMemberNamespace, ViemFunctionOptions };

--- a/tsconfig.public-types.json
+++ b/tsconfig.public-types.json
@@ -16,7 +16,11 @@
   },
   // The DOM-free entry points and, through them, every declaration they import.
   // dist/viem.d.ts stays out: it imports viem, whose types are viem's to define.
-  "include": ["dist/index.d.ts", "dist/react-native-webauthn-client.d.ts"],
+  "include": [
+    "dist/index.d.ts",
+    "dist/react-native-webauthn-client.d.ts",
+    "test/public-api-types.test-d.ts"
+  ],
   // tsc excludes outDir by default, and outDir is the inherited dist/, which
   // would drop the one file this checks.
   "exclude": []


### PR DESCRIPTION
Function-associated public types currently use several top-level naming schemes, which makes ownership harder to see and adds noise to the root API.

This change groups APIs with two or more associated types under the owning function or contract. The passkey functions now expose `.Options` and `.Result`, and `WebAuthnClient` owns its request and result types. APIs with only one associated type keep a standalone prefixed name, avoiding one-member namespaces.

This is a type-only breaking change. The old passkey and WebAuthn aliases are removed; runtime behavior, validation, error handling, cryptographic operations, and byte ownership stay unchanged. The demos and reference docs use the new names, and type fixtures cover the intended declaration shape.

Local validation:

- `npm run check`
- `npm test` (71 tests)
- `npm run check:pack`
- web demo build
- PRF demo tests and build
- mobile demo typecheck and Android bundle
- documentation build
