### PR TITLE
Drop the engines field from the published package

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -82,8 +82,5 @@
     "react-native-passkey": "3.6.1",
     "typescript": "7.0.2",
     "viem": "2.55.13"
-  },
-  "engines": {
-    "node": ">=24"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "react": "19.2.8",
         "react-native": "0.86.2",
         "react-native-passkey": "3.6.1",
-        "react-native-safe-area-context": "^5.8.1"
+        "react-native-safe-area-context": "~5.8.1"
       },
       "devDependencies": {
         "@types/react": "~19.2.18",
@@ -588,9 +588,6 @@
         "react-native-passkey": "3.6.1",
         "typescript": "7.0.2",
         "viem": "2.55.13"
-      },
-      "engines": {
-        "node": ">=24"
       },
       "peerDependencies": {
         "react-native-passkey": "3.6.1",


### PR DESCRIPTION
`library/package.json` declared `engines.node: ">=24"`. That describes this repository's toolchain, not the library's runtime: the package targets browsers and React Native, and in Node it needs only the built-in Web Crypto global. npm applies a dependency's `engines` to every consumer install, and Yarn Classic refuses to install on a mismatch, so a consumer on an older Node bundling for the browser pays for a constraint that only this repo needs.

The repository keeps its floor: the root `package.json` still declares `engines.node: ">=24"` and `.nvmrc` pins CI.