### PR TITLE
Fund and read a new account before the web demo shows it

### DIFF
--- a/demos/web/src/ConnectPanel.tsx
+++ b/demos/web/src/ConnectPanel.tsx
@@ -12,18 +12,27 @@ import {
 
 type ConnectPanelProps = {
   mode: AccountMode;
-  onConnected: (wallet: ConnectedWallet) => void;
+  onConnected: (wallet: ConnectedWallet) => Promise<void>;
+};
+
+// The action a click started, and how far it has come: the passkey ceremony,
+// then the awaited `onConnected`.
+type ConnectBusy = {
+  action: "create" | "signin";
+  phase: "passkey" | "opening";
 };
 
 /**
  * The connect area under the market data. Passkey mode offers explicit
  * create and sign-in actions; new passkeys are created under a fixed default
- * name. Vault mode imports or creates a phrase-backed account. Mount with
- * `key={mode}` so switching modes resets the local state.
+ * name. Vault mode imports or creates a phrase-backed account. The panel
+ * stays busy until `onConnected` settles, so the parent can load the account
+ * before this panel gives way to it. Mount with `key={mode}` so switching
+ * modes resets the local state.
  */
 function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
   const [secret, setSecret] = useState("");
-  const [busy, setBusy] = useState<"create" | "signin" | null>(null);
+  const [busy, setBusy] = useState<ConnectBusy | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const trimmedSecret = secret.trim();
@@ -35,15 +44,24 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
   }
 
   async function run(action: "create" | "signin") {
-    setBusy(action);
+    setBusy({ action, phase: "passkey" });
     setError(null);
     try {
-      onConnected(await connect(mode, action, secret));
+      const wallet = await connect(mode, action, secret);
+      setBusy({ action, phase: "opening" });
+      await onConnected(wallet);
     } catch (caught) {
       setError(describeError(caught));
     } finally {
       setBusy(null);
     }
+  }
+
+  function actionLabel(action: "create" | "signin", idle: string): string {
+    if (busy === null || busy.action !== action) return idle;
+    return busy.phase === "passkey"
+      ? "Waiting for passkey…"
+      : "Opening account…";
   }
 
   if (mode === "vault") {
@@ -87,7 +105,7 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
             onClick={() => void run("create")}
             disabled={busy !== null || !secretValid}
           >
-            {busy === "create" ? "Waiting for passkey…" : "Open account"}
+            {actionLabel("create", "Open account")}
           </button>
           <button
             type="button"
@@ -95,7 +113,7 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
             onClick={() => void run("signin")}
             disabled={busy !== null}
           >
-            {busy === "signin" ? "Waiting for passkey…" : "Sign in"}
+            {actionLabel("signin", "Sign in")}
           </button>
         </div>
         {error && <p className="status error">{error}</p>}
@@ -112,7 +130,7 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
           onClick={() => void run("create")}
           disabled={busy !== null}
         >
-          {busy === "create" ? "Waiting for passkey…" : "Create account"}
+          {actionLabel("create", "Create account")}
         </button>
         <button
           type="button"
@@ -120,7 +138,7 @@ function ConnectPanel({ mode, onConnected }: ConnectPanelProps): ReactElement {
           onClick={() => void run("signin")}
           disabled={busy !== null}
         >
-          {busy === "signin" ? "Waiting for passkey…" : "Sign in"}
+          {actionLabel("signin", "Sign in")}
         </button>
       </div>
       {error && <p className="status error">{error}</p>}

--- a/demos/web/src/TradingCard.tsx
+++ b/demos/web/src/TradingCard.tsx
@@ -100,10 +100,20 @@ function TradingCard({
 
   const address = accountAddress(account);
 
+  // Polling, foregrounding, funding, and trades all refresh, so reads
+  // overlap. Only the newest may commit: a slow pre-funding snapshot would
+  // otherwise overwrite fresh balances, and its zero shares would trip the
+  // basis reset below and erase the saved basis.
+  const readGeneration = useRef(0);
+
   // Switches to `next` and drops everything scoped to the previous account.
-  function adoptAccount(next: AccountState): void {
+  function adoptAccount(
+    next: AccountState,
+    portfolio: Portfolio | null = null,
+  ): void {
+    readGeneration.current += 1;
     onAccountChange(next);
-    setPortfolio(null);
+    setPortfolio(portfolio);
     setAmount("");
     setSellAll(false);
     setFill(null);
@@ -138,10 +148,14 @@ function TradingCard({
   const refresh = useCallback(async () => {
     setNow(Math.floor(Date.now() / 1000));
     if (evm === null || address === null) return;
+    const generation = ++readGeneration.current;
     try {
-      setPortfolio(await readPortfolio(evm, address));
+      const read = await readPortfolio(evm, address);
+      if (generation !== readGeneration.current) return;
+      setPortfolio(read);
       setReadError(null);
     } catch (caught) {
+      if (generation !== readGeneration.current) return;
       setReadError(describeError(caught));
     }
   }, [evm, address]);
@@ -153,13 +167,36 @@ function TradingCard({
   useEffect(() => {
     if (address === null || funded.current === address) return;
     funded.current = address;
+    setFunding(true);
     fundAccount(RPC_URL, address)
       .catch(() => {
         // A failed top-up surfaces through the balance read; the button
         // below offers a retry once the network is back.
       })
-      .finally(() => void refresh());
+      .finally(() => {
+        setFunding(false);
+        void refresh();
+      });
   }, [address, refresh]);
+
+  // Funds and reads a freshly connected account before adopting it, so the
+  // connect panel gives way to settled balances instead of placeholders that
+  // fill in one network round trip at a time. On failure the account is
+  // adopted without a portfolio and the poll's read error reports the cause.
+  async function openAccount(wallet: ConnectedWallet): Promise<void> {
+    let portfolio: Portfolio | null = null;
+    const nextAddress = wallet.account.address;
+    if (evm !== null) {
+      funded.current = nextAddress; // the auto-fund effect must not repeat this
+      try {
+        await fundAccount(RPC_URL, nextAddress);
+        portfolio = await readPortfolio(evm, nextAddress);
+      } catch {
+        // Adopt anyway; the account exists even when the network misbehaves.
+      }
+    }
+    adoptAccount({ status: "unlocked", wallet }, portfolio);
+  }
 
   useEffect(() => {
     const tick = window.setInterval(
@@ -359,9 +396,7 @@ function TradingCard({
           <ConnectPanel
             key={connectMode}
             mode={connectMode}
-            onConnected={(wallet) =>
-              adoptAccount({ status: "unlocked", wallet })
-            }
+            onConnected={openAccount}
           />
         ) : (
           <>


### PR DESCRIPTION
## Why

Creating a passkey in the web demo flashed two broken-looking states before the funded view: the card mounted with "…" balances beside the Export account link, then the first balance read raced the automatic top-up and briefly showed $0.00 with an actionable "Add 10,000 DEMOCASH" link. The view switched the moment the ceremony ended, and nothing ordered the first read after the funding call.

Now the card funds the account and reads its portfolio before adopting it, while the connect panel holds and the clicked button reports the wait ("Waiting for passkey…", then "Opening account…"). The card mounts once, fully populated, for create and sign-in alike. When the network context is missing or the pre-load fails, adoption falls back to the previous behavior — placeholders, the read error line, and the manual top-up link — so an outage degrades instead of blocking.

Two smaller guards are included. The auto-fund effect sets the existing `funding` flag, so a cached account refilling after a network reset shows a disabled "Adding funds…" instead of a top-up button that vanishes on its own. And `refresh` now discards stale reads (mobile's generation guard): a slow pre-funding read landing late would re-flash the low-cash state, and its zero shares would trip the basis reset and erase the saved cost basis.

## Notes for reviewers

Verified by driving the flow headlessly with a virtual WebAuthn authenticator while recording every DOM commit: unfixed code reproduces the reported flash sequence exactly; with this change, create, sign-in, and reload with a cached account each render the card once, already funded.

demos/mobile and demos/extension flash the same way; ports follow as separate PRs.
