### PR TITLE
Share the trade policy and the cash input format

### DIFF
--- a/demos/extension/src/TradingPanel.tsx
+++ b/demos/extension/src/TradingPanel.tsx
@@ -9,11 +9,17 @@ import { prfOutputToMnemonic } from "@category-labs/mera-demo-shared/hd";
 import {
   buyShares,
   COMPANY_NAME,
+  coversTrade,
   type Fill,
+  LOW_CASH_WEI,
+  maxTradeInput,
   type Portfolio,
   priceAt,
+  REFRESH_MS,
   readPortfolio,
+  type Side,
   sellShares,
+  sharesToSell,
   TICKER,
   UNIT,
 } from "@category-labs/mera-demo-shared/market";
@@ -60,11 +66,6 @@ import {
   walletFromPrf,
 } from "./wallet";
 
-const REFRESH_MS = 5_000;
-const FEE_RESERVE_WEI = 10n ** 16n;
-const CENT_WEI = 10n ** 16n;
-const LOW_CASH_WEI = 100n * UNIT;
-
 type Props = {
   evm: EvmContext | null;
   evmError: string | null;
@@ -99,7 +100,8 @@ function TradingPanel({
         ? account.address
         : account.wallet.address;
   const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
-  const [side, setSide] = useState<"buy" | "sell">("buy");
+  const [side, setSide] = useState<Side>("buy");
+  const [sellAll, setSellAll] = useState(false);
   const [amount, setAmount] = useState("");
   const [pending, setPending] = useState<PendingAction>(null);
   const [error, setError] = useState<string | null>(null);
@@ -188,6 +190,7 @@ function TradingPanel({
     setBasis(address ? loadCostBasis(address) : 0n);
     setPortfolio(null);
     setAmount("");
+    setSellAll(false);
     setFill(null);
     hideRecovery();
   }, [address, hideRecovery]);
@@ -259,28 +262,14 @@ function TradingPanel({
   const covered =
     amountWei !== null &&
     portfolio !== null &&
-    (side === "buy"
-      ? amountWei + FEE_RESERVE_WEI <= portfolio.cash
-      : positionValue !== null &&
-        estimatedShares !== null &&
-        estimatedShares > 0n &&
-        amountWei <= positionValue + CENT_WEI &&
-        portfolio.cash >= FEE_RESERVE_WEI);
-
-  function cashInput(wei: bigint): string {
-    const cents = wei / CENT_WEI;
-    return `${cents / 100n}.${(cents % 100n).toString().padStart(2, "0")}`;
-  }
+    coversTrade({ side, amountWei, price, portfolio });
 
   function fillMax(): void {
     if (portfolio === null) return;
-    const value =
-      side === "buy"
-        ? portfolio.cash > FEE_RESERVE_WEI
-          ? portfolio.cash - FEE_RESERVE_WEI
-          : 0n
-        : (positionValue ?? 0n);
-    setAmount(cashInput(value));
+    setAmount(maxTradeInput({ side, price, portfolio }));
+    // Max on the sell side means the whole position: converting its stale
+    // cash figure back to shares at a moved price can strand dust.
+    setSellAll(side === "sell");
     setError(null);
   }
 
@@ -367,10 +356,12 @@ function TradingPanel({
         setFill({ ...result, spent: amountWei });
         updateBasis(costBasisAfterBuy(basis, amountWei));
       } else {
-        const shares =
-          amountWei >= (portfolio.shares * price) / UNIT
-            ? portfolio.shares
-            : (amountWei * UNIT) / price;
+        const shares = sharesToSell({
+          amountWei,
+          price,
+          heldShares: portfolio.shares,
+          sellAll,
+        });
         const result = await sellShares(wallet.session, evm, shares);
         if (!operationIsCurrent(epoch, viaTab)) {
           wallet.lock();
@@ -380,6 +371,7 @@ function TradingPanel({
         updateBasis(costBasisAfterSell(basis, result.shares, portfolio.shares));
       }
       setAmount("");
+      setSellAll(false);
       await refresh();
     } catch (caught) {
       if (!operationIsCurrent(epoch, viaTab)) {
@@ -603,7 +595,10 @@ function TradingPanel({
                   role="tab"
                   aria-selected={side === value}
                   disabled={busy}
-                  onClick={() => setSide(value)}
+                  onClick={() => {
+                    setSide(value);
+                    setSellAll(false);
+                  }}
                 >
                   {value === "buy" ? "Buy" : "Sell"}
                 </button>
@@ -634,7 +629,10 @@ function TradingPanel({
                     inputMode="decimal"
                     placeholder="100.00"
                     disabled={busy}
-                    onChange={(event) => setAmount(event.target.value)}
+                    onChange={(event) => {
+                      setAmount(event.target.value);
+                      setSellAll(false);
+                    }}
                   />
                 </label>
                 <button

--- a/demos/mobile/src/TradeForm.tsx
+++ b/demos/mobile/src/TradeForm.tsx
@@ -1,4 +1,8 @@
-import { type Fill, TICKER } from "@category-labs/mera-demo-shared/market";
+import {
+  type Fill,
+  type Side,
+  TICKER,
+} from "@category-labs/mera-demo-shared/market";
 import {
   CASH_SYMBOL,
   formatCash,
@@ -8,8 +12,6 @@ import type { ReactElement } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import { Button, LinkButton } from "./Button";
 import { palette, text } from "./theme";
-
-type Side = "buy" | "sell";
 
 type TradeFormProps = {
   side: Side;
@@ -164,5 +166,4 @@ const styles = StyleSheet.create({
   trade: { gap: 12 },
 });
 
-export type { Side };
 export { TradeForm };

--- a/demos/mobile/src/TradingScreen.tsx
+++ b/demos/mobile/src/TradingScreen.tsx
@@ -7,11 +7,17 @@ import {
 import {
   buyShares,
   COMPANY_NAME,
+  coversTrade,
   type Fill,
+  LOW_CASH_WEI,
+  maxTradeInput,
   type Portfolio,
   priceAt,
+  REFRESH_MS,
   readPortfolio,
+  type Side,
   sellShares,
+  sharesToSell,
   TICKER,
   UNIT,
 } from "@category-labs/mera-demo-shared/market";
@@ -37,7 +43,7 @@ import { NewsTicker } from "./NewsTicker";
 import { PriceChart } from "./PriceChart";
 import { RecoveryPhrase } from "./RecoveryPhrase";
 import { clearStoredAccount, loadCostBasis, saveCostBasis } from "./storage";
-import { type Side, TradeForm } from "./TradeForm";
+import { TradeForm } from "./TradeForm";
 import { palette } from "./theme";
 import {
   createAccount,
@@ -47,17 +53,6 @@ import {
   unlockStoredWallet,
   type Wallet,
 } from "./wallet";
-
-const REFRESH_MS = 5_000;
-// Cash kept out of Max buys so the account can always pay a trade's network
-// fee; at the demo network's gas prices this covers hundreds of trades.
-const FEE_RESERVE_WEI = 10n ** 16n;
-// Cash below this offers the 10,000 DEMOCASH top-up; the guard enforces the
-// same threshold, so the button cannot inflate a healthy account.
-const LOW_CASH_WEI = 100n * UNIT;
-// One cent, the display resolution: sells that would leave less than this
-// behind sell the whole position instead.
-const CENT_WEI = 10n ** 16n;
 
 type Pending = "create" | "signin" | "trade" | "recovery" | "funding";
 
@@ -233,18 +228,10 @@ function TradingScreen({
     pnl !== null && basis > 0n ? Number((pnl * 10_000n) / basis) / 100 : null;
 
   const amountWei = parseDecimalAmount(amount, 18);
-  // Buys must leave the fee reserve behind; sells cannot exceed the position
-  // (with a cent of slack for price movement between render and submit) and
-  // still need the reserve for the trade's network fee.
   const covered =
     portfolio !== null &&
     amountWei !== null &&
-    (side === "buy"
-      ? amountWei + FEE_RESERVE_WEI <= portfolio.cash
-      : positionValue !== null &&
-        positionValue > 0n &&
-        amountWei <= positionValue + CENT_WEI &&
-        portfolio.cash >= FEE_RESERVE_WEI);
+    coversTrade({ side, amountWei, price, portfolio });
   const canTrade = covered && !busy;
 
   const estimatedShares =
@@ -261,22 +248,10 @@ function TradingScreen({
         ? "Buy"
         : "Sell";
 
-  // Wei to a plain decimal cash string, floored to cents.
-  function cashInput(wei: bigint): string {
-    const cents = wei / CENT_WEI;
-    return `${cents / 100n}.${(cents % 100n).toString().padStart(2, "0")}`;
-  }
-
   function fillMax(): void {
     if (portfolio === null) return;
     setTradeError(null);
-    const wei =
-      side === "buy"
-        ? portfolio.cash > FEE_RESERVE_WEI
-          ? portfolio.cash - FEE_RESERVE_WEI
-          : 0n
-        : (positionValue ?? 0n);
-    setAmount(cashInput(wei));
+    setAmount(maxTradeInput({ side, price, portfolio }));
     // Max on the sell side means the whole position: converting its stale
     // cash figure back to shares at a moved price can strand dust.
     setSellAll(side === "sell");
@@ -339,16 +314,12 @@ function TradingScreen({
         setFill({ ...result, spent: amountWei });
         applyBasis(costBasisAfterBuy(basis, amountWei));
       } else {
-        let shares = (amountWei * UNIT) / price;
-        // A Max sell, or a typed amount within a cent of the whole position,
-        // sells all of it, so no dust the display would round to 0.00 is
-        // left behind.
-        if (
-          sellAll ||
-          ((portfolio.shares - shares) * price) / UNIT < CENT_WEI
-        ) {
-          shares = portfolio.shares;
-        }
+        const shares = sharesToSell({
+          amountWei,
+          price,
+          heldShares: portfolio.shares,
+          sellAll,
+        });
         const result = await sellShares(wallet.session, evm, shares);
         setFill(result);
         applyBasis(costBasisAfterSell(basis, result.shares, portfolio.shares));

--- a/demos/mobile/src/useCopyButton.ts
+++ b/demos/mobile/src/useCopyButton.ts
@@ -1,18 +1,31 @@
 import { setStringAsync } from "expo-clipboard";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-/** Copies text to the clipboard; `copied` holds for 1.2 s after each copy. */
+/**
+ * Copies text to the clipboard; `copied` holds for 1.2 s after each copy.
+ * After unmount, a pending copy changes nothing.
+ */
 function useCopyButton(): {
   copied: boolean;
   copy: (text: string) => Promise<void>;
 } {
   const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const mounted = useRef(true);
 
-  useEffect(() => () => clearTimeout(timer.current), []);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      clearTimeout(timer.current);
+    };
+  }, []);
 
   const copy = useCallback(async (text: string) => {
     await setStringAsync(text);
+    // The write can outlive the component; a timer set now would leak past
+    // the cleanup that already ran.
+    if (!mounted.current) return;
     setCopied(true);
     clearTimeout(timer.current);
     timer.current = setTimeout(() => setCopied(false), 1_200);

--- a/demos/shared/src/market.ts
+++ b/demos/shared/src/market.ts
@@ -199,13 +199,119 @@ async function sellShares(
   return { side: "sell", shares: await minedShares(evm, hash) };
 }
 
-export type { Fill, Portfolio };
+// ----- Trade policy -----------------------------------------------------------
+// Client-side trading rules; every demo applies the same ones.
+
+type Side = "buy" | "sell";
+
+// How often the demos re-read the portfolio.
+const REFRESH_MS = 5_000;
+// Cash kept out of Max buys so the account can always pay a trade's network
+// fee; at the demo network's gas prices this covers hundreds of trades.
+const FEE_RESERVE_WEI = 10n ** 16n;
+// One cent, the display resolution: sells that would leave less than this
+// behind sell the whole position instead.
+const CENT_WEI = 10n ** 16n;
+// Cash below this offers the 10,000 DEMOCASH top-up; the guard enforces the
+// same threshold, so the button cannot inflate a healthy account.
+const LOW_CASH_WEI = 100n * UNIT;
+
+/** Wei to a plain decimal cash string floored to cents, e.g. "9999.99". */
+function cashInput(wei: bigint): string {
+  const cents = wei / CENT_WEI;
+  return `${cents / 100n}.${(cents % 100n).toString().padStart(2, "0")}`;
+}
+
+/**
+ * The Max amount for the trade input. Buys offer the cash minus the fee
+ * reserve. Sells offer the whole position; a position worth less than a cent
+ * still offers one cent, because flooring it to "0.00" would parse to
+ * nothing and leave the position unsellable from Max.
+ */
+function maxTradeInput({
+  side,
+  price,
+  portfolio,
+}: {
+  side: Side;
+  price: bigint;
+  portfolio: Portfolio;
+}): string {
+  if (side === "buy") {
+    return cashInput(
+      portfolio.cash > FEE_RESERVE_WEI ? portfolio.cash - FEE_RESERVE_WEI : 0n,
+    );
+  }
+  const positionValue = (portfolio.shares * price) / UNIT;
+  if (positionValue > 0n && positionValue < CENT_WEI) {
+    return cashInput(CENT_WEI);
+  }
+  return cashInput(positionValue);
+}
+
+/**
+ * Whether the portfolio can pay for the trade. Buys must leave the fee
+ * reserve behind. Sells cannot exceed the position (with a cent of slack for
+ * price movement between render and submit), must round to at least one
+ * share-wei at the current price, and still need the reserve for the trade's
+ * network fee.
+ */
+function coversTrade({
+  side,
+  amountWei,
+  price,
+  portfolio,
+}: {
+  side: Side;
+  amountWei: bigint;
+  price: bigint;
+  portfolio: Portfolio;
+}): boolean {
+  if (side === "buy") return amountWei + FEE_RESERVE_WEI <= portfolio.cash;
+  const positionValue = (portfolio.shares * price) / UNIT;
+  return (
+    positionValue > 0n &&
+    (amountWei * UNIT) / price > 0n &&
+    amountWei <= positionValue + CENT_WEI &&
+    portfolio.cash >= FEE_RESERVE_WEI
+  );
+}
+
+/**
+ * Shares a sell of `amountWei` moves at `price`. A Max sell, or an amount
+ * within a cent of the whole position, sells all of it, so no dust the
+ * display would round to 0.00 is left behind.
+ */
+function sharesToSell({
+  amountWei,
+  price,
+  heldShares,
+  sellAll,
+}: {
+  amountWei: bigint;
+  price: bigint;
+  heldShares: bigint;
+  sellAll: boolean;
+}): bigint {
+  const shares = (amountWei * UNIT) / price;
+  if (sellAll || ((heldShares - shares) * price) / UNIT < CENT_WEI) {
+    return heldShares;
+  }
+  return shares;
+}
+
+export type { Fill, Portfolio, Side };
 export {
   buyShares,
   COMPANY_NAME,
+  coversTrade,
+  LOW_CASH_WEI,
+  maxTradeInput,
   priceAt,
+  REFRESH_MS,
   readPortfolio,
   sellShares,
+  sharesToSell,
   TICKER,
   UNIT,
 };

--- a/demos/shared/src/useCopyButton.ts
+++ b/demos/shared/src/useCopyButton.ts
@@ -1,18 +1,34 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Copy-to-clipboard button state: `copy(text)` writes to the clipboard and
  * flips `copied` true for a moment so the button can show a confirmation.
+ * After unmount, a pending copy changes nothing.
  */
 function useCopyButton(): {
   copied: boolean;
   copy: (text: string) => Promise<void>;
 } {
   const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      clearTimeout(timer.current);
+    };
+  }, []);
+
   const copy = useCallback(async (text: string) => {
     await navigator.clipboard.writeText(text);
+    // The write can outlive the component; a timer set now would leak past
+    // the cleanup that already ran.
+    if (!mounted.current) return;
     setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 1_200);
   }, []);
   return { copied, copy };
 }

--- a/demos/web/src/TradingCard.tsx
+++ b/demos/web/src/TradingCard.tsx
@@ -7,11 +7,17 @@ import {
 import {
   buyShares,
   COMPANY_NAME,
+  coversTrade,
   type Fill,
+  LOW_CASH_WEI,
+  maxTradeInput,
   type Portfolio,
   priceAt,
+  REFRESH_MS,
   readPortfolio,
+  type Side,
   sellShares,
+  sharesToSell,
   TICKER,
   UNIT,
 } from "@category-labs/mera-demo-shared/market";
@@ -50,19 +56,6 @@ import {
 import { loadCostBasis, saveCostBasis } from "./costBasis";
 import { currentPasskeyWallet } from "./passkeyWallet";
 import { WalletBackup } from "./WalletBackup";
-
-const REFRESH_MS = 5_000;
-// Cash kept out of Max buys so the account can always pay a trade's network
-// fee; at the demo network's gas prices this covers hundreds of trades.
-const FEE_RESERVE_WEI = 10n ** 16n;
-// Cash below this offers the 10,000 DEMOCASH top-up; the guard enforces the
-// same threshold, so the button cannot inflate a healthy account.
-const LOW_CASH_WEI = 100n * UNIT;
-// One cent, the display resolution: sells that would leave less than this
-// behind sell the whole position instead.
-const CENT_WEI = 10n ** 16n;
-
-type Side = "buy" | "sell";
 
 type TradingCardProps = {
   evm: EvmContext | null;
@@ -209,39 +202,19 @@ function TradingCard({
     pnl !== null && basis > 0n ? Number((pnl * 10_000n) / basis) / 100 : null;
 
   const amountWei = parseDecimalAmount(amount, 18);
-  // Buys must leave the fee reserve behind; sells cannot exceed the position
-  // (with a cent of slack for price movement between render and submit) and
-  // still need the reserve for the trade's network fee.
   const covered =
     portfolio !== null &&
     amountWei !== null &&
-    (side === "buy"
-      ? amountWei + FEE_RESERVE_WEI <= portfolio.cash
-      : positionValue !== null &&
-        positionValue > 0n &&
-        amountWei <= positionValue + CENT_WEI &&
-        portfolio.cash >= FEE_RESERVE_WEI);
+    coversTrade({ side, amountWei, price, portfolio });
   const canTrade = covered && !busy;
 
   const estimatedShares =
     amountWei !== null ? (amountWei * UNIT) / price : null;
 
-  // Wei to a plain decimal cash string, floored to cents.
-  function cashInput(wei: bigint): string {
-    const cents = wei / CENT_WEI;
-    return `${cents / 100n}.${(cents % 100n).toString().padStart(2, "0")}`;
-  }
-
   function fillMax(): void {
     if (portfolio === null) return;
     setTradeError(null);
-    const wei =
-      side === "buy"
-        ? portfolio.cash > FEE_RESERVE_WEI
-          ? portfolio.cash - FEE_RESERVE_WEI
-          : 0n
-        : (positionValue ?? 0n);
-    setAmount(cashInput(wei));
+    setAmount(maxTradeInput({ side, price, portfolio }));
     // Max on the sell side means the whole position: converting its stale
     // cash figure back to shares at a moved price can strand dust.
     setSellAll(side === "sell");
@@ -284,16 +257,12 @@ function TradingCard({
         setFill({ ...result, spent: amountWei });
         applyBasis(costBasisAfterBuy(basis, amountWei));
       } else {
-        let shares = (amountWei * UNIT) / price;
-        // A Max sell, or a typed amount within a cent of the whole position,
-        // sells all of it, so no dust the display would round to 0.00 is
-        // left behind.
-        if (
-          sellAll ||
-          ((portfolio.shares - shares) * price) / UNIT < CENT_WEI
-        ) {
-          shares = portfolio.shares;
-        }
+        const shares = sharesToSell({
+          amountWei,
+          price,
+          heldShares: portfolio.shares,
+          sellAll,
+        });
         const result = await sellShares(session, evm, shares);
         setFill(result);
         applyBasis(costBasisAfterSell(basis, result.shares, portfolio.shares));


### PR DESCRIPTION
With the mobile rewrite merged, the client-side trading rules existed three times, and the copies had already drifted: the extension's covered gate allowed a sell attempt against an empty position, its Max sell had no dust handling and could strand a sub-cent position when the price moved between Max and submit, and only web carried the sell-all flag. Three copies of the same policy is exactly where the next drift starts.

This moves the policy into `demos/shared/src/market.ts` — the `Side` type, `REFRESH_MS` and `LOW_CASH_WEI`, and three pure functions: `coversTrade`, `sharesToSell`, and `maxTradeInput`. The cash-input formatter and the `FEE_RESERVE_WEI`/`CENT_WEI` constants become private to the module: no demo needs them directly once the Max computation is shared. All three demos are rewired onto these.

Unifying means small behavior changes where the copies disagreed, all in the strict direction:

- The shared gate takes web's position checks plus the extension's at-least-one-share-wei check, so web and mobile now also refuse a sell that would round to zero shares and throw at submit.
- The extension gains the sell-all flag and the dust clause: Max reliably closes the position, and no sub-cent dust is left behind.
- Sell Max on a position worth less than a cent now offers `0.01` instead of an unparseable `0.00`, so dust positions (small buys, or leftovers from the old extension behavior) stay closable from Max.

Also fixes the shared `useCopyButton` (and its mobile counterpart): the reset timer is cleared on unmount and on rapid re-copy, and a copy that resolves after unmount no longer creates a timer past cleanup.

The extension Playwright suite passes with zero test edits.