### PR TITLE
Keep .well-known in the docs Pages artifact

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -57,10 +57,13 @@ jobs:
         env:
           DOCS_SITE: https://mera.category.xyz
 
+      # The action tars the site with hidden paths excluded by default, which
+      # drops .well-known and with it the passkey app-association files.
       - name: Upload site
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/dist
+          include-hidden-files: true
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Android passkey sign-in in the mobile demo fails: 1Password rejects the passkey because https://mera.category.xyz/.well-known/assetlinks.json returns 404, so no provider can verify that the demo app belongs to the relying party. The checked-in fingerprint and package match the demo's debug build, so the check passes once the file serves.

The site build is not at fault: `astro build` writes `dist/.well-known/assetlinks.json`. The upload step drops the directory: `upload-pages-artifact` tars the site with `--exclude=.[^/]*` unless `include-hidden-files` is true, and the default is false. The v4 pin excluded hidden paths with no opt-out, so Pages never served the file; v5 added the input this change sets. Today's deployed artifact shows the result: 172 entries, `favicon.svg` present, `.well-known` absent.

The action keeps excluding `.git` and `.github`, and `.well-known` is the only hidden entry in `docs/dist`, so the artifact gains exactly the association file. Merging triggers the docs deploy on its own; after it, `curl -I https://mera.category.xyz/.well-known/assetlinks.json` should return 200 with JSON.

Follow-up outside this diff: `docs/public/.well-known/` still lacks `apple-app-site-association`, so iOS association also needs that file, filled with a real team ID.