### PR TITLE
Let a fresh npm install resolve the docs dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
     "@biomejs/biome": "2.5.8",
     "typescript": "5.9.3"
   },
+  "overrides": {
+    "expressive-code-twoslash@0.6.1": {
+      "@expressive-code/core": ">=0.44.1",
+      "expressive-code": ">=0.44.1"
+    }
+  },
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
`npm install` fails with `ERESOLVE` whenever npm has to resolve the tree from scratch, which is any time the lockfile is missing, stale, or being regenerated for a dependency bump:

```
Could not resolve dependency:
peer @expressive-code/core@"^0.41.7" from expressive-code-twoslash@0.6.1
```

`expressive-code-twoslash@0.6.1` is the latest release, and its peer range on `@expressive-code/core` and `expressive-code` has not been widened past 0.41. The docs workspace cannot stay on 0.41: `@astrojs/starlight@0.41.7` depends on `astro-expressive-code@^0.44.0`, which pulls `expressive-code@0.44.1`. So the range is stale rather than a real incompatibility, and the only way out short of dropping Twoslash from the docs is to override it.

Two details of how the override is written, both chosen so that a later Expressive Code or Twoslash bump cannot slip through unnoticed:

The key is qualified with `@0.6.1`, so the exception covers only the release whose metadata was actually checked. A future plugin release that ships a corrected peer range keeps it. Pointing the key at a version that is not installed and resolving from an empty `node_modules` brings the `ERESOLVE` straight back, so the qualifier is enforced rather than decorative, and an upgrade to a still-stale release fails the install instead of passing quietly.

The value is `>=0.44.1` rather than an exact pin. An exact pin goes stale the next time Expressive Code is bumped, and npm answers a stale pin by installing a second copy of `@expressive-code/core` nested under the plugin instead of failing. Two cores in one tree breaks the plugin at runtime with no install-time signal. I hit exactly that while testing a `$@expressive-code/core` reference, which npm accepted and then quietly resolved to a nested 0.41.7.

The docs build runs Twoslash over every `ts`/`tsx` block, so `npm run check:docs` passing is direct evidence the plugin works against 0.44.1.

`package-lock.json` is byte-identical to `main` — the committed tree already matched what the override resolves to, so no installed version moves. Verified `npm install` from no lockfile, `npm ci` from a clean `node_modules`, `npm ls @expressive-code/core` reporting one deduped 0.44.1, and `npm run check:docs`.

The override can come out once upstream widens the peer range.