### PR TITLE
Name Chrome extensions and native apps in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Developers can use mera to:
 ## Supported platforms
 
 - Web browsers
+- Chrome extensions
 - React Native on iOS 18 or later and Android 9 or later
+
+The same approach can be used in native applications.
 
 See [authenticator support](https://mera.category.xyz/authenticator-support/) for browser and OS support.
 
@@ -25,10 +28,7 @@ Installation, guides, compatibility information, the security model, the API ref
 ## Repository
 
 - [`library/`](./library/) contains the published package and its tests.
-- [`demos/web/`](./demos/web/) contains the live demo application source.
-- [`demos/extension/`](./demos/extension/) contains the unpacked Chrome side-panel demo.
-- [`demos/mobile/`](./demos/mobile/) contains the Expo mobile demo.
-- [`demos/prf/`](./demos/prf/) contains the standalone passkey PRF model.
+- [`demos/`](./demos/) contains web, Chrome extension, and mobile demos, and a model of how a passkey determines account data.
 - [`docs/`](./docs/) contains the documentation website.
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Developers can use mera to:
 - Chrome extensions
 - React Native on iOS 18 or later and Android 9 or later
 
-The same approach can be used in native applications.
+Native applications can reuse passkeys created with mera through the platform's WebAuthn APIs.
 
 See [authenticator support](https://mera.category.xyz/authenticator-support/) for browser and OS support.
 


### PR DESCRIPTION
## Summary

- The README listed every demo folder. One link to `demos/` with the kinds of demos is enough.
- Platforms now mention Chrome extensions and that the same approach can be used in native applications.

## Test plan

- [ ] Read the Supported platforms and Repository sections in the root README.