### PR TITLE
Fund and read a new account before the extension demo shows it

### DIFF
--- a/demos/extension/src/TradingPanel.tsx
+++ b/demos/extension/src/TradingPanel.tsx
@@ -79,6 +79,8 @@ type Props = {
 type PendingAction =
   | "create"
   | "signin"
+  | "opening:create"
+  | "opening:signin"
   | "trade"
   | "recovery"
   | "funding"
@@ -115,6 +117,26 @@ function TradingPanel({
   const [copied, setCopied] = useState(false);
   const funded = useRef<string | null>(null);
   const busy = pending !== null;
+
+  // Polling, funding, and trades all refresh, so reads overlap. Only the
+  // newest may commit: a slow pre-funding snapshot would otherwise overwrite
+  // fresh balances, and its zero shares would trip the basis reset below and
+  // erase the saved basis.
+  const readGeneration = useRef(0);
+
+  // Switches to `next` and drops everything scoped to the previous account.
+  function adoptAccount(
+    next: AccountState,
+    portfolio: Portfolio | null = null,
+  ): void {
+    readGeneration.current += 1;
+    onAccountChange(next);
+    setPortfolio(portfolio);
+    setAmount("");
+    setSellAll(false);
+    setFill(null);
+    setError(null);
+  }
 
   function operationIsCurrent(
     epoch: number,
@@ -183,17 +205,20 @@ function TradingPanel({
   const refresh = useCallback(async (): Promise<void> => {
     setNow(Math.floor(Date.now() / 1000));
     if (evm === null || address === null) return;
-    setPortfolio(await readPortfolio(evm, address));
+    const generation = ++readGeneration.current;
+    try {
+      const read = await readPortfolio(evm, address);
+      if (generation !== readGeneration.current) return;
+      setPortfolio(read);
+    } catch (caught) {
+      if (generation !== readGeneration.current) return;
+      throw caught;
+    }
   }, [address, evm]);
 
   useEffect(() => {
     setBasis(address ? loadCostBasis(address) : 0n);
-    setPortfolio(null);
-    setAmount("");
-    setSellAll(false);
-    setFill(null);
-    hideRecovery();
-  }, [address, hideRecovery]);
+  }, [address]);
 
   useEffect(() => {
     function hideWhenPanelHides(): void {
@@ -231,7 +256,15 @@ function TradingPanel({
   useEffect(() => {
     if (address === null || funded.current === address || evm === null) return;
     funded.current = address;
-    void fundAccount(DEMO_RPC_URL, address).then(refresh).catch(reportError);
+    // The network context can resolve while a user action is already
+    // pending; the functional updates leave such an action's state alone.
+    setPending((current) => current ?? "funding");
+    void fundAccount(DEMO_RPC_URL, address)
+      .then(refresh)
+      .catch(reportError)
+      .finally(() =>
+        setPending((current) => (current === "funding" ? null : current)),
+      );
   }, [address, evm, refresh, reportError]);
 
   useEffect(() => {
@@ -297,13 +330,36 @@ function TradingPanel({
         wallet.lock();
         return;
       }
-      storeWallet(wallet);
+      // Fund and read the account before adopting it, so the connect buttons
+      // give way to settled balances instead of placeholders that fill in
+      // one network round trip at a time.
+      setPending(`opening:${action}`);
+      funded.current = wallet.address; // the auto-fund effect must not repeat this
+      let portfolio: Portfolio | null = null;
+      try {
+        await fundAccount(DEMO_RPC_URL, wallet.address);
+        portfolio = await readPortfolio(evm, wallet.address);
+      } catch {
+        // Adopt anyway; the account exists even when the network misbehaves.
+      }
+      if (!operationIsCurrent(epoch, viaTab)) {
+        wallet.lock();
+        return;
+      }
+      saveAccount({ address: wallet.address, credential: wallet.credential });
+      adoptAccount({ status: "unlocked", wallet }, portfolio);
     } catch (caught) {
       wallet?.lock();
       if (operationIsCurrent(epoch, viaTab)) setError(describeError(caught));
     } finally {
       setPending(null);
     }
+  }
+
+  function connectLabel(action: "create" | "signin", idle: string): string {
+    if (pending === action) return "Waiting for passkey…";
+    if (pending === `opening:${action}`) return "Opening account…";
+    return idle;
   }
 
   function updateBasis(value: bigint): void {
@@ -422,7 +478,7 @@ function TradingPanel({
     try {
       clearAccount();
     } finally {
-      onAccountChange({ status: "none" });
+      adoptAccount({ status: "none" });
     }
   }
 
@@ -538,9 +594,7 @@ function TradingPanel({
                 disabled={busy || evm === null}
                 onClick={() => void connect("create")}
               >
-                {pending === "create"
-                  ? "Waiting for passkey…"
-                  : "Create account"}
+                {connectLabel("create", "Create account")}
               </button>
               <button
                 className="btn"
@@ -548,7 +602,7 @@ function TradingPanel({
                 disabled={busy || evm === null}
                 onClick={() => void connect("signin")}
               >
-                {pending === "signin" ? "Waiting for passkey…" : "Sign in"}
+                {connectLabel("signin", "Sign in")}
               </button>
             </div>
             {error && <p className="status error">{error}</p>}

--- a/demos/extension/tests/sidepanel.spec.ts
+++ b/demos/extension/tests/sidepanel.spec.ts
@@ -10,6 +10,7 @@ const extensionDir = resolve(
   "../dist",
 );
 const rpcUrl = "https://evm-network-production.up.railway.app/";
+const fundedBalance = "0x21e19e0c9bab2400000";
 const marketAddress = "0x1111111111111111111111111111111111111111";
 const transactionHash = `0x${"12".repeat(32)}`;
 const blockHash = `0x${"34".repeat(32)}`;
@@ -25,15 +26,16 @@ async function expectedExtensionId(): Promise<string> {
   return extensionIdFromKey(manifest.key);
 }
 
-function rpcResult(method: string): unknown {
+function rpcResult(method: string, funded: boolean): unknown {
   switch (method) {
     case "eth_chainId":
       return "0x7a69";
     case "demo_market":
       return { address: marketAddress };
     case "demo_fundAccount":
+      return fundedBalance;
     case "eth_getBalance":
-      return "0x21e19e0c9bab2400000";
+      return funded ? fundedBalance : "0x0";
     case "eth_call":
       return `0x${"0".repeat(64)}`;
     case "eth_getTransactionCount":
@@ -195,17 +197,19 @@ test("runs the side-panel account lifecycle", async () => {
     ],
   });
   try {
+    let funded = false;
     await context.route(rpcUrl, async (route) => {
       const body = route.request().postDataJSON() as {
         id: unknown;
         method: string;
       };
+      if (body.method === "demo_fundAccount") funded = true;
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({
           jsonrpc: "2.0",
           id: body.id,
-          result: rpcResult(body.method),
+          result: rpcResult(body.method, funded),
         }),
       });
     });
@@ -244,6 +248,11 @@ test("runs the side-panel account lifecycle", async () => {
     );
     await page.getByRole("button", { name: "Create account" }).click();
     await expect(page.getByRole("button", { name: /^0x/u })).toBeVisible();
+    // The panel adopts the account only after funding it and reading the
+    // portfolio, so the account view appears with the balance already set.
+    expect(await page.locator(".holding-value").first().textContent()).toBe(
+      "10,000.00",
+    );
     await expect(page.getByRole("button", { name: "Lock" })).toBeEnabled();
     const storedAccount = await page.evaluate(() =>
       localStorage.getItem("mera.extension.account.v1"),
@@ -392,17 +401,19 @@ test("opens a passkey tab from the side panel", async () => {
     ],
   });
   try {
+    let funded = false;
     await context.route(rpcUrl, async (route) => {
       const body = route.request().postDataJSON() as {
         id: unknown;
         method: string;
       };
+      if (body.method === "demo_fundAccount") funded = true;
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({
           jsonrpc: "2.0",
           id: body.id,
-          result: rpcResult(body.method),
+          result: rpcResult(body.method, funded),
         }),
       });
     });


### PR DESCRIPTION
Connecting a passkey account adopted it the moment the ceremony ended: the panel flashed placeholder balances with the account links, then a short \$0 state with an actionable "Add 10,000" link, before settling at the funded balance.

This is the extension port of #315: connect funds the account and reads its portfolio while the button holds ("Waiting for passkey…" → "Opening account…"), then adopts both together, so the trading view mounts with settled balances. The auto-fund effect holds the pending state while it runs, so a pre-funding read shows "Adding funds…" instead of an actionable link.

Beyond the web port:

- The panel lacked the web/mobile stale-read guard, so `refresh` gains the `readGeneration` scheme here. It rethrows only current failures, which keeps the callers' `reportError` contract while a stale read reports nothing.
- The per-account reset moved from the address-keyed effect into an explicit `adoptAccount`: an effect resets after paint, which would clobber the preloaded portfolio and repaint the placeholders this change removes. The effect keeps only the cost-basis load; the parent changes the address only through this panel, so no other path needs the reset.
- The network work widens the gap between the ceremony and adoption, so connect re-checks the operation epoch afterwards and discards the wallet on a miss — the same treatment as a ceremony that ends hidden.
- The auto-fund effect updates the pending state functionally because the network context can resolve while a user action is already pending; a plain set would displace it.

The mock now answers `eth_getBalance` with zero until `demo_fundAccount` runs, and the lifecycle test asserts the account view appears with the funded balance already rendered. Against the previous panel code that assertion fails on the placeholder.
