### PR TITLE
Cache chart grid prices across redraws

### DIFF
--- a/demos/shared/src/chart.ts
+++ b/demos/shared/src/chart.ts
@@ -25,6 +25,12 @@ type ChartGeometry = {
   low: number;
 };
 
+// Grid prices, pruned to the drawn window. A redraw resamples the whole
+// window at eight keccak hashes per sample, which stalls JIT-less engines
+// when repeated every second; a grid price never changes, so a redraw
+// computes only the samples that newly entered the window.
+const gridPrices = new Map<number, bigint>();
+
 /**
  * Lays out the last CHART_WINDOW_SECONDS of the stock price as SVG path data
  * in the CHART_WIDTH by CHART_HEIGHT space. History comes from the price
@@ -38,8 +44,17 @@ function chartGeometry(livePrice: bigint, now: number): ChartGeometry {
   // the price noise across the whole line and making it visibly shimmer.
   const start =
     Math.ceil((now - CHART_WINDOW_SECONDS) / SAMPLE_SECONDS) * SAMPLE_SECONDS;
+  // Dropping t >= now also clears samples ahead of a clock that moved back.
+  for (const t of gridPrices.keys()) {
+    if (t < start || t >= now) gridPrices.delete(t);
+  }
   for (let t = start; t < now; t += SAMPLE_SECONDS) {
-    points.push({ t, price: priceAt(BigInt(t)) });
+    let price = gridPrices.get(t);
+    if (price === undefined) {
+      price = priceAt(BigInt(t));
+      gridPrices.set(t, price);
+    }
+    points.push({ t, price });
   }
   points.push({ t: now, price: livePrice });
 


### PR DESCRIPTION
On Android the mobile demo answers every tap about a second late. The trading screen redraws once a second, and each redraw resampled the chart's whole 30-minute window: 360 samples at eight keccak hashes each, roughly 2,900 hashes per second on the JS thread. Hermes runs JavaScript without a JIT, so one redraw's sampling costs hundreds of milliseconds there, and every touch handler and network callback queues behind it. The web and extension demos share the path but run on JIT engines, which is why only mobile felt it.

A grid price is a pure function of its timestamp, so the sampled window now lives in a cache pruned to the drawn window, and a redraw computes only the samples that newly entered the window: none or one on a steady per-second tick, more after the app wakes from the background and the window jumps. Output is unchanged for every consumer; the work per redraw is what changes.

Validation: replicated one redraw's computation in Node as a JIT lower bound: 12.7 ms before, 0.52 ms after, steady state. Not measured on an Android device, but the removed work is the hash loop itself, so the ratio carries to interpreted engines.

Out of scope, noted while profiling: sign-in still freezes the JS thread for the BIP-39 PBKDF2 derivation, and trades still spend ~5 sequential RPC round trips filling the transaction.