### PR TITLE
Simplify the README into the plain language of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@ Accounts on any chain and platform, from a passkey.
 
 ![The mera web demo in mobile Safari: creating an account with a passkey, then trading on a demo network.](./.github/assets/web-demo.gif)
 
-mera is a TypeScript library for building passkey accounts. It gives applications authenticator-bound entropy and signing sessions that zero their keys when ended, while leaving account derivation, recovery, storage, and product flows under application control.
+mera is a TypeScript library for creating accounts from a passkey. It derives 32 secret bytes from the passkey to serve as the root for each account and enables signing sessions. Account derivation, recovery, storage, and product flows such as funding remain under application control.
 
 Developers can use mera to:
 
-- create new accounts from a passkey without adding smart-account contracts or a custody service;
-- protect an existing recovery phrase, private key, or other secret with a passkey;
-- keep account derivation and recovery choices in the application;
-- use the same passkey across web, iOS, and Android applications tied to the same domain.
+- create new accounts from a passkey without requiring a smart-account contract or custody service;
+- provide users with an account that is instantly backed up and recoverable on any device with a passkey;
+- secure an existing recovery phrase, private key, or other data with a passkey;
 
 ## Supported platforms
 
@@ -19,23 +18,23 @@ Developers can use mera to:
 - Chrome extensions
 - React Native on iOS 18 or later and Android 9 or later
 
-Native applications can reuse passkeys created with mera through the platform's WebAuthn APIs.
+Native applications can reuse passkeys created with mera by using the platform's WebAuthn APIs.
 
 See [authenticator support](https://mera.category.xyz/authenticator-support/) for browser and OS support.
 
 ## Documentation and demos
 
-Installation, guides, compatibility information, the security model, the API reference, and the live demos are on the [mera documentation website](https://mera.category.xyz/). The [passkey PRF model](https://mera.category.xyz/prf-demo/) shows how stable PRF output determines account data.
+Installation instructions, guides, compatibility details, the security model, API reference, and live demos are available on the [mera documentation website](https://mera.category.xyz/). The [passkey PRF model](https://mera.category.xyz/prf-demo/) demonstrates how a passkey determines account data.
 
 ## Repository
 
 - [`library/`](./library/) contains the published package and its tests.
-- [`demos/`](./demos/) contains web, Chrome extension, and mobile demos, and a model of how a passkey determines account data.
+- [`demos/`](./demos/) includes web, Chrome extension, and mobile demos, as well as a model illustrating how a passkey determines account data.
 - [`docs/`](./docs/) contains the documentation website.
 
 ## Status
 
-mera is in preview. The API may change before 1.0. Category Labs has completed an internal security review. The documentation describes its [security model](https://mera.category.xyz/concepts/security-model/).
+mera is currently in preview, and the API may change before version 1.0. Category Labs has completed an internal security review. The documentation outlines its [security model](https://mera.category.xyz/concepts/security-model/).
 
 ## Contributing
 


### PR DESCRIPTION
The README overview used cryptography jargon the docs deliberately avoid. "Authenticator-bound entropy" names a mechanism instead of the concrete thing the application receives, and "stable PRF output" restates the demo's own description of itself.

This PR aligns the README with the human-polished voice in docs/: name the 32 secret bytes, say what they become ("the root of every account"), and let the passkey determine account data. It prefers "accounts from a passkey" over "passkey accounts", matching the tagline and package description, and states the two benefits the docs own: the private key never leaves the authenticator, and the passkey syncs to give the same accounts on every device. No content changes; every claim is stated the way the docs already state it.